### PR TITLE
Pfsdirect

### DIFF
--- a/doc/rst/index.rst
+++ b/doc/rst/index.rst
@@ -12,18 +12,19 @@ for checkpointing, restarting, and writing large datasets.
 With SCR, jobs run more efficiently, recompute less work upon a failure,
 and reduce load on shared resources like the parallel file system.
 It provides the most benefit to large-scale jobs that write large datasets. 
-(Check out our video_ on how SCR works for more information.)
+Check out our video_ on how SCR works for more information.
 
 .. _video: https://youtu.be/_r6svl_eAns
 
-SCR utilizes tiered storage in a cluster to provide applications
-with the following capabilities:
+SCR provides the following capabilities:
 
 * guidance for the optimal checkpoint frequency,
 * scalable checkpoint bandwidth,
 * scalable restart bandwidth,
 * scalable output bandwidth,
-* asynchronous data transfers to the parallel file system.
+* asynchronous data transfers to the parallel file system,
+* automated tracking and restart from most recent checkpoint,
+* automated job relaunch within an allocation after hangs or failures.
 
 SCR originated as a production-level implementation of a multi-level checkpoint system
 of the type analyzed by [Vaidya]_

--- a/doc/rst/users/assumptions.rst
+++ b/doc/rst/users/assumptions.rst
@@ -30,11 +30,10 @@ The goal is to expand the implementation to support a large number of applicatio
   current dataset to a file containing data from a previous dataset.
   Each dataset must be self-contained.
 * On some systems, datasets are cached in RAM disk.
-  This restricts usage of SCR on those machines to applications whose memory
-  footprint leaves sufficient room to store the dataset files in memory
-  simultaneously with the running application.
+  One must ensure there is sufficient memory capacity to store the dataset files
+  after accounting for the memory consumed by the application.
   The amount of storage needed depends on the number of cached datasets
-  and the redundancy scheme used.
+  and the redundancy scheme that is applied.
   See Section :ref:`sec-redundancy` for details.
 * SCR occasionally flushes files from cache to the parallel file system.
   All files must reside under a top-level directory on the parallel file system
@@ -44,5 +43,4 @@ The goal is to expand the implementation to support a large number of applicatio
   See Section :ref:`sec-checkpoint_directories` for details.
 * Time limits should be imposed so that the SCR library has sufficient time
   to flush files from cache to the parallel file system before the resource allocation expires.
-  Additionally, care should be taken so that the run does not stop in the middle of a checkpoint.
   See Section :ref:`sec-halt` for details.

--- a/doc/rst/users/config.rst
+++ b/doc/rst/users/config.rst
@@ -248,13 +248,10 @@ The table in this section specifies the full set of SCR configuration parameters
        should keep in cache.  SCR will delete the oldest checkpoint from cache before
        saving another in order to keep the total count below this limit.
    * - :code:`SCR_CACHE_BYPASS`
-     - N/A
-     - When bypass is enabled, data files are directly read from and written to the
+     - 1
+     - Specify the bypass mode.  When bypass is enabled, data files are directly read from and written to the
        parallel file system, thus bypassing the cache.  Even in bypass mode, internal
-       SCR metadata corresponding to the dataset is still kept in cache.
-       Bypass mode is enabled by default, unless one has specified a checkpoint
-       descriptor or set one of :code:`SCR_GROUP`, :code:`SCR_COPY_TYPE`,
-       :code:`SCR_CACHE_BASE`, :code:`SCR_CACHE_SIZE`, or :code:`SCR_SET_SIZE`.
+       SCR metadata corresponding to the dataset is stored in cache.
    * - :code:`SCR_SET_SIZE`
      - 8
      - Specify the minimum number of processes to include in an XOR set.

--- a/doc/rst/users/overview.rst
+++ b/doc/rst/users/overview.rst
@@ -5,6 +5,7 @@ Concepts
 
 This section discusses concepts one should understand about the SCR library
 implementation including how it interacts with file systems.
+Terms defined here are used throughout the documentation.
 
 Jobs, allocations, and runs
 ---------------------------
@@ -14,9 +15,9 @@ It may be interrupted due to a failure,
 or it may be interrupted due to time limits imposed by the resource scheduler.
 We use the term *allocation* to refer to an assigned set of compute resources
 that are available to the user for a period of time.
-A resource manager typically assigns an identifier to each resource allocation,
+A resource manager typically assigns an identifier label to each resource allocation,
 which we refer to as the *allocation id*.
-SCR uses the allocation id in some directory and file names.
+SCR embeds the allocation id in some directory and file names.
 Within an allocation, a user may execute a simulation one or more times.
 We call each execution a *run*.
 For MPI applications, each run corresponds to a single invocation
@@ -91,7 +92,7 @@ The *control directory* is where SCR writes files to store internal state about 
 This directory is expected to be stored in node-local storage.
 SCR writes multiple, small files in the control directory,
 and it may access these files frequently.
-It is best to configure this directory to be stored in a node-local RAM disk.
+It is best to configure this directory to be in node-local RAM disk.
 
 To construct the full path of the control directory,
 SCR incorporates a control base directory name along with
@@ -249,7 +250,7 @@ After the run is killed,
 and if there are sufficient healthy nodes remaining,
 the same job can be restarted within the same allocation.
 In practice, such a restart typically amounts to issuing another
-":code:`mpirun`" in the job batch script.
+:code:`mpirun` in the job batch script.
 
 Of the set of nodes used by the previous run,
 the restarted run should use as many of the same nodes as it can
@@ -368,7 +369,8 @@ Set :code:`SCR_FLUSH` to 0 to disable periodic writes in SCR.
 If an application disables the periodic flush feature,
 the application is responsible for writing occasional checkpoint sets to the parallel file system.
 
-By default, SCR computes and stores a CRC32 checksum value for each checkpoint file during a flush.
-It then uses the checksum to verify the integrity of each file as it is read back into cache during a fetch.
-If data corruption is detected, SCR falls back to fetch an earlier checkpoint set.
-To disable this checksum feature, set the :code:`SCR_CRC_ON_FLUSH` parameter to 0.
+.. TODO: fetch/flush crc32 does not currently work with filo, consider how to add this back
+.. By default, SCR computes and stores a CRC32 checksum value for each checkpoint file during a flush.
+   It then uses the checksum to verify the integrity of each file as it is read back into cache during a fetch.
+   If data corruption is detected, SCR falls back to fetch an earlier checkpoint set.
+   To disable this checksum feature, set the :code:`SCR_CRC_ON_FLUSH` parameter to 0.

--- a/doc/rst/users/quick.rst
+++ b/doc/rst/users/quick.rst
@@ -126,7 +126,7 @@ Assuming all goes well, you should see output similar to the following
 
 If you did not see output similar to this, there is likely a problem
 with your environment set up or build of SCR. Please see the
-detailed sections of this user guide for more help or email us (See
+detailed sections of this user guide for more help or email us (see
 the Support and Contacts section of this user guide.)
 
 If you want to get into more depth, in the SCR source directory,
@@ -160,29 +160,35 @@ other programs in the examples directory.
       /* Ask SCR if we should take a checkpoint now */
       SCR_Need_checkpoint(&flag);
       if (flag)
-        checkpoint();
+        checkpoint(t);
     }
 
     /* Call SCR_Finalize before MPI_Finalize */
     SCR_Finalize();
+
     MPI_Finalize();
+
     return 0;
   }
 
-  void checkpoint() {
+  void checkpoint(int timestep) {
+    /* define a name for your checkpoint */
+    char name[256];
+    sprintf(name, "timestep.%d", timestep);
+
     /* Tell SCR that you are getting ready to start a checkpoint phase */
-    SCR_Start_checkpoint();
+    SCR_Start_output(name, SCR_FLAG_CHECKPOINT);
 
     int rank;
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 
-    char file[256];
     /* create your checkpoint file name */
-    sprintf(file, "rank_%d.ckpt", rank);
+    char file[256];
+    sprintf(file, "%s/rank_%d.ckpt", name, rank);
 
     /* Call SCR_Route_file to request a new file name (scr_file) that will cause
-       your application to write the file to a fast tier of storage, e.g.,
-       a burst buffer */
+     * your application to write the file to a fast tier of storage, e.g.,
+     * a burst buffer */
     char scr_file[SCR_MAX_FILENAME];
     SCR_Route_file(file, scr_file);
 
@@ -194,7 +200,8 @@ other programs in the examples directory.
     }
 
     /* Tell SCR that you are done with your checkpoint phase */
-    SCR_Complete_checkpoint(1);
+    SCR_Complete_output(1);
+
     return;
   }
 

--- a/examples/test_api.c
+++ b/examples/test_api.c
@@ -482,9 +482,13 @@ int main (int argc, char* argv[])
       );
     }
 
+    /* include checkpoint directory path in name */
+    char newname[SCR_MAX_FILENAME];
+    sprintf(newname, "%s/%s", dset, name);
+
     /* get our file name */
     char file[SCR_MAX_FILENAME];
-    scr_retval = SCR_Route_file(name, file);
+    scr_retval = SCR_Route_file(newname, file);
     if (scr_retval != SCR_SUCCESS) {
       printf("%d: failed calling SCR_Route_file: %d: @%s:%d\n",
              rank, scr_retval, __FILE__, __LINE__

--- a/src/scr.c
+++ b/src/scr.c
@@ -630,22 +630,9 @@ static int scr_get_params()
     scr_cntl_base = spath_strdup_reduce_str(SCR_CNTL_BASE);
   }
 
-  /* we set this flag if we find the user defining a checkpoint
-   * descriptor by:
-   *   CKPTDESC in a config file or
-   *   SCR_CACHE_BASE
-   *   SCR_CACHE_SIZE
-   *   SCR_COPY_TYPE
-   *   SCR_SET_SIZE
-   *   SCR_GROUP */
-  int found_ckptdesc = 0;
-
   /* override default base directory for checkpoint cache */
   if ((value = scr_param_get("SCR_CACHE_BASE")) != NULL) {
     scr_cache_base = spath_strdup_reduce_str(value);
-
-    /* assume user is defining a checkpoint descriptor */
-    found_ckptdesc = 1;
   } else {
     scr_cache_base = spath_strdup_reduce_str(SCR_CACHE_BASE);
   }
@@ -653,9 +640,6 @@ static int scr_get_params()
   /* set maximum number of checkpoints to keep in cache */
   if ((value = scr_param_get("SCR_CACHE_SIZE")) != NULL) {
     scr_cache_size = atoi(value);
-
-    /* assume user is defining a checkpoint descriptor */
-    found_ckptdesc = 1;
   }
 
   /* fill in a hash of group descriptors */
@@ -695,25 +679,16 @@ static int scr_get_params()
     } else {
       scr_copy_type = SCR_COPY_FILE;
     }
-
-    /* assume user is defining a checkpoint descriptor */
-    found_ckptdesc = 1;
   }
 
   /* specify the number of tasks in xor set */
   if ((value = scr_param_get("SCR_SET_SIZE")) != NULL) {
     scr_set_size = atoi(value);
-
-    /* assume user is defining a checkpoint descriptor */
-    found_ckptdesc = 1;
   }
 
   /* specify the group name to protect failures */
   if ((value = scr_param_get("SCR_GROUP")) != NULL) {
     scr_group = strdup(value);
-
-    /* assume user is defining a checkpoint descriptor */
-    found_ckptdesc = 1;
   } else {
     scr_group = strdup(SCR_GROUP);
   }
@@ -743,9 +718,6 @@ static int scr_get_params()
     tmp = scr_param_get_hash(SCR_CONFIG_KEY_CKPTDESC);
     if (tmp != NULL) {
       kvtree_set(scr_reddesc_hash, SCR_CONFIG_KEY_CKPTDESC, tmp);
-
-      /* assume user is defining a checkpoint descriptor */
-      found_ckptdesc = 1;
     } else {
       scr_abort(-1, "Failed to define checkpoints @ %s:%d",
               __FILE__, __LINE__
@@ -757,10 +729,6 @@ static int scr_get_params()
   if ((value = scr_param_get("SCR_CACHE_BYPASS")) != NULL) {
     /* if BYPASS is set explicitly, we use that */
     scr_cache_bypass = atoi(value);
-  } else if (found_ckptdesc) {
-    /* if the user has specified a checkpoint descriptor,
-     * we'll assume they actually want to use the cache */
-    scr_cache_bypass = 0;
   }
 
   /* if job has fewer than SCR_HALT_SECONDS remaining after completing a checkpoint,

--- a/src/scr_cache_index.h
+++ b/src/scr_cache_index.h
@@ -49,15 +49,6 @@ Cache index set/get/unset data functions
 =========================================
 */
 
-/* sets the flush/scavenge descriptor hash for the given dataset id */
-int scr_cache_index_set_flushdesc(scr_cache_index* cindex, int dset, kvtree* hash);
-
-/* copies the flush/scavenge descriptor hash for the given dataset id into hash */
-int scr_cache_index_get_flushdesc(const scr_cache_index* cindex, int dset, kvtree* hash);
-
-/* unset the flush/scavenge descriptor hash for the given dataset id */
-int scr_cache_index_unset_flushdesc(scr_cache_index* cindex, int dset);
-
 /* sets the dataset hash for the given dataset id */
 int scr_cache_index_set_dataset(scr_cache_index* cindex, int dset, kvtree* hash);
 
@@ -75,6 +66,12 @@ int scr_cache_index_get_dir(const scr_cache_index* cindex, int dset, char** path
 
 /* unset the directory for the given dataset id */
 int scr_cache_index_unset_dir(scr_cache_index* cindex, int dset);
+
+/* mark dataset as cache bypass (read/write direct to prefix dir) */
+int scr_cache_index_set_bypass(scr_cache_index* cindex, int dset, int bypass);
+
+/* get value of bypass flag for dataset */
+int scr_cache_index_get_bypass(const scr_cache_index* cindex, int dset, int* bypass);
 
 /*
 =========================================

--- a/src/scr_conf.h
+++ b/src/scr_conf.h
@@ -88,14 +88,19 @@
 #define SCR_COPY_TYPE (SCR_COPY_XOR)
 #endif
 
-/* default set size */
+/* default failure group */
+#ifndef SCR_GROUP
+#define SCR_GROUP (SCR_GROUP_NODE)
+#endif
+
+/* default failure group set size */
 #ifndef SCR_SET_SIZE
 #define SCR_SET_SIZE (8)
 #endif
 
-/* default hop distance */
-#ifndef SCR_GROUP
-#define SCR_GROUP (SCR_GROUP_NODE)
+/* default cache bypass setting */
+#ifndef SCR_CACHE_BYPASS
+#define SCR_CACHE_BYPASS (1)
 #endif
 
 /* =========================================================================

--- a/src/scr_fetch.c
+++ b/src/scr_fetch.c
@@ -346,6 +346,9 @@ static int scr_fetch_files(
   /* get the redundancy descriptor for this id */
   scr_reddesc* c = scr_reddesc_for_checkpoint(ckpt_id, scr_nreddescs, scr_reddescs);
 
+  /* record bypass property in cache index*/
+  scr_cache_index_set_bypass(cindex, id, c->bypass);
+
   /* store the name of the directory we're about to create */
   const char* dir = scr_cache_dir_get(c, id);
   scr_cache_index_set_dir(scr_cindex, id, dir);
@@ -360,9 +363,16 @@ static int scr_fetch_files(
   /* get the cache directory */
   char* cache_dir = scr_cache_dir_get(c, id);
 
+  /* we fetch into the cache directory, but we use NULL to indicate
+   * that we're in bypass mode and shouldn't actually transfer files */
+  char* target_dir = cache_dir;
+  if (c->bypass) {
+    target_dir = NULL;
+  }
+
   /* now we can finally fetch the actual files */
   int success = 1;
-  if (scr_fetch_data(summary_hash, fetch_dir, cache_dir, cindex, id) != SCR_SUCCESS) {
+  if (scr_fetch_data(summary_hash, fetch_dir, target_dir, cindex, id) != SCR_SUCCESS) {
     success = 0;
   }
 

--- a/src/scr_flush.h
+++ b/src/scr_flush.h
@@ -26,6 +26,11 @@ int scr_flush_filolist_free(int num_files, char*** ptr_src_filelist, char*** ptr
  * metadata directory for that dataset, must be freed by caller */
 char* scr_flush_dataset_metadir(const scr_dataset* dataset);
 
+/* create entry in scr index file to indicate that a new dataset
+ * has been started to be copied to the prefix directory, but mark
+ * it as incomplete */
+int scr_flush_init_index(scr_dataset* dataset);
+
 /* given a filemap and a dataset id, prepare and return a list of files to be flushed */
 int scr_flush_prepare(const scr_filemap* map, int id, kvtree* file_list);
 

--- a/src/scr_flush_async.c
+++ b/src/scr_flush_async.c
@@ -134,6 +134,9 @@ int scr_flush_async_start(scr_cache_index* cindex, int id)
   /* get the dataset of this flush */
   scr_dataset* dataset = kvtree_get(scr_flush_async_file_list, SCR_KEY_DATASET);
 
+  /* create enty in index file to indicate that dataset may exist, but is not yet complete */
+  scr_flush_init_index(dataset);
+
   /* define path to metadata directory for this dataset */
   char* dataset_path_str = scr_flush_dataset_metadir(dataset);
   spath* dataset_path = spath_from_str(dataset_path_str);

--- a/src/scr_flush_file_mpi.c
+++ b/src/scr_flush_file_mpi.c
@@ -34,8 +34,8 @@ int scr_flush_file_need_flush(int id)
     /* if we have the dataset in cache, but not on the parallel file system,
      * then it needs to be flushed */
     kvtree* dset_hash = kvtree_get_kv_int(hash, SCR_FLUSH_KEY_DATASET, id);
-    kvtree* in_cache = kvtree_get_kv(dset_hash, SCR_FLUSH_KEY_LOCATION, SCR_FLUSH_KEY_LOCATION_CACHE);
-    kvtree* in_pfs   = kvtree_get_kv(dset_hash, SCR_FLUSH_KEY_LOCATION, SCR_FLUSH_KEY_LOCATION_PFS);
+    kvtree* in_cache  = kvtree_get_kv(dset_hash, SCR_FLUSH_KEY_LOCATION, SCR_FLUSH_KEY_LOCATION_CACHE);
+    kvtree* in_pfs    = kvtree_get_kv(dset_hash, SCR_FLUSH_KEY_LOCATION, SCR_FLUSH_KEY_LOCATION_PFS);
     if (in_cache != NULL && in_pfs == NULL) {
       need_flush = 1;
     }

--- a/src/scr_globals.c
+++ b/src/scr_globals.c
@@ -96,6 +96,7 @@ int scr_cache_size    = SCR_CACHE_SIZE; /* set number of checkpoints to keep at 
 int scr_copy_type     = SCR_COPY_TYPE;  /* select which redundancy algorithm to use */
 char* scr_group       = NULL;           /* name of process group likely to fail */
 int scr_set_size      = SCR_SET_SIZE;   /* specify number of tasks in xor set */
+int scr_cache_bypass  = 1;              /* default bypass, whether to directly read/write parallel file system */
 
 size_t scr_mpi_buf_size  = SCR_MPI_BUF_SIZE;  /* set MPI buffer size to chunk file transfer */
 size_t scr_file_buf_size = SCR_FILE_BUF_SIZE; /* set buffer size to chunk file copies to/from parallel file system */

--- a/src/scr_globals.c
+++ b/src/scr_globals.c
@@ -92,11 +92,11 @@ int scr_debug         = SCR_DEBUG;      /* set debug verbosity */
 int scr_log_enable    = SCR_LOG_ENABLE; /* whether to log SCR events */
 int scr_page_size     = 0;              /* records block size for aligning MPI and file buffers */
 
-int scr_cache_size    = SCR_CACHE_SIZE; /* set number of checkpoints to keep at one time */
-int scr_copy_type     = SCR_COPY_TYPE;  /* select which redundancy algorithm to use */
-char* scr_group       = NULL;           /* name of process group likely to fail */
-int scr_set_size      = SCR_SET_SIZE;   /* specify number of tasks in xor set */
-int scr_cache_bypass  = 1;              /* default bypass, whether to directly read/write parallel file system */
+int scr_cache_size    = SCR_CACHE_SIZE;   /* set number of checkpoints to keep at one time */
+int scr_copy_type     = SCR_COPY_TYPE;    /* select which redundancy algorithm to use */
+char* scr_group       = NULL;             /* name of process group likely to fail */
+int scr_set_size      = SCR_SET_SIZE;     /* specify number of tasks in xor set */
+int scr_cache_bypass  = SCR_CACHE_BYPASS; /* default bypass, whether to directly read/write parallel file system */
 
 size_t scr_mpi_buf_size  = SCR_MPI_BUF_SIZE;  /* set MPI buffer size to chunk file transfer */
 size_t scr_file_buf_size = SCR_FILE_BUF_SIZE; /* set buffer size to chunk file copies to/from parallel file system */

--- a/src/scr_globals.h
+++ b/src/scr_globals.h
@@ -152,6 +152,7 @@ extern int scr_cache_size;    /* number of checkpoints to keep in cache at one t
 extern int scr_copy_type;     /* select which redundancy algorithm to use */
 extern char* scr_group;       /* name of process group likely to fail */
 extern int scr_set_size;      /* specify number of tasks in xor set */
+extern int scr_cache_bypass;  /* default bypass, whether to directly read/write parallel file system */
 
 extern size_t scr_mpi_buf_size;  /* set MPI buffer size to chunk file transfer */
 extern size_t scr_file_buf_size; /* set buffer size to chunk file copies to/from parallel file system */

--- a/src/scr_index.c
+++ b/src/scr_index.c
@@ -780,41 +780,43 @@ int scr_rebuild_scan(const spath* prefix, const spath* dir, kvtree* scan)
     /* check whether there are any missing files in this dataset */
     kvtree* missing_hash = kvtree_get(dset_hash, SCR_SCAN_KEY_MISSING);
     if (missing_hash != NULL) {
-      /* nede to rebuild some files,
-       * determine the encoding type and call cooresponging rebuild functions */
-      kvtree* partner_hash = kvtree_get(dset_hash, SCR_SCAN_KEY_PARTNER);
-      kvtree* xor_hash = kvtree_get(dset_hash, SCR_SCAN_KEY_XOR);
-      if (partner_hash != NULL) {
-        /* rebuild filemap files */
+      /* need to rebuild some files, determine the encoding type
+       * and call corresponding function to define rebuild command */
+
+      /* rebuild filemap files with PARTNER */
+      kvtree* mappartner_hash = kvtree_get(dset_hash, SCR_SCAN_KEY_MAPPARTNER);
+      if (mappartner_hash != NULL) {
         int tmp_rc = scr_rebuild_partner(prefix, dir, dset_id, dset_hash, missing_hash, SCR_SCAN_KEY_MAPPARTNER, "map");
         if (tmp_rc != SCR_SUCCESS) {
           rc = SCR_FAILURE;
-          continue;
         }
+      }
 
-        /* rebuild data files */
-        tmp_rc = scr_rebuild_partner(prefix, dir, dset_id, dset_hash, missing_hash, SCR_SCAN_KEY_PARTNER, "xor");
-        if (tmp_rc != SCR_SUCCESS) {
-          rc = SCR_FAILURE;
-          continue;
-        }
-      } else if (xor_hash != NULL) {
-        /* rebuild filemap files */
+      /* rebuild filemap files with XOR */
+      kvtree* mapxor_hash = kvtree_get(dset_hash, SCR_SCAN_KEY_MAPXOR);
+      if (mapxor_hash != NULL) {
         int tmp_rc = scr_rebuild_xor(prefix, dir, dset_id, dset_hash, missing_hash, SCR_SCAN_KEY_MAPXOR, "map");
         if (tmp_rc != SCR_SUCCESS) {
           rc = SCR_FAILURE;
-          continue;
         }
+      }
 
-        /* rebuild data files */
-        tmp_rc = scr_rebuild_xor(prefix, dir, dset_id, dset_hash, missing_hash, SCR_SCAN_KEY_XOR, "xor");
+      /* rebuild data files with PARTNER */
+      kvtree* partner_hash = kvtree_get(dset_hash, SCR_SCAN_KEY_PARTNER);
+      if (partner_hash != NULL) {
+        int tmp_rc = scr_rebuild_partner(prefix, dir, dset_id, dset_hash, missing_hash, SCR_SCAN_KEY_PARTNER, "partner");
         if (tmp_rc != SCR_SUCCESS) {
           rc = SCR_FAILURE;
-          continue;
         }
-      } else {
-        /* need a rebuild, but failed to find any valid rebuild method */
-        rc = SCR_FAILURE;
+      }
+
+      /* rebuild data files with XOR */
+      kvtree* xor_hash = kvtree_get(dset_hash, SCR_SCAN_KEY_XOR);
+      if (xor_hash != NULL) {
+        int tmp_rc = scr_rebuild_xor(prefix, dir, dset_id, dset_hash, missing_hash, SCR_SCAN_KEY_XOR, "xor");
+        if (tmp_rc != SCR_SUCCESS) {
+          rc = SCR_FAILURE;
+        }
       }
     }
   }
@@ -2053,10 +2055,10 @@ int index_add(const spath* prefix, int id, int* complete_flag)
 {
   int rc = SCR_SUCCESS;
 
-  /* assume dataset if not complete */
+  /* assume dataset is not complete */
   *complete_flag = 0;
 
-  /* get string versions of prefix and subdir */
+  /* get string versions of prefix */
   char* prefix_str = spath_strdup(prefix);
 
   /* create a new hash to store our index file data */

--- a/src/scr_keys.h
+++ b/src/scr_keys.h
@@ -159,6 +159,7 @@ Define common hash key strings
 #define SCR_CONFIG_KEY_INDEX      ("INDEX")
 #define SCR_CONFIG_KEY_INTERVAL   ("INTERVAL")
 #define SCR_CONFIG_KEY_OUTPUT     ("OUTPUT")
+#define SCR_CONFIG_KEY_BYPASS     ("BYPASS")
 #define SCR_CONFIG_KEY_DIRECTORY  ("DIRECTORY")
 #define SCR_CONFIG_KEY_TYPE       ("TYPE")
 #define SCR_CONFIG_KEY_FAIL_GROUP ("FAIL_GROUP")

--- a/src/scr_param.c
+++ b/src/scr_param.c
@@ -67,7 +67,10 @@ static char* expand_env(const char* value)
   ssize_t rlen = len;
   char* retval = malloc(rlen);
   assert(retval); /* TODO: should I check for running out of memory? */
-  for(int i = 0, j = 0 ; i < len ; /*nop*/) {
+
+  int i;
+  int j;
+  for(i = 0, j = 0 ; i < len ; /*nop*/) {
     if(value[i] == '$') {
       /* try and extract an environment variable name the '$' */
       int envbegin = -1, envend = -1;
@@ -115,7 +118,8 @@ static char* expand_env(const char* value)
         assert(retval); /* TODO: should I check for running out of memory? */
 
         /* finally copy value into retval */
-        for(int envi = 0 ; envi < envlen ; /*nop*/) {
+        int envi;
+        for(envi = 0 ; envi < envlen ; /*nop*/) {
           assert(j < rlen);
           assert(envi < envlen);
           retval[j++] = env[envi++];

--- a/src/scr_reddesc.h
+++ b/src/scr_reddesc.h
@@ -49,6 +49,7 @@ typedef struct {
   int      interval;       /* how often to apply this descriptor, pick largest such
                             * that interval evenly divides checkpoint id */
   int      output;         /* flag indicating whether this descriptor should be used for output */
+  int      bypass;         /* flag indicating whether data should bypass cache */
   int      store_index;    /* index into scr_storedesc for storage descriptor */
   int      group_index;    /* index into scr_groupdesc for failure group */
   char*    base;           /* base cache directory to use */


### PR DESCRIPTION
This is to enable cache-bypass so that an application can write checkpoint/output datasets directly to the parallel file system and read them directly from the file system on a restart.

Resolves https://github.com/LLNL/scr/issues/54

On output:
- route_file returns a PFS path, so the app writes directly to the file system 
- no redundancy scheme is applied to data files in complete_output, though redundancy is applied to metadata and stored in cache
- summary and rank2node metadata files are still created for the dataset in the prefix directory as though it had been flushed through normal mechanisms, which enables the checkpoint to be fetched into cache on a later run if so desired

On restart:
- considers both bypassed and non-bypassed checkpoints
- datasets on PFS are not rebuilt, though associated metadata and filemaps are
- if restarting from a bypass, route_file returns a PFS path for each file, so the app reads files from the file system 

On scavenge:
- no data files are copied from compute nodes, though filemaps are copied and rebuilt if needed, index file is updated appropriately

The internal cindex structure is updated to mark and query whether a dataset is stored in cache or if it has bypassed the cache for the parallel file system.

Various metadata and redundancy encodings of filemaps are still kept in cache, even for datasets that are bypassed.  This design simplifies flush, rebuild, and scavenge logic, though it means some cache space is still required.

The bypass mode is now the default, unless the user specifies a checkpoint descriptor.  Using bypass as default enables one to use SCR out-of-the-box even on machines that have no cache.

A checkpoint descriptor is defined if the user has either defined CKPT lines in a config file or has defined any of a number of parameters including SCR_CACHE_BASE, SCR_CACHE_SIZE, SCR_COPY_TYPE which are taken to imply the user is trying to use the cache.  In this case, bypass is disabled.

If one has defined checkpoint descriptors and still wants to use bypass, they can selectively add "BYPASS=1" to the specific checkpoint descriptor line in a config file meaning bypass should be applied to any dataset which would select that descriptor.  Or one can set "SCR_CACHE_BYPASS=1" to apply to all checkpoint descriptors (quick way to turn on bypass without making lots of changes to an existing config file).

Even in bypass mode, SCR continues to manage cache directories for bypassed datasets on the compute nodes.  It stores metadata in cache in this case, rather than user data files, so space requirements are minimal.  The default cache directory should be the same as the default control directory, and both should be ramdisk for performance reasons.  SCR selects a checkpoint descriptor for the bypassed dataset in the normal way, and that descriptor determines how to encode metadata that is in cache.