### PR TITLE
Fix compile error when building with BBAPI

### DIFF
--- a/cmake/FindBBAPI.cmake
+++ b/cmake/FindBBAPI.cmake
@@ -10,12 +10,12 @@ FIND_PATH(WITH_BBAPI_PREFIX
 
 FIND_LIBRARY(BBAPI_LIBRARIES
     NAMES bbAPI
-    HINTS ${WITH_BBAPI_PREFIX}/lib
+    HINTS ${WITH_BBAPI_PREFIX}/lib /opt/ibm/bb/lib
 )
 
 FIND_PATH(BBAPI_INCLUDE_DIRS
     NAMES bbapi.h
-    HINTS ${WITH_BBAPI_PREFIX}/include
+    HINTS ${WITH_BBAPI_PREFIX}/include /opt/ibm/bb/include
 )
 
 INCLUDE(FindPackageHandleStandardArgs)


### PR DESCRIPTION
When building SCR with the `-DSCR_ASYNC_API=IBM_BBAPI` option, the build errors out with:
```
libscr.so: undefined reference to `scr_bool_is_flushing'
libscr.so: undefined reference to `scr_bool_need_flush'
libscr.so: undefined reference to `getLastErrorDetails'
```

This updates the out-of-date SCR function names that get called when using BBAPI, as well as updating the call to BBAPI's `BB_GetLastErrorDetails()`.

Also adds hints for where the BBAPI Libraries might be found to avoid needing to provide the `-DWITH_BBAPI_PREFIX` cmake option (as was done in AXL).