### PR TITLE
Have downnodes report reasons

### DIFF
--- a/testing/TEST
+++ b/testing/TEST
@@ -308,7 +308,7 @@ print "-----------------------------------------------------------"
 # check that scr_list_down_nodes returns good values
 downnode = os.environ['downnode']
 
-p=Popen([scrbin+'/scr_list_down_nodes'], stderr=STDOUT, stdout=PIPE)
+p=Popen([scrbin+'/scr_list_down_nodes', '--reason'], stderr=STDOUT, stdout=PIPE)
 p.wait()
 print p.stdout.read().strip()
 if p.returncode != 0 or p.stdout.read().strip() != "":


### PR DESCRIPTION
Have scr_list_down_nodes report reasons when it should not fail anyway.
This may help with debugging bamboo failures.