### PR TITLE
Restartloop

### DIFF
--- a/doc/rst/users/api.rst
+++ b/doc/rst/users/api.rst
@@ -371,7 +371,13 @@ all of its files successfully or it read no files during the checkpoint.
 Otherwise, the process should call :code:`SCR_Complete_restart` with :code:`valid` set to :code:`0`.
 SCR will determine whether all processes read their checkpoint files 
 successfully based on the values supplied in the :code:`valid` parameter.
-If any process failed to read its checkpoint files, then SCR will abort.
+:code:`SCR_Complete_restart` only returns :code:`SCR_SUCCESS` if
+all processes called with :code:`valid` set to :code:`1`,
+meaning that all processes succeeded in their restart.
+If the restart failed on any process, SCR loads the next most recent checkpoint,
+and the application can call :code:`SCR_Have_restart` to determine whether a new checkpoint is available.
+An application can loop until it either successfully restarts from a checkpoint
+or it exhausts all known checkpoints.
 
 Each call to :code:`SCR_Complete_restart` must be preceded by a corresponding call
 to :code:`SCR_Start_restart`.

--- a/src/scr_flush.c
+++ b/src/scr_flush.c
@@ -397,6 +397,13 @@ int scr_flush_complete(int id, kvtree* file_list)
       /* update complete flag in index file */
       scr_index_set_dataset(index_hash, id, name, dataset, complete);
 
+      /* record flushed tag */
+      scr_index_mark_flushed(index_hash, id, name);
+
+      /* remove any failed marker, since we may have flushed over
+       * a previously failed dataset */
+      scr_index_clear_failed(index_hash, id, name);
+
       /* if this is a checkpoint, update current to point to new dataset,
        * this must come after index_set_dataset above because set_current
        * checks that named dataset is a checkpoint */

--- a/src/scr_index_api.c
+++ b/src/scr_index_api.c
@@ -292,6 +292,20 @@ int scr_index_mark_failed(kvtree* index, int id, const char* name)
   return SCR_SUCCESS;
 }
 
+/* clear any failed fetch event for given dataset id and name in given hash */
+int scr_index_clear_failed(kvtree* index, int id, const char* name)
+{
+  /* mark the dataset as failed at current timestamp */
+  kvtree* dset_hash = kvtree_set_kv_int(index, SCR_INDEX_1_KEY_DATASET, id);
+  kvtree* dir_hash  = kvtree_set_kv(dset_hash, SCR_INDEX_1_KEY_NAME, name);
+  kvtree_unset(dir_hash, SCR_INDEX_1_KEY_FAILED);
+
+  /* add entry to directory index (maps name to dataset id) */
+  scr_index_set_directory(index, name, id);
+
+  return SCR_SUCCESS;
+}
+
 /* record flush event for given dataset id and name in given hash */
 int scr_index_mark_flushed(kvtree* index, int id, const char* name)
 {

--- a/src/scr_index_api.h
+++ b/src/scr_index_api.h
@@ -52,6 +52,9 @@ int scr_index_mark_fetched(kvtree* index, int id, const char* name);
 /* record failed fetch event for given dataset id and name in given hash */
 int scr_index_mark_failed(kvtree* index, int id, const char* name);
 
+/* clear failed fetch events for given dataset id and name in given hash */
+int scr_index_clear_failed(kvtree* index, int id, const char* name);
+
 /* record flush time for given dataset id and name in given hash */
 int scr_index_mark_flushed(kvtree* index, int id, const char* name);
 


### PR DESCRIPTION
If some process marks a restart as invalid, it would be nice to load up the next most recent checkpoint and loop until we find one that works.  The idea is support something like:
```
int have_restart = 0;
int restarted = 0;
do {
  scr_have_restart(&have_restart)
  if (have_restart) {
    scr_start_restart()
    scr_route_file()
    rc = scr_complete_restart(valid)
    restarted = (rc == SCR_SUCCESS)
  }
} while (have_restart && !restarted);
```
This PR is currently noisy because it's based on https://github.com/LLNL/scr/pull/166