### PR TITLE
Redirect ping stderr to stdout

### DIFF
--- a/scripts/LSF/scr_list_down_nodes.in
+++ b/scripts/LSF/scr_list_down_nodes.in
@@ -117,7 +117,7 @@ foreach my $node (@nodes) {
   # `ping -c2` will be slower in the "normal" case
   # that ping succeeds, because non-root users cannot
   # set the ping interval below 0.2 seconds.
-  `$ping -c 1 -w 1 $node || $ping -c 1 -w 1 $node`;
+  `$ping -c 1 -w 1 $node 2>&1 || $ping -c 1 -w 1 $node 2>&1`;
   if ($? != 0) {
     delete $available{$node};
     $unavailable{$node} = 1;

--- a/scripts/PMIX/scr_list_down_nodes.in
+++ b/scripts/PMIX/scr_list_down_nodes.in
@@ -120,7 +120,7 @@ foreach my $node (@nodes) {
   # `ping -c2` will be slower in the "normal" case
   # that ping succeeds, because non-root users cannot
   # set the ping interval below 0.2 seconds.
-  `$ping -c 1 -w 1 $node || $ping -c 1 -w 1 $node`;
+  `$ping -c 1 -w 1 $node 2>&1 || $ping -c 1 -w 1 $node 2>&1`;
   if ($? != 0) {
     delete $available{$node};
     $unavailable{$node} = 1;

--- a/scripts/TLCC/scr_list_down_nodes.in
+++ b/scripts/TLCC/scr_list_down_nodes.in
@@ -117,7 +117,7 @@ foreach my $node (@nodes) {
   # `ping -c2` will be slower in the "normal" case
   # that ping succeeds, because non-root users cannot
   # set the ping interval below 0.2 seconds.
-  `$ping -c 1 -w 1 $node || $ping -c 1 -w 1 $node`;
+  `$ping -c 1 -w 1 $node 2>&1 || $ping -c 1 -w 1 $node 2>&1`;
   if ($? != 0) {
     delete $available{$node};
     $unavailable{$node} = 1;

--- a/scripts/cray_xt/scr_list_down_nodes.in
+++ b/scripts/cray_xt/scr_list_down_nodes.in
@@ -120,7 +120,7 @@ foreach my $node (@hosts) {
   # `ping -c2` will be slower in the "normal" case
   # that ping succeeds, because non-root users cannot
   # set the ping interval below 0.2 seconds.
-  `$ping -c 1 -w 1 $node || $ping -c 1 -w 1 $node`;
+  `$ping -c 1 -w 1 $node 2>&1 || $ping -c 1 -w 1 $node 2>&1`;
   if ($? != 0) {
     delete $available{$node};
     $unavailable{$node} = 1;


### PR DESCRIPTION
ping warnings were leading to incorrect assumptions about whether ping had succeeded. Since we never check ping output (only error code) decided to suppress warnings by redirecting stderr to stdout.