### PR TITLE
Update Filo_Fetch()/Filo_Flush() calls

### DIFF
--- a/src/scr_fetch.c
+++ b/src/scr_fetch.c
@@ -172,7 +172,8 @@ static int scr_fetch_data(
   int num_files = 0;
   char** src_filelist = NULL;
   char** dest_filelist = NULL;
-  if (Filo_Fetch(mapfile, scr_prefix, cache_dir, &num_files, &src_filelist, &dest_filelist, scr_comm_world) != FILO_SUCCESS) {
+  if (Filo_Fetch(mapfile, scr_prefix, cache_dir, &num_files, &src_filelist,
+    &dest_filelist, scr_comm_world, "pthread") != FILO_SUCCESS) {
     rc = SCR_FAILURE;
   }
 

--- a/src/scr_flush_async.c
+++ b/src/scr_flush_async.c
@@ -160,7 +160,8 @@ int scr_flush_async_start(scr_cache_index* cindex, int id)
 
   /* flush data */
   int rc = SCR_SUCCESS;
-  if (Filo_Flush_start(scr_flush_async_rankfile, scr_prefix, numfiles, src_filelist, dst_filelist, scr_comm_world) != FILO_SUCCESS) {
+  if (Filo_Flush_start(scr_flush_async_rankfile, scr_prefix, numfiles,
+    src_filelist, dst_filelist, scr_comm_world, "pthread") != FILO_SUCCESS) {
     rc = SCR_FAILURE;
   }
 

--- a/src/scr_flush_sync.c
+++ b/src/scr_flush_sync.c
@@ -62,7 +62,8 @@ static int scr_flush_files_list(kvtree* file_list)
   const char* rankfile = spath_strdup(dataset_path);
 
   /* flush data */
-  if (Filo_Flush(rankfile, scr_prefix, numfiles, src_filelist, dst_filelist, scr_comm_world) != FILO_SUCCESS) {
+  if (Filo_Flush(rankfile, scr_prefix, numfiles, src_filelist, dst_filelist,
+    scr_comm_world, "pthread") != FILO_SUCCESS) {
     rc = SCR_FAILURE;
   }
 


### PR DESCRIPTION
`Filo_Fetch()`/`Filo_Flush()` were recently updated to allow you to specify the AXL transfer type.  Use the 'pthread' transfer type for good performance across all types of filesystems.

**Note: this requires https://github.com/ECP-VeloC/filo/pull/6 to be in first.  Do not merge this PR until it's in.**