### PR TITLE
add exit query and param to disable auto-exit on active halt condition

### DIFF
--- a/src/scr.c
+++ b/src/scr.c
@@ -2346,6 +2346,11 @@ char* SCR_Get_version()
 /* query whether it is time to exit */
 int SCR_Should_exit(int* flag)
 {
+  /* manage state transition */
+  if (scr_state != SCR_STATE_IDLE) {
+    scr_state_transition_error(scr_state, "SCR_Should_exit()", __FILE__, __LINE__);
+  }
+
   /* if not enabled, bail with an error */
   if (! scr_enabled) {
     return SCR_FAILURE;

--- a/src/scr.h
+++ b/src/scr.h
@@ -95,6 +95,9 @@ int SCR_Complete_output(int valid);
 /* get and return the SCR version */
 char* SCR_Get_version(void);
 
+/* query whether it is time to exit */
+int SCR_Should_exit(int* flag);
+
 /* enable C++ codes to include this header directly */
 #ifdef __cplusplus
 } /* extern "C" */

--- a/src/scr_conf.h
+++ b/src/scr_conf.h
@@ -51,6 +51,11 @@
 #define SCR_HALT_SECONDS (0)
 #endif
 
+/* whether SCR will shut down and call exit if halt condition is detected */
+#ifndef SCR_HALT_ENABLED
+#define SCR_HALT_ENABLED (1)
+#endif
+
 /* =========================================================================
  * Default config file location, control directory, and cache and checkpoint configuration.
  * ========================================================================= */

--- a/src/scr_globals.c
+++ b/src/scr_globals.c
@@ -100,6 +100,7 @@ size_t scr_mpi_buf_size  = SCR_MPI_BUF_SIZE;  /* set MPI buffer size to chunk fi
 size_t scr_file_buf_size = SCR_FILE_BUF_SIZE; /* set buffer size to chunk file copies to/from parallel file system */
 
 int scr_halt_seconds     = SCR_HALT_SECONDS; /* secs remaining in allocation before job should be halted */
+int scr_halt_enabled     = SCR_HALT_ENABLED; /* whether SCR will exit job if halt condition is detected */
 
 int scr_distribute       = SCR_DISTRIBUTE;       /* whether to call scr_distribute_files during SCR_Init */
 int scr_fetch            = SCR_FETCH;            /* whether to call scr_fetch_files during SCR_Init */

--- a/src/scr_halt.c
+++ b/src/scr_halt.c
@@ -152,6 +152,11 @@ int scr_halt_sync_and_decrement(const scr_path* file_path, scr_hash* hash, int d
     int ckpts = atoi(ckpts_str);
     ckpts -= dec_count;
 
+    /* don't go below zero */
+    if (ckpts < 0) {
+      ckpts = 0;
+    }
+
     /* write this new value back to the hash */
     scr_hash_unset(hash, SCR_HALT_KEY_CHECKPOINTS);
     scr_hash_setf(hash, NULL, "%s %d", SCR_HALT_KEY_CHECKPOINTS, ckpts);


### PR DESCRIPTION
Some apps like to print summary info before exit, so calling exit() from within SCR is not acceptable.  This adds a new query functions so an app can ask SCR if it should exit.  It also provides a parameter so apps can configure SCR to not auto-exit.