### PR TITLE
Fix ping

### DIFF
--- a/scripts/LSF/scr_list_down_nodes.in
+++ b/scripts/LSF/scr_list_down_nodes.in
@@ -117,7 +117,7 @@ foreach my $node (@nodes) {
   # `ping -c2` will be slower in the "normal" case
   # that ping succeeds, because non-root users cannot
   # set the ping interval below 0.2 seconds.
-  `$ping -c 1 $node || $ping -c 1 $node`;
+  `$ping -c 1 -w 1 $node || $ping -c 1 -w 1 $node`;
   if ($? != 0) {
     delete $available{$node};
     $unavailable{$node} = 1;

--- a/scripts/LSF/scr_list_down_nodes.in
+++ b/scripts/LSF/scr_list_down_nodes.in
@@ -112,7 +112,12 @@ if ($resmgr_down ne "") {
 # mark the set of nodes we can't ping
 my @failed_ping = ();
 foreach my $node (@nodes) {
-  `$ping -c 1 $node`;
+  # ICMP over omnipath can fail due to bad arp
+  # First ping will replenish arp, second succeed
+  # `ping -c2` will be slower in the "normal" case
+  # that ping succeeds, because non-root users cannot
+  # set the ping interval below 0.2 seconds.
+  `$ping -c 1 $node || $ping -c 1 $node`;
   if ($? != 0) {
     delete $available{$node};
     $unavailable{$node} = 1;

--- a/scripts/PMIX/scr_list_down_nodes.in
+++ b/scripts/PMIX/scr_list_down_nodes.in
@@ -5,7 +5,7 @@ use scr_param;
 use scr_hostlist;
 use Getopt::Long qw/ :config gnu_getopt ignore_case /;
 
-#  TODO: pmix does not support this yet either, so this has not been modified 
+#  TODO: pmix does not support this yet either, so this has not been modified
 #    beyond the standard ping test built which already existed
 
 my $prog = "scr_list_down_nodes";
@@ -115,7 +115,12 @@ if ($resmgr_down ne "") {
 # mark the set of nodes we can't ping
 my @failed_ping = ();
 foreach my $node (@nodes) {
-  `$ping -c 1 $node`;
+  # ICMP over omnipath can fail due to bad arp
+  # First ping will replenish arp, second succeed
+  # `ping -c2` will be slower in the "normal" case
+  # that ping succeeds, because non-root users cannot
+  # set the ping interval below 0.2 seconds.
+  `$ping -c 1 $node || $ping -c 1 $node`;
   if ($? != 0) {
     delete $available{$node};
     $unavailable{$node} = 1;

--- a/scripts/PMIX/scr_list_down_nodes.in
+++ b/scripts/PMIX/scr_list_down_nodes.in
@@ -120,7 +120,7 @@ foreach my $node (@nodes) {
   # `ping -c2` will be slower in the "normal" case
   # that ping succeeds, because non-root users cannot
   # set the ping interval below 0.2 seconds.
-  `$ping -c 1 $node || $ping -c 1 $node`;
+  `$ping -c 1 -w 1 $node || $ping -c 1 -w 1 $node`;
   if ($? != 0) {
     delete $available{$node};
     $unavailable{$node} = 1;

--- a/scripts/TLCC/scr_list_down_nodes.in
+++ b/scripts/TLCC/scr_list_down_nodes.in
@@ -117,7 +117,7 @@ foreach my $node (@nodes) {
   # `ping -c2` will be slower in the "normal" case
   # that ping succeeds, because non-root users cannot
   # set the ping interval below 0.2 seconds.
-  `$ping -c 1 $node || $ping -c 1 $node`;
+  `$ping -c 1 -w 1 $node || $ping -c 1 -w 1 $node`;
   if ($? != 0) {
     delete $available{$node};
     $unavailable{$node} = 1;

--- a/scripts/TLCC/scr_list_down_nodes.in
+++ b/scripts/TLCC/scr_list_down_nodes.in
@@ -112,7 +112,12 @@ if ($resmgr_down ne "") {
 # mark the set of nodes we can't ping
 my @failed_ping = ();
 foreach my $node (@nodes) {
-  `$ping -c 1 $node`;
+  # ICMP over omnipath can fail due to bad arp
+  # First ping will replenish arp, second succeed
+  # `ping -c2` will be slower in the "normal" case
+  # that ping succeeds, because non-root users cannot
+  # set the ping interval below 0.2 seconds.
+  `$ping -c 1 $node || $ping -c 1 $node`;
   if ($? != 0) {
     delete $available{$node};
     $unavailable{$node} = 1;

--- a/scripts/cray_xt/scr_list_down_nodes.in
+++ b/scripts/cray_xt/scr_list_down_nodes.in
@@ -120,7 +120,7 @@ foreach my $node (@hosts) {
   # `ping -c2` will be slower in the "normal" case
   # that ping succeeds, because non-root users cannot
   # set the ping interval below 0.2 seconds.
-  `$ping -c 1 $node || $ping -c 1 $node`;
+  `$ping -c 1 -w 1 $node || $ping -c 1 -w 1 $node`;
   if ($? != 0) {
     delete $available{$node};
     $unavailable{$node} = 1;

--- a/scripts/cray_xt/scr_list_down_nodes.in
+++ b/scripts/cray_xt/scr_list_down_nodes.in
@@ -115,7 +115,12 @@ my $hostnames = `$bindir/scr_env --hostnames`;
 my @hosts = scr_hostlist::expand($hostnames);
 
 foreach my $node (@hosts) {
-  `$ping -c 1 $node`;
+  # ICMP over omnipath can fail due to bad arp
+  # First ping will replenish arp, second succeed
+  # `ping -c2` will be slower in the "normal" case
+  # that ping succeeds, because non-root users cannot
+  # set the ping interval below 0.2 seconds.
+  `$ping -c 1 $node || $ping -c 1 $node`;
   if ($? != 0) {
     delete $available{$node};
     $unavailable{$node} = 1;

--- a/testing/TEST
+++ b/testing/TEST
@@ -308,7 +308,7 @@ print "-----------------------------------------------------------"
 # check that scr_list_down_nodes returns good values
 downnode = os.environ['downnode']
 
-p=Popen([scrbin+'/scr_list_down_nodes'], stderr=STDOUT, stdout=PIPE)
+p=Popen([scrbin+'/scr_list_down_nodes', '--reason'], stderr=STDOUT, stdout=PIPE)
 p.wait()
 print p.stdout.read().strip()
 if p.returncode != 0 or p.stdout.read().strip() != "":


### PR DESCRIPTION
Change `ping -c1` to `ping -c1 || ping -c1`

On some networks the first packet is dropped due to stale arp information, so we need a second packet. `ping -c2` is slow, because non-root users cannot set the ping interval below 0.2 seconds.

This will be slow when arp information is stale. Will continue looking into methods that will be faster when arp info is stale.