### PR TITLE
Generalize node name format

### DIFF
--- a/scripts/LSF/scr_list_down_nodes.in
+++ b/scripts/LSF/scr_list_down_nodes.in
@@ -128,10 +128,7 @@ if ($resmgr_down ne "") {
 #}
 
 # only run this against set of nodes known to be responding
-my @still_up = (sort {
-  my ($num_a) = ($a =~ /^[\D]+(\d+$)/);
-  my ($num_b) = ($b =~ /^[\D]+(\d+$)/);
-  return $num_a <=> $num_b;} keys %available);
+my @still_up = (keys %available);
 my $upnodes = scr_hostlist::compress(@still_up);
 
 # add all up nodes into an assumed down list
@@ -249,10 +246,7 @@ if (defined $conf{nodeset_down}) {
 #}
 #
 ## only run this against set of nodes known to be responding
-#my @still_up = (sort {
-#  my ($num_a) = ($a =~ /^[\D]+(\d+$)/);
-#  my ($num_b) = ($b =~ /^[\D]+(\d+$)/);
-#  return $num_a <=> $num_b;} keys %available);
+#my @still_up = (keys %available);
 #my $upnodes = scr_hostlist::compress(@still_up);
 #
 ## run scr_check_node on each node specifying control and cache directories to check
@@ -279,11 +273,8 @@ if (defined $conf{nodeset_down}) {
 #  }
 #}
 
-# take union of all these sets and sort by node name
-my @failed_nodes = (sort {
-  my ($num_a) = ($a =~ /^[\D]+(\d+$)/);
-  my ($num_b) = ($b =~ /^[\D]+(\d+$)/);
-  return $num_a <=> $num_b;} keys %unavailable);
+# take union of all these sets
+my @failed_nodes = (keys %unavailable);
 
 # print any failed nodes to stdout and exit with non-zero
 if (@failed_nodes) {

--- a/scripts/LSF/scr_scavenge.in
+++ b/scripts/LSF/scr_scavenge.in
@@ -164,14 +164,14 @@ if (-r $output) {
   open(OUT, $output);
   while (my $line = <OUT>) {
     chomp $line;
-    if ($line =~ /(\w+\d+): Partners: (.*)$/) {
+    if ($line =~ /(\S+): Partners: (.*)$/) {
       #atlas693: atlas693: Partners: atlas690 atlas692
       my $current_node = $1;
       my @partner_list = split(/\s+/, $2);
       foreach my $p (@partner_list) {
         push @{$partner{$p}}, $current_node;
       }
-    } elsif ($line =~ /(\w+\d+): Return code: (\d+)/) {
+    } elsif ($line =~ /(\S+): Return code: (\d+)/) {
       #atlas692: atlas692: Return code: 256
       if ($2 != 0) {
         push @copy_failed, $1;
@@ -187,11 +187,11 @@ if (-r $error) {
   open(ERR, $error);
   while (my $line = <ERR>) {
     #pdsh@atlas156: atlas193: mcmd: connect failed: No route to host
-    if ($line =~ /pdsh\@\w+\d+: (\w+\d+):/) {
+    if ($line =~ /pdsh\@\S+: (\S+):/) {
       $pdsh_failed_nodes{$1} = 1;
     }
     #atlas193: mcmd: connect failed: No route to host
-    if ($line =~ /^(\w+\d+):/) {
+    if ($line =~ /^(\S+):/) {
       $pdsh_failed_nodes{$1} = 1;
     }
   }
@@ -213,11 +213,8 @@ if (@copy_failed > 0 or @pdsh_failed > 0) {
     $all_failures{$node} = 1;
   }
 
-  # sort all failed nodes and list them in stdout
-  my @failed = (sort {
-    my ($numA) = ($a =~ /\w+(\d+)/);
-    my ($numB) = ($b =~ /\w+(\d+)/);
-    return $numA <=> $numB} keys %all_failures);
+  # list all failed nodes in stdout
+  my @failed = (keys %all_failures);
 
   # for each failed node, try to find a partner
   my $missing_partner_for_failed_node = 0;
@@ -241,11 +238,8 @@ if (@copy_failed > 0 or @pdsh_failed > 0) {
     }
   }
 
-  # sort partner nodes
-  my @partners = (sort {
-    my ($numA) = ($a =~ /\w+(\d+)/);
-    my ($numB) = ($b =~ /\w+(\d+)/);
-    return $numA <=> $numB} keys %partner_nodes);
+  # get list of partner nodes
+  my @partners = (keys %partner_nodes);
 
   print "$prog: pdsh failed on: ", scalar(scr_hostlist::compress(@failed));
   print ", trying partners: ", scalar(scr_hostlist::compress(@partners)), "\n\n";

--- a/scripts/PMIX/scr_list_down_nodes.in
+++ b/scripts/PMIX/scr_list_down_nodes.in
@@ -209,10 +209,7 @@ if (@cachedir_vals > 0) {
 }
 
 # only run this against set of nodes known to be responding
-my @still_up = (sort {
-  my ($num_a) = ($a =~ /^[\D]+(\d+.*$)/);
-  my ($num_b) = ($b =~ /^[\D]+(\d+.*$)/);
-  return $num_a cmp $num_b;} keys %available);
+my @still_up = (keys %available);
 my $upnodes = scr_hostlist::compress(@still_up);
 
 # run scr_check_node on each node specifying control and cache directories to check
@@ -239,11 +236,8 @@ if (@still_up > 0) {
   }
 }
 
-# take union of all these sets and sort by node name
-my @failed_nodes = (sort {
-  my ($num_a) = ($a =~ /^[\D]+(\d+.*$)/);
-my ($num_b) = ($b =~ /^[\D]+(\d+.*$)/);
-  return $num_a cmp $num_b;} keys %unavailable);
+# take union of all these sets
+my @failed_nodes = (keys %unavailable);
 
 # print any failed nodes to stdout and exit with non-zero
 if (@failed_nodes) {

--- a/scripts/PMIX/scr_scavenge.in
+++ b/scripts/PMIX/scr_scavenge.in
@@ -179,14 +179,14 @@ if (-r $output) {
   open(OUT, $output);
   while (my $line = <OUT>) {
     chomp $line;
-    if ($line =~ /(\w+\d+): Partners: (.*)$/) {
+    if ($line =~ /(\S+): Partners: (.*)$/) {
       #atlas693: atlas693: Partners: atlas690 atlas692
       my $current_node = $1;
       my @partner_list = split(/\s+/, $2);
       foreach my $p (@partner_list) {
         push @{$partner{$p}}, $current_node;
       }
-    } elsif ($line =~ /(\w+\d+): Return code: (\d+)/) {
+    } elsif ($line =~ /(\S+): Return code: (\d+)/) {
       #atlas692: atlas692: Return code: 256
       if ($2 != 0) {
         push @copy_failed, $1;
@@ -202,11 +202,11 @@ if (-r $error) {
   open(ERR, $error);
   while (my $line = <ERR>) {
     #pdsh@atlas156: atlas193: mcmd: connect failed: No route to host
-    if ($line =~ /pdsh\@\w+\d+: (\w+\d+):/) {
+    if ($line =~ /pdsh\@\S+: (\S+):/) {
       $pdsh_failed_nodes{$1} = 1;
     }
     #atlas193: mcmd: connect failed: No route to host
-    if ($line =~ /^(\w+\d+):/) {
+    if ($line =~ /^(\S+):/) {
       $pdsh_failed_nodes{$1} = 1;
     }
   }
@@ -228,11 +228,8 @@ if (@copy_failed > 0 or @pdsh_failed > 0) {
     $all_failures{$node} = 1;
   }
 
-  # sort all failed nodes and list them in stdout
-  my @failed = (sort {
-    my ($numA) = ($a =~ /\w+(\d+)/);
-    my ($numB) = ($b =~ /\w+(\d+)/);
-    return $numA <=> $numB} keys %all_failures);
+  # list all failed nodes in stdout
+  my @failed = (keys %all_failures);
 
   # for each failed node, try to find a partner
   my $missing_partner_for_failed_node = 0;
@@ -256,11 +253,8 @@ if (@copy_failed > 0 or @pdsh_failed > 0) {
     }
   }
 
-  # sort partner nodes
-  my @partners = (sort {
-    my ($numA) = ($a =~ /\w+(\d+)/);
-    my ($numB) = ($b =~ /\w+(\d+)/);
-    return $numA <=> $numB} keys %partner_nodes);
+  # get list of partner nodes
+  my @partners = (keys %partner_nodes);
 
   print "$prog: pdsh failed on: ", scalar(scr_hostlist::compress(@failed));
   print ", trying partners: ", scalar(scr_hostlist::compress(@partners)), "\n\n";

--- a/scripts/TLCC/scr_list_down_nodes.in
+++ b/scripts/TLCC/scr_list_down_nodes.in
@@ -208,10 +208,7 @@ if (@cachedir_vals > 0) {
 }
 
 # only run this against set of nodes known to be responding
-my @still_up = (sort {
-  my ($num_a) = ($a =~ /^[\D]+(\d+$)/);
-  my ($num_b) = ($b =~ /^[\D]+(\d+$)/);
-  return $num_a <=> $num_b;} keys %available);
+my @still_up = (keys %available);
 my $upnodes = scr_hostlist::compress(@still_up);
 
 # run scr_check_node on each node specifying control and cache directories to check
@@ -238,11 +235,8 @@ if (@still_up > 0) {
   }
 }
 
-# take union of all these sets and sort by node name
-my @failed_nodes = (sort {
-  my ($num_a) = ($a =~ /^[\D]+(\d+$)/);
-  my ($num_b) = ($b =~ /^[\D]+(\d+$)/);
-  return $num_a <=> $num_b;} keys %unavailable);
+# take union of all these sets
+my @failed_nodes = (keys %unavailable);
 
 # print any failed nodes to stdout and exit with non-zero
 if (@failed_nodes) {

--- a/scripts/TLCC/scr_scavenge.in
+++ b/scripts/TLCC/scr_scavenge.in
@@ -167,14 +167,14 @@ if (-r $output) {
   open(OUT, $output);
   while (my $line = <OUT>) {
     chomp $line;
-    if ($line =~ /(\w+\d+): Partners: (.*)$/) {
+    if ($line =~ /(\S+): Partners: (.*)$/) {
       #atlas693: atlas693: Partners: atlas690 atlas692
       my $current_node = $1;
       my @partner_list = split(/\s+/, $2);
       foreach my $p (@partner_list) {
         push @{$partner{$p}}, $current_node;
       }
-    } elsif ($line =~ /(\w+\d+): Return code: (\d+)/) {
+    } elsif ($line =~ /(\S+): Return code: (\d+)/) {
       #atlas692: atlas692: Return code: 256
       if ($2 != 0) {
         push @copy_failed, $1;
@@ -190,11 +190,11 @@ if (-r $error) {
   open(ERR, $error);
   while (my $line = <ERR>) {
     #pdsh@atlas156: atlas193: mcmd: connect failed: No route to host
-    if ($line =~ /pdsh\@\w+\d+: (\w+\d+):/) {
+    if ($line =~ /pdsh\@\S+: (\S+):/) {
       $pdsh_failed_nodes{$1} = 1;
     }
     #atlas193: mcmd: connect failed: No route to host
-    if ($line =~ /^(\w+\d+):/) {
+    if ($line =~ /^(\S+):/) {
       $pdsh_failed_nodes{$1} = 1;
     }
   }
@@ -216,11 +216,8 @@ if (@copy_failed > 0 or @pdsh_failed > 0) {
     $all_failures{$node} = 1;
   }
 
-  # sort all failed nodes and list them in stdout
-  my @failed = (sort {
-    my ($numA) = ($a =~ /\w+(\d+)/);
-    my ($numB) = ($b =~ /\w+(\d+)/);
-    return $numA <=> $numB} keys %all_failures);
+  # list all failed nodes in stdout
+  my @failed = (keys %all_failures);
 
   # for each failed node, try to find a partner
   my $missing_partner_for_failed_node = 0;
@@ -244,11 +241,8 @@ if (@copy_failed > 0 or @pdsh_failed > 0) {
     }
   }
 
-  # sort partner nodes
-  my @partners = (sort {
-    my ($numA) = ($a =~ /\w+(\d+)/);
-    my ($numB) = ($b =~ /\w+(\d+)/);
-    return $numA <=> $numB} keys %partner_nodes);
+  # get list of partner nodes
+  my @partners = (keys %partner_nodes);
 
   print "$prog: pdsh failed on: ", scalar(scr_hostlist::compress(@failed));
   print ", trying partners: ", scalar(scr_hostlist::compress(@partners)), "\n\n";

--- a/scripts/common/scr_hostlist.pm
+++ b/scripts/common/scr_hostlist.pm
@@ -96,81 +96,81 @@ sub expand {
   return @nodes;
 }
 
-## Returns a hostlist string given a list of hostnames
-## compress('rhea2','rhea3','rhea4','rhea6') returns "rhea[2-4,6]"
-#sub compress {
-#  if (@_ == 0) {
-#    return "";
-#  }
-#
-#  # pull the machine name from the first node name
-#  my @numbers = ();
-#  my @vmnumbers = ();
-#  my ($machine) = ($_[0] =~ /([\D]*)(\d+.*)/);
-#  foreach my $host (@_) {
-#    # get the machine name and node number for this node
-#    my ($name, $number) = ($host =~ /([\D]*)(\d+.*)/);
-#
-#    # check that all nodes belong to the same machine
-#    if ($name ne $machine) {
-#      return undef;
-#    }
-#    my ($temp_comp) = ($number =~ /([\d]+)/);
-#    if ( $number eq $temp_comp ){
-#        # record the number
-#        push @numbers, $number;
-#    }
-#    else{
-#        # we have a machine number with letters attached, so add to 
-#        # separate list (we're not going to truly compress these)
-#        push @vmnumbers, $machine . $number;
-#    }
-#
-#  }
-#
-#  # order the nodes by number
-#  my @sorted = sort {$a <=> $b} @numbers;
-#
-#  # TODO: toss out duplicates?
-#
-#  # build the ranges
-#  my @ranges = ();
-#  my $low  = $sorted[0];
-#  my $last = $low;
-#  for(my $i=1; $i < @sorted; $i++) {
-#    my $high = $sorted[$i];
-#    if($high == $last + 1) {
-#      $last = $high;
-#      next;
-#    }
-#    if($last > $low) {
-#      push @ranges, $low . "-" . $last;
-#    } else {
-#      push @ranges, $low;
-#    }
-#    $low  = $high;
-#    $last = $low;
-#  }
-#  if(@sorted > 0 ){
-#      if($last > $low) {
-#          push @ranges, $low . "-" . $last;
-#      } else {
-#          push @ranges, $low;
-#      }
-#  }
-#  my $csv_vals = "";
-#  if(@vmnumbers > 0){
-#      $csv_vals = ",";
-#      $csv_vals .= join(",", @vmnumbers);
-#  }
-#
-#  if(@ranges == 0 && $csv_vals ne ""){
-#      return  substr($csv_vals, 1, length($csv_vals));
-#  }
-#
-#  # join the ranges with commas and return the compressed hostlist
-#  return $machine . "[" . join(",", @ranges) . "]" . $csv_vals;
-#}
+# Returns a hostlist string given a list of hostnames
+# compress('rhea2','rhea3','rhea4','rhea6') returns "rhea[2-4,6]"
+sub compress_range {
+  if (@_ == 0) {
+    return "";
+  }
+
+  # pull the machine name from the first node name
+  my @numbers = ();
+  my @vmnumbers = ();
+  my ($machine) = ($_[0] =~ /([\D]*)(\d+.*)/);
+  foreach my $host (@_) {
+    # get the machine name and node number for this node
+    my ($name, $number) = ($host =~ /([\D]*)(\d+.*)/);
+
+    # check that all nodes belong to the same machine
+    if ($name ne $machine) {
+      return undef;
+    }
+    my ($temp_comp) = ($number =~ /([\d]+)/);
+    if ( $number eq $temp_comp ){
+        # record the number
+        push @numbers, $number;
+    }
+    else{
+        # we have a machine number with letters attached, so add to 
+        # separate list (we're not going to truly compress these)
+        push @vmnumbers, $machine . $number;
+    }
+
+  }
+
+  # order the nodes by number
+  my @sorted = sort {$a <=> $b} @numbers;
+
+  # TODO: toss out duplicates?
+
+  # build the ranges
+  my @ranges = ();
+  my $low  = $sorted[0];
+  my $last = $low;
+  for(my $i=1; $i < @sorted; $i++) {
+    my $high = $sorted[$i];
+    if($high == $last + 1) {
+      $last = $high;
+      next;
+    }
+    if($last > $low) {
+      push @ranges, $low . "-" . $last;
+    } else {
+      push @ranges, $low;
+    }
+    $low  = $high;
+    $last = $low;
+  }
+  if(@sorted > 0 ){
+      if($last > $low) {
+          push @ranges, $low . "-" . $last;
+      } else {
+          push @ranges, $low;
+      }
+  }
+  my $csv_vals = "";
+  if(@vmnumbers > 0){
+      $csv_vals = ",";
+      $csv_vals .= join(",", @vmnumbers);
+  }
+
+  if(@ranges == 0 && $csv_vals ne ""){
+      return  substr($csv_vals, 1, length($csv_vals));
+  }
+
+  # join the ranges with commas and return the compressed hostlist
+  return $machine . "[" . join(",", @ranges) . "]" . $csv_vals;
+}
 
 # Returns a hostlist string given a list of hostnames
 # compress('rhea2','rhea3','rhea4','rhea6') returns "rhea2,rhea3,rhea4,rhea6"
@@ -179,9 +179,8 @@ sub compress {
     return "";
   }
 
-  # sort the node names and join them with commas
-  my @nodes = sort {$a cmp $b} @_;
-  return join(",", @nodes);
+  # join nodes with commas
+  return join(",", @_);
 }
 
 # Given references to two lists, subtract elements in list 2 from list 1 and return remainder

--- a/scripts/common/scr_hostlist.pm
+++ b/scripts/common/scr_hostlist.pm
@@ -9,90 +9,101 @@ use strict;
 #   returns an ordered hostlist string given a list of hostnames
 #
 # Author:  Adam Moody (moody20@llnl.gov)
-
-
-# Returns a list of hostnames, give a hostlist string
-# expand("rhea[2-4,6]") returns ('rhea2','rhea3','rhea4','rhea6')
-
 # modified by Christopher Holguin <christopher.a.holguin@intel.com>
-#   notes: there are 2 new features 1) it now supports hostnames like rhea-1
-#     and 2) rhea-1vm1
 
-
+# Returns a list of hostnames given a hostlist string
+# expand("rhea[2-4,6]") returns ('rhea2','rhea3','rhea4','rhea6')
+# hostrange can contain an optional suffix after brackets:
+#   rhea[2-4,6].llnl.gov
+# multiple ranges can be listed as csv:
+#   machine[1-3,5],machine[7-8],machine10
+# left fills with 0 if a host starts with 0:
+#   machine[08-10] --> machine08,machine09,machine10
 sub expand {
   # read in our hostlist, should be first parameter
   if (@_ != 1) {
     return undef;
   }
   my $nodeset = shift @_;
-  # produce our list of nodes
+
   my @nodes = ();
-  my $machine = undef;
-  my @lowhighs = ();
-  my @single_nodes = ();
-  my $numberLength = 0; # for leading zeros, e.g atlas[0001-0003]
-  if ($nodeset =~ /([\D\d]*)\[([\d,-]+)\](.*)/) {
-    # hostlist with brackets, e.g., atlas[2-5,28,30]
-    $machine = $1;
-    my @ranges = split ",", $2;
-    foreach my $range (@ranges) {
-      my $low  = undef;
-      my $high = undef;
-      if ($range =~ /(\d+)-(\d+)/) {
-        # low-to-high range
-        $low  = $1;
-        $high = $2;
-        #if the lowest number starts with 0
-        if($numberLength == 0 and index($low,"0") == 0){ 
-            $numberLength = length($low);
-        }
+
+  # split entries on commas
+  # machine[1-3,5],machine[7-8],machine10
+  my @chunks = split ",", $nodeset;
+  while (@chunks > 0) {
+    # look for opening bracket
+    my $chunk = shift @chunks;
+    if ($chunk =~ /^(.*)\[(.*)$/) {
+      # got a starting bracket, scan until we find the closing bracket
+      my $prefix  = $1;
+      my $content = $2;
+      my $suffix  = "";
+
+      # build a list of ranges until we find the closing bracket
+      my @ranges = ();
+      if ($content =~ /^(.*)\](.*)$/) {
+        # found the closing bracket (and optional suffix) in the same chunk
+        push @ranges, $1;
+        $suffix = $2;
       } else {
-        # single element range
-        push @single_nodes, $range;
-        #if the lowest number starts with 0
-        if($numberLength == 0 and index($range,"0") == 0){ 
-            $numberLength = length($range);
+        # no bracket, so we either got a single number or a range here
+        push @ranges, $content;
+
+        # pluck off entries until we find the closing bracket
+        while ($chunks[0] !~ /^(.*)\](.*)$/) {
+          $chunk = shift @chunks;
+          push @ranges, $chunk;
         }
-        
-        next;
+
+        # if well formed, this item must now have the bracket
+        $chunk = shift @chunks;
+        if ($chunk =~ /^(.*)\](.*)$/) {
+          # found the closing bracket (and optional suffix)
+          push @ranges, $1;
+          $suffix = $2;
+        }
       }
 
-      push @lowhighs, $low, $high;
-    }
+      # expand ranges to pairs of low/high values
+      my @lowhighs = ();
+      my $numberLength = 0; # for leading zeros, e.g atlas[0001-0003]
+      foreach my $range (@ranges) {
+        my $low  = undef;
+        my $high = undef;
+        if ($range =~ /(\d+)-(\d+)/) {
+          # low-to-high range
+          $low  = $1;
+          $high = $2;
+        } else {
+          # single element range
+          $low  = $range;
+          $high = $range;
+        }
+        #if the lowest number starts with 0
+        if($numberLength == 0 and index($low,"0") == 0){ 
+           $numberLength = length($low);
+        }
+        push @lowhighs, $low, $high;
+      }
 
-    if($3 ne ""){
-        my $temp_csv = $3;
-        $temp_csv = substr($temp_csv, 1, length($temp_csv));
-        my @extra_ranges = split ",", $temp_csv;
-        push @nodes, @extra_ranges;
-    }
-  } else {
-    # supports a simple list of host names, e.g., atlas2,atlas3,atlas4
-    my @items = split ",", $nodeset;
-    foreach my $item (@items) {
-        # single host name, e.g., atlas2
-        $item =~ /([\D]*)(\d+.*)/;
-        $machine = $1;
-        $numberLength = length($2);
-        push @single_nodes, $2;
+      # produce our list of node names
+      while(@lowhighs) {
+        my $low  = shift @lowhighs;
+        my $high = shift @lowhighs;
+        for(my $i = $low; $i <= $high; $i++) {
+          # tack on leading 0's if input had them
+          my $nodenumber = sprintf("%0*d", $numberLength, $i);
+          my $nodename = $prefix . $nodenumber . $suffix;
+          push @nodes, $nodename;
+        }
+      }
+    } else {
+      # no brackets, just a single node name, copy it verbatim
+      push @nodes, $chunk;
     }
   }
 
-
-  while(@lowhighs) {
-    my $low  = shift @lowhighs;
-    my $high = shift @lowhighs;
-    for(my $i = $low; $i <= $high; $i++) {
-      my $nodenumber = sprintf("%0*d", $numberLength, $i);
-      push @nodes, $machine . $nodenumber;
-    }
-  }
-  while(@single_nodes){
-      my $temp = shift @single_nodes;
-      my $nodenumber = sprintf("%0*s", $numberLength, $temp);
-      push @nodes, $machine . $temp;
-  }
-  
   return @nodes;
 }
 

--- a/scripts/cray_xt/scr_list_down_nodes.in
+++ b/scripts/cray_xt/scr_list_down_nodes.in
@@ -209,10 +209,7 @@ if (@cachedir_vals > 0) {
 }
 
 # only run this against set of nodes known to be responding
-my @still_up = (sort {
-  my ($num_a) = ($a =~ /^[\D]*(\d+$)/);
-  my ($num_b) = ($b =~ /^[\D]*(\d+$)/);
-  return $num_a <=> $num_b;} keys %available);
+my @still_up = (keys %available);
 my $upnodes = scr_hostlist::compress(@still_up);
 
 # run scr_check_node on each node specifying control and cache directories to check
@@ -239,11 +236,8 @@ if (@still_up > 0) {
   }
 }
 
-# take union of all these sets and sort by node name
-my @failed_nodes = (sort {
-  my ($num_a) = ($a =~ /^[\D]*(\d+$)/);
-  my ($num_b) = ($b =~ /^[\D]*(\d+$)/);
-  return $num_a <=> $num_b;} keys %unavailable);
+# take union of all these sets
+my @failed_nodes = (keys %unavailable);
 
 # print any failed nodes to stdout and exit with non-zero
 if (@failed_nodes) {

--- a/scripts/cray_xt/scr_scavenge.in
+++ b/scripts/cray_xt/scr_scavenge.in
@@ -169,14 +169,14 @@ if (-r $output) {
   open(OUT, $output);
   while (my $line = <OUT>) {
     chomp $line;
-    if ($line =~ /(\w*\d+): Partners: (.*)$/) {
+    if ($line =~ /(\S+): Partners: (.*)$/) {
       #atlas693: atlas693: Partners: atlas690 atlas692
       my $current_node = $1;
       my @partner_list = split(/\s+/, $2);
       foreach my $p (@partner_list) {
         push @{$partner{$p}}, $current_node;
       }
-    } elsif ($line =~ /(\w*\d+): Return code: (\d+)/) {
+    } elsif ($line =~ /(\S+): Return code: (\d+)/) {
       #atlas692: atlas692: Return code: 256
       if ($2 != 0) {
         push @copy_failed, $1;
@@ -192,11 +192,11 @@ if (-r $error) {
   open(ERR, $error);
   while (my $line = <ERR>) {
     #pdsh@atlas156: atlas193: mcmd: connect failed: No route to host
-    if ($line =~ /pdsh\@\w*\d+: (\w*\d+):/) {
+    if ($line =~ /pdsh\@\S+: (\S+):/) {
       $pdsh_failed_nodes{$1} = 1;
     }
     #atlas193: mcmd: connect failed: No route to host
-    if ($line =~ /^(\w*\d+):/) {
+    if ($line =~ /^(\S+):/) {
       $pdsh_failed_nodes{$1} = 1;
     }
   }
@@ -218,11 +218,8 @@ if (@copy_failed > 0 or @pdsh_failed > 0) {
     $all_failures{$node} = 1;
   }
 
-  # sort all failed nodes and list them in stdout
-  my @failed = (sort {
-    my ($numA) = ($a =~ /\w*(\d+)/);
-    my ($numB) = ($b =~ /\w*(\d+)/);
-    return $numA <=> $numB} keys %all_failures);
+  # list all failed nodes in stdout
+  my @failed = (keys %all_failures);
 
   # for each failed node, try to find a partner
   my $missing_partner_for_failed_node = 0;
@@ -246,11 +243,8 @@ if (@copy_failed > 0 or @pdsh_failed > 0) {
     }
   }
 
-  # sort partner nodes
-  my @partners = (sort {
-    my ($numA) = ($a =~ /\w*(\d+)/);
-    my ($numB) = ($b =~ /\w*(\d+)/);
-    return $numA <=> $numB} keys %partner_nodes);
+  # get list of partner nodes
+  my @partners = (keys %partner_nodes);
 
   print "$prog: pdsh failed on: ", scalar(scr_hostlist::compress(@failed));
   print ", trying partners: ", scalar(scr_hostlist::compress(@partners)), "\n\n";


### PR DESCRIPTION
At LLNL, nodes typically follow a syntax like <name><number> which can be read using a regex like \w+\d+.  For example, node 34 on a system called "machine" would be "machine34".  This enables a list of machines to be given in simple compressed format like: machine34,machine35,machine36,machine37 --> machine[34-37].

Other sites use different conventions in node names, including a suffix following the numbers or perhaps dashes/dots and multiple numbers.  This change extends the node name range to have an arbitrary prefix and suffix.  It also drops the logic that compresses a list of nodes, since that becomes non-trivial in other formats.  For example, this supports ranges like:

"machine2-[3-5]-vm1" --> "machine2-3-vm1,machine2-4-vm1,machine2-5-vm1"