### PR TITLE
Clean up detritus of scr_cntl_dir to scr_list_dir rename

### DIFF
--- a/scripts/cray_xt/scr_halt.in
+++ b/scripts/cray_xt/scr_halt.in
@@ -272,7 +272,7 @@ foreach my $dir (@dirs) {
 #  my ($nodeset, $username) = split(/\s+/, $nodes_and_user);
 
 #  # build the name of the halt file
-#  my $cntldir = `$bindir/scr_cntl_dir --user $username --jobid $jobid`;
+#  my $cntldir = `$bindir/scr_list_dir --user $username --jobid $jobid control`;
 #  chomp $cntldir;
   my $halt_file = "$dir/.scr/halt.scr";
 

--- a/scripts/cray_xt/scr_list_down_nodes.in
+++ b/scripts/cray_xt/scr_list_down_nodes.in
@@ -159,7 +159,7 @@ if (defined $conf{free}) {
 # check that control and cache directories on each node work and are of proper size
 # get the control directory the job will use
 my @cntldir_vals = ();
-my $cntldir_string = `$bindir/scr_cntl_dir --base`;
+my $cntldir_string = `$bindir/scr_list_dir --base control`;
 if ($? == 0) {
   chomp $cntldir_string;
   my @dirs = split(" ", $cntldir_string);
@@ -182,7 +182,7 @@ if (@cntldir_vals > 0) {
 
 # get the cache directory the job will use
 my @cachedir_vals = ();
-my $cachedir_string = `$bindir/scr_cntl_dir --cache --base`;
+my $cachedir_string = `$bindir/scr_list_dir --base cache`;
 if ($? == 0) {
   chomp $cachedir_string;
   my @dirs = split(" ", $cachedir_string);


### PR DESCRIPTION
Some cray_xt scripts were never fully updated with the rename from scr_cntl_dir to scr_list_dir.