### PR TITLE
check valid flag in SCR_Complete_restart and bail if invalid

### DIFF
--- a/src/scr.c
+++ b/src/scr.c
@@ -2172,6 +2172,19 @@ int SCR_Complete_restart(int valid)
     return SCR_FAILURE;
   }
 
+  /* check that all procs read valid data */
+  if (! scr_alltrue(valid)) {
+    /* TODO: if some process fails, it would be more graceful to fetch
+     * the next most recent checkpoint and cycle through
+     * the have/start/complete restart calls again,
+     * we should also record this current checkpoint as failed in the
+     * index file so that we don't fetch it again*/
+    scr_abort(-1, "At least one process reported valid=0 in SCR_Complete_restart() @ %s:%d",
+      __FILE__, __LINE__
+    );
+    return SCR_FAILURE;
+  }
+
   /* turn off our restart flag */
   scr_have_restart = 0;
 


### PR DESCRIPTION
If any process reports valid=0 in Complete_restart, then the app failed to read its checkpoint.  For now, let's abort.  A better failure mode would be to drop this from cache, mark it as invalid in the index file so we don't fetch it again, fetch the next most recent restart, and have the caller cycle through the restart calls again.  We can implement the more graceful failure if we have time for v1.2, but at least we have something with this.