### PR TITLE
Set pdsh rcmd module to ssh

### DIFF
--- a/scripts/LSF/scr_inspect.in
+++ b/scripts/LSF/scr_inspect.in
@@ -90,7 +90,7 @@ my $cmd = undef;
 # gather files via pdsh
 my $filemap = "$cntldir/filemap.scrinfo";
 $cmd = "$bindir/scr_inspect_cache $filemap";
-`$pdsh -f 256 -S -w '$upnodes'  "$cmd"  >$output 2>$error`;
+`$pdsh -R ssh -f 256 -S -w '$upnodes'  "$cmd"  >$output 2>$error`;
 
 # scan output file for list of partners and failed copies
 my %groups = ();

--- a/scripts/LSF/scr_list_down_nodes.in
+++ b/scripts/LSF/scr_list_down_nodes.in
@@ -139,7 +139,7 @@ foreach my $node (@still_up) {
 
 # run an "echo UP" on each node to check whether it works
 if (@still_up > 0) {
-  my $output = `$pdsh -f 256 -w '$upnodes' "echo UP" | $dshbak -c`;
+  my $output = `$pdsh -R ssh -f 256 -w '$upnodes' "echo UP" | $dshbak -c`;
   my @lines = (split "\n", $output);
   while (@lines) {
     my $line = shift @lines;

--- a/scripts/LSF/scr_scavenge.in
+++ b/scripts/LSF/scr_scavenge.in
@@ -139,8 +139,8 @@ my $cmd = undef;
 my $partner_flag = "";
 $cmd = "$bindir/scr_copy --cntldir $cntldir --id $dset --prefix $prefixdir --buf $buf_size $crc_flag $partner_flag $container_flag $downnodes_spaced";
 print "$prog: ", scalar(localtime), "\n";
-print "$prog: $pdsh -f 256 -S -w '$upnodes' \"$cmd\" >$output 2>$error\n";
-             `$pdsh -f 256 -S -w '$upnodes'  "$cmd"  >$output 2>$error`;
+print "$prog: $pdsh -R ssh -f 256 -S -w '$upnodes' \"$cmd\" >$output 2>$error\n";
+             `$pdsh -R ssh -f 256 -S -w '$upnodes'  "$cmd"  >$output 2>$error`;
 
 # print pdsh output to screen
 if ($conf{verbose}) {
@@ -262,8 +262,8 @@ if (@copy_failed > 0 or @pdsh_failed > 0) {
   $partner_flag = "--partner";
   $cmd = "$bindir/scr_copy --cntldir $cntldir --id $dset --prefix $prefixdir --buf $buf_size $crc_flag $partner_flag $container_flag $new_downnodes_spaced";
   if ($new_upnodes ne "") {
-    print "$prog: $pdsh -f 256 -S -w '$new_upnodes' \"$cmd\" >$output2 2>$error2\n";
-                 `$pdsh -f 256 -S -w '$new_upnodes'  "$cmd"  >$output2 2>$error2`;
+    print "$prog: $pdsh -R ssh -f 256 -S -w '$new_upnodes' \"$cmd\" >$output2 2>$error2\n";
+                 `$pdsh -R ssh -f 256 -S -w '$new_upnodes'  "$cmd"  >$output2 2>$error2`;
 
     # print pdsh output to screen
     if ($conf{verbose}) {


### PR DESCRIPTION
The restart-in-place scripts for LSF use `pdsh`. Without `-R ssh`, `pdsh` fails with
```
mcmd: xpoll: protocol failure in circuit setup
```
for "non-privileged" users.

This only solves the problem with the LSF scripts. Don't know if the PMIX or TLCC scripts currently work at all at the moment, and so left those unchanged.