### PR TITLE
Return value used without being saved from SCR_Start_restart()

### DIFF
--- a/examples/test_api.c
+++ b/examples/test_api.c
@@ -475,7 +475,7 @@ int main (int argc, char* argv[])
     }
 
     /* indicate to library that we're start to read our restart */
-    SCR_Start_restart(dset);
+    scr_retval = SCR_Start_restart(dset);
     if (scr_retval != SCR_SUCCESS) {
       printf("%d: failed calling SCR_Start_restart: %d: @%s:%d\n",
              rank, scr_retval, __FILE__, __LINE__


### PR DESCRIPTION
Simple bug fix. Return value was not saved before being used, which was fine under normal conditions since the unset value of scr_retval happened to be SCR_SUCCESS, but a problem if SCR_Start_restart() actually failed.