### PR TITLE
enforce one-to-one mapping of id-to-name

### DIFF
--- a/src/scr.c
+++ b/src/scr.c
@@ -2323,6 +2323,11 @@ int SCR_Route_file(const char* file, char* newfile)
     /* delete the meta data object */
     scr_meta_delete(&meta);
   } else {
+    /* if user specified path to file within prefix, return */
+    if (scr_file_is_readable(newfile) == SCR_SUCCESS) {
+      return SCR_SUCCESS;
+    }
+
     /* TODO: To support backwards compatibility, the user is allowed
      * to pass just the file name with no path component during restart.
      * This means that they cannot have two files in the same checkpoint

--- a/src/scr_cache_rebuild.c
+++ b/src/scr_cache_rebuild.c
@@ -227,9 +227,6 @@ int scr_cache_rebuild(scr_cache_index* cindex)
         scr_dataset* dataset = scr_dataset_new();
         scr_cache_index_get_dataset(cindex, current_id, dataset);
 
-        /* determine whether this is an output dataset */
-        int is_output = scr_dataset_is_output(dataset);
-
         /* get and recreate directory from cindex */
         char* path;
         if (scr_distribute_dir(cindex, current_id, &path) == SCR_SUCCESS) {
@@ -285,6 +282,7 @@ int scr_cache_rebuild(scr_cache_index* cindex)
         }
 
         /* remember if we fail to rebuild an output set */
+        int is_output = scr_dataset_is_output(dataset);
         if (!rebuild_succeeded && is_output) {
           output_failed_rebuild = 1;
         }

--- a/src/scr_conf.h
+++ b/src/scr_conf.h
@@ -137,6 +137,11 @@
 #define SCR_FETCH_WIDTH (256)
 #endif
 
+/* whether to use implied bypass on fetch to read files from file system rather than actually copy to cache */
+#ifndef SCR_FETCH_BYPASS
+#define SCR_FETCH_BYPASS (0)
+#endif
+
 /* set to 0 to disable flush, set to a positive number to set how many checkpoints between flushes */
 #ifndef SCR_FLUSH
 #define SCR_FLUSH (10)

--- a/src/scr_fetch.h
+++ b/src/scr_fetch.h
@@ -15,7 +15,8 @@
 /* attempt to fetch most recent checkpoint from prefix directory into cache */
 int scr_fetch_latest(scr_filemap* map, int* fetch_attempted);
 
-/* fetch files from given dataset from parallel file system */
-int scr_fetch_dset(scr_cache_index* cindex, int dset_id, const char* dset_name, int* dataset_id, int* checkpoint_id);
+/* fetch files from given dataset id and name from parallel file system,
+ * return its checkpoint id */
+int scr_fetch_dset(scr_cache_index* cindex, int dset_id, const char* dset_name, int* checkpoint_id);
 
 #endif

--- a/src/scr_fetch.h
+++ b/src/scr_fetch.h
@@ -13,6 +13,9 @@
 #define SCR_FETCH_H
 
 /* attempt to fetch most recent checkpoint from prefix directory into cache */
-int scr_fetch_sync(scr_filemap* map, int* fetch_attempted);
+int scr_fetch_latest(scr_filemap* map, int* fetch_attempted);
+
+/* fetch files from given dataset from parallel file system */
+int scr_fetch_dset(scr_cache_index* cindex, int dset_id, const char* dset_name, int* dataset_id, int* checkpoint_id);
 
 #endif

--- a/src/scr_flush.c
+++ b/src/scr_flush.c
@@ -345,6 +345,9 @@ int scr_flush_init_index(scr_dataset* dataset)
       );
     }
 
+    /* clear any existing entry for this dataset */
+    scr_index_remove(index_hash, name);
+
     /* update complete flag in index file */
     int complete = 0;
     scr_index_set_dataset(index_hash, id, name, dataset, complete);
@@ -393,6 +396,9 @@ int scr_flush_complete(int id, kvtree* file_list)
           __FILE__, __LINE__
         );
       }
+
+      /* clear any existing entry for this dataset */
+      scr_index_remove(index_hash, name);
 
       /* update complete flag in index file */
       scr_index_set_dataset(index_hash, id, name, dataset, complete);

--- a/src/scr_globals.c
+++ b/src/scr_globals.c
@@ -107,6 +107,7 @@ int scr_halt_enabled     = SCR_HALT_ENABLED; /* whether SCR will exit job if hal
 int scr_distribute       = SCR_DISTRIBUTE;       /* whether to call scr_distribute_files during SCR_Init */
 int scr_fetch            = SCR_FETCH;            /* whether to call scr_fetch_files during SCR_Init */
 int scr_fetch_width      = SCR_FETCH_WIDTH;      /* specify number of processes to read files simultaneously */
+int scr_fetch_bypass     = SCR_FETCH_BYPASS;     /* whether to use implied bypass mode on fetch */
 int scr_flush            = SCR_FLUSH;            /* how many checkpoints between flushes */
 int scr_flush_width      = SCR_FLUSH_WIDTH;      /* specify number of processes to write files simultaneously */
 int scr_flush_on_restart = SCR_FLUSH_ON_RESTART; /* specify whether to flush cache on restart */

--- a/src/scr_globals.h
+++ b/src/scr_globals.h
@@ -163,6 +163,7 @@ extern int scr_halt_enabled; /* whether SCR will exit job if halt condition is d
 extern int scr_distribute;       /* whether to call scr_distribute_files during SCR_Init */
 extern int scr_fetch;            /* whether to call scr_fetch_files during SCR_Init */
 extern int scr_fetch_width;      /* specify number of processes to read files simultaneously */
+extern int scr_fetch_bypass;     /* whether to use implied bypass on fetch operations */
 extern int scr_flush;            /* how many checkpoints between flushes */
 extern int scr_flush_width;      /* specify number of processes to write files simultaneously */
 extern int scr_flush_on_restart; /* specify whether to flush cache on restart */

--- a/src/scr_index.c
+++ b/src/scr_index.c
@@ -1835,7 +1835,8 @@ int index_list(const spath* prefix)
   kvtree_sort_int(dset_hash, KVTREE_SORT_DESCENDING);
 
   /* print header */
-  printf("   DSET VALID FLUSHED             NAME\n");
+  //printf("   DSET VALID FLUSHED             NAME\n");
+  printf("  DSET VALID FLUSHED              NAME\n");
 
   /* iterate over each of the datasets and print the id and other info */
   kvtree_elem* elem;
@@ -1847,107 +1848,103 @@ int index_list(const spath* prefix)
     int dset = kvtree_elem_key_int(elem);
 
     /* get the hash for this dataset */
-    kvtree* hash = kvtree_elem_hash(elem);
-    kvtree* name_hash = kvtree_get(hash, SCR_INDEX_1_KEY_NAME);
+    kvtree* info_hash = kvtree_elem_hash(elem);
 
-    /* sort dataset names in descending order */
-    kvtree_sort(name_hash, KVTREE_SORT_DESCENDING);
-
-    kvtree_elem* name_elem;
-    for (name_elem = kvtree_elem_first(name_hash);
-         name_elem != NULL;
-         name_elem = kvtree_elem_next(name_elem))
-    {
-      /* get the dataset name for this dataset */
-      char* name = kvtree_elem_key(name_elem);
-
-      /* get the directory hash */
-      kvtree* info_hash = kvtree_elem_hash(name_elem);
-
-      /* skip this dataset if it's not a checkpoint */
-      kvtree* dataset_hash = kvtree_get(info_hash, SCR_INDEX_1_KEY_DATASET);
-      if (! scr_dataset_is_ckpt(dataset_hash)) {
-        continue;
-      }
-
-      /* determine whether this dataset is complete */
-      int complete = 0;
-      kvtree_util_get_int(info_hash, SCR_INDEX_1_KEY_COMPLETE, &complete);
-
-      /* determine time at which this checkpoint was marked as failed */
-      char* failed_str = NULL;
-      kvtree_util_get_str(info_hash, SCR_INDEX_1_KEY_FAILED, &failed_str);
-
-      /* determine time at which this checkpoint was flushed */
-      char* flushed_str = NULL;
-      kvtree_util_get_str(info_hash, SCR_INDEX_1_KEY_FLUSHED, &flushed_str);
-
-      /* compute number of times (and last time) checkpoint has been fetched */
-/*
-      kvtree* fetched_hash = kvtree_get(info_hash, SCR_INDEX_1_KEY_FETCHED);
-      int num_fetch = kvtree_size(fetched_hash);
-      kvtree_sort(fetched_hash, KVTREE_SORT_DESCENDING);
-      kvtree_elem* fetched_elem = kvtree_elem_first(fetched_hash);
-      char* fetched_str = kvtree_elem_key(fetched_elem);
-*/
-
-      /* print a star beside the dataset directory marked as current */
-      if (current != NULL && strcmp(name, current) == 0) {
-        printf("*");
-      } else {
-        printf(" ");
-      }
-
-      printf("%6d", dset);
-
-      printf(" ");
-
-      /* to be valid, the dataset must be marked as vaild and it must
-       * not have failed a fetch attempt */
-      if (complete == 1 && failed_str == NULL) {
-        printf("YES  ");
-      } else {
-        printf("NO   ");
-      }
-
-      printf(" ");
-
-/*
-      if (failed_str != NULL) {
-        printf("YES   ");
-      } else {
-        printf("NO    ");
-      }
-
-      printf(" ");
-*/
-
-      if (flushed_str != NULL) {
-        printf("%s", flushed_str);
-      } else {
-        printf("                   ");
-      }
-
-      printf(" ");
-
-/*
-      printf("%7d", num_fetch);
-
-      printf("  ");
-      if (fetched_str != NULL) {
-        printf("%s", fetched_str);
-      } else {
-        printf("                   ");
-      }
-*/
-
-      if (name != NULL) {
-        printf("%s", name);
-      } else {
-        printf("UNKNOWN_NAME");
-      }
-      printf("\n");
+    /* skip this dataset if it's not a checkpoint */
+    kvtree* dataset_hash = kvtree_get(info_hash, SCR_INDEX_1_KEY_DATASET);
+    if (! scr_dataset_is_ckpt(dataset_hash)) {
+      continue;
     }
+
+    /* get the dataset name for this dataset */
+    char* name;
+    scr_dataset_get_name(dataset_hash, &name);
+
+    /* determine whether this dataset is complete */
+    int complete = 0;
+    kvtree_util_get_int(info_hash, SCR_INDEX_1_KEY_COMPLETE, &complete);
+
+    /* determine time at which this checkpoint was marked as failed */
+    char* failed_str = NULL;
+    kvtree_util_get_str(info_hash, SCR_INDEX_1_KEY_FAILED, &failed_str);
+
+    /* determine time at which this checkpoint was flushed */
+    char* flushed_str = NULL;
+    kvtree_util_get_str(info_hash, SCR_INDEX_1_KEY_FLUSHED, &flushed_str);
+
+    /* compute number of times (and last time) checkpoint has been fetched */
+/*
+    kvtree* fetched_hash = kvtree_get(info_hash, SCR_INDEX_1_KEY_FETCHED);
+    int num_fetch = kvtree_size(fetched_hash);
+    kvtree_sort(fetched_hash, KVTREE_SORT_DESCENDING);
+    kvtree_elem* fetched_elem = kvtree_elem_first(fetched_hash);
+    char* fetched_str = kvtree_elem_key(fetched_elem);
+*/
+
+    /* print a star beside the dataset directory marked as current */
+/*
+    if (current != NULL && strcmp(name, current) == 0) {
+      printf("*");
+    } else {
+      printf(" ");
+    }
+*/
+
+    printf("%6d", dset);
+
+    printf(" ");
+
+    /* to be valid, the dataset must be marked as vaild and it must
+     * not have failed a fetch attempt */
+    if (complete == 1 && failed_str == NULL) {
+      printf("YES  ");
+    } else {
+      printf("NO   ");
+    }
+
+    printf(" ");
+
+/*
+    if (failed_str != NULL) {
+      printf("YES   ");
+    } else {
+      printf("NO    ");
+    }
+
+    printf(" ");
+*/
+
+    if (flushed_str != NULL) {
+      printf("%s", flushed_str);
+    } else {
+      printf("                   ");
+    }
+
+    printf(" ");
+
+/*
+    printf("%7d", num_fetch);
+
+    printf("  ");
+    if (fetched_str != NULL) {
+      printf("%s", fetched_str);
+    } else {
+      printf("                   ");
+    }
+*/
+
+    if (current != NULL && strcmp(name, current) == 0) {
+      printf("*");
+    } else {
+      printf(" ");
+    }
+
+    if (name != NULL) {
+      printf("%s", name);
+    } else {
+      printf("UNKNOWN_NAME");
+    }
+    printf("\n");
   }
 
   /* free off our index hash */

--- a/src/scr_index.c
+++ b/src/scr_index.c
@@ -2090,6 +2090,7 @@ int index_add(const spath* prefix, int id, int* complete_flag)
       int complete;
       if (kvtree_util_get_int(summary, SCR_SUMMARY_6_KEY_COMPLETE, &complete) == KVTREE_SUCCESS) {
         /* write values to the index file */
+        scr_index_remove(index, dataset_name);
         scr_index_set_dataset(index, id, dataset_name, dataset, complete);
         scr_index_mark_flushed(index, id, dataset_name);
         scr_index_write(prefix, index);

--- a/src/scr_index_api.c
+++ b/src/scr_index_api.c
@@ -294,16 +294,12 @@ int scr_index_remove(kvtree* index, const char* name)
       }
     }
 
-    /* write out the new index file */
     return SCR_SUCCESS;
   } else {
     /* drop index from current if it matches */
     kvtree_unset_kv(index, SCR_INDEX_1_KEY_CURRENT, name);
 
-    /* couldn't find the named dataset, print an error */
-    scr_err("Named dataset was not found in index file: %s @ %s:%d",
-      name, __FILE__, __LINE__
-    );
+    /* couldn't find the named dataset, return an error */
     return SCR_FAILURE;
   }
 }

--- a/src/scr_index_api.h
+++ b/src/scr_index_api.h
@@ -25,6 +25,10 @@ int scr_index_read(const spath* dir, kvtree* index);
 /* overwrite the contents of the index file in given directory with given hash */
 int scr_index_write(const spath* dir, kvtree* index);
 
+/* read index file and return max dataset and checkpoint ids,
+ * returns SCR_SUCCESS if file read successfully */
+int scr_index_get_max_ids(const spath* dir, int* dset_id, int* ckpt_id, int* ckpt_dset_id);
+
 /* remove given dataset name from hash */
 int scr_index_remove(kvtree* index, const char* name);
 

--- a/src/scr_index_api.h
+++ b/src/scr_index_api.h
@@ -25,9 +25,6 @@ int scr_index_read(const spath* dir, kvtree* index);
 /* overwrite the contents of the index file in given directory with given hash */
 int scr_index_write(const spath* dir, kvtree* index);
 
-/* add given dataset id and dataset name to given hash */
-int scr_index_add_name(kvtree* index, int id, const char* name);
-
 /* remove given dataset name from hash */
 int scr_index_remove(kvtree* index, const char* name);
 

--- a/src/scr_io.c
+++ b/src/scr_io.c
@@ -750,10 +750,14 @@ int scr_file_is_writeable(const char* file)
 int scr_file_unlink(const char* file)
 {
   if (unlink(file) != 0) {
-    scr_dbg(2, "Failed to delete file: %s errno=%d %s @ %s:%d",
-      file, errno, strerror(errno), __FILE__, __LINE__
-    );
-    return SCR_FAILURE;
+    /* hit an error deleting, but don't care if we failed
+     * because there is no file at that path */
+    if (errno != ENOENT) {
+      scr_dbg(2, "Failed to delete file: %s errno=%d %s @ %s:%d",
+        file, errno, strerror(errno), __FILE__, __LINE__
+      );
+      return SCR_FAILURE;
+    }
   }
   return SCR_SUCCESS;
 }

--- a/src/scr_keys.h
+++ b/src/scr_keys.h
@@ -94,6 +94,7 @@ Define common hash key strings
 #define SCR_INDEX_KEY_VERSION ("VERSION")
 
 #define SCR_INDEX_FILE_VERSION_1 (1)
+#define SCR_INDEX_FILE_VERSION_2 (2)
 #define SCR_INDEX_1_KEY_NAME      ("NAME")
 #define SCR_INDEX_1_KEY_DIR       ("DIR")
 #define SCR_INDEX_1_KEY_CKPT      ("CKPT")


### PR DESCRIPTION
While testing the restart loop and forcing checkpoints to be bad so that SCR would fetch the next most recent checkpoint, I came across an old bug in our index metadata.  This file resides in the prefix directory to record the list of datasets on the parallel file system.  In short, it was possible and somewhat typical to end up with multiple and inconsistent entries in the index for a given dataset id value.

This was a desired feature when SCR was creating the dataset directories on the parallel file system.  One could flush multiple copies of the same checkpoint, where each lived in its own directory.  Then if one copy of a particular checkpoint was corrupted, one could try another copy of the same checkpoint if available before falling back to try an older checkpoint.

However, now that directory layout is under control of the user, we typically will just have one copy of each checkpoint.  A re-flushed checkpoint will typically overwrite an existing one in the same location.  Instead, what is more typical is for the app and SCR to get out of sync so that dataset id may get used again but for a different checkpoint.  This ends up corrupting the metadata file so that a single dataset id refers to two distinct checkpoints.

The fix here is to enforce a one-to-one mapping of dataset id to name, rather than the one-to-many that used to exist.  To simplify the code. this changes the index file format in a way that is not backwards compatible, meaning any users who update to this new version but have an existing index file will fail.  If needed, we could do this change in a way that is backwards compatible or we could write a converter.

Resolves https://github.com/LLNL/scr/issues/175

This PR also updates scr_complete_output to return SCR_FAILURE if any process sets valid=0:

Resolves https://github.com/LLNL/scr/issues/173

This modifies SCR_GLOBAL_RESTART to change the fetch to use bypass, allowing an application to use the SCR restart API even with the global restart option.  This allows any process to read any file in its checkpoint during a restart.  That's often necessary in applications that can restart with a different number of processes than were used to write the original checkpoint.

Resolves https://github.com/LLNL/scr/issues/182

While at it, I was looking at tweaking our scr_index output.  We use a ```*``` in our scr_index list of checkpoints to mark the current checkpoint, similar to how git labels the current branch.  This provides an ```ls``` like listing, where the NAME field will be the most useful bit to users.

Do people have a preference between these?
```
>>: $scrbin/scr_index 
   DSET VALID FLUSHED              NAME
*     6 YES   2020-05-09T13:01:38 ckpt.6
      5 YES   2020-05-09T13:01:38 ckpt.5
```
```
>>: $scrbin/scr_index 
  DSET VALID FLUSHED             CUR NAME
     6 YES   2020-05-09T13:01:38   * ckpt.6
     5 YES   2020-05-09T13:01:38     ckpt.5
```
```
>>: $scrbin/scr_index
CUR   DSET VALID FLUSHED             NAME
 *       6 YES   2020-05-13T11:37:36 ckpt.6
         5 YES   2020-05-13T11:37:36 ckpt.5
```
```
>>: $scrbin/scr_index
CUR DSET VALID FLUSHED             NAME
  *    6 YES   2020-05-13T11:37:36 ckpt.6
       5 YES   2020-05-13T11:37:36 ckpt.5
```
```
>>: $scrbin/scr_index
  DSET CUR VALID FLUSHED             NAME
     6  *  YES   2020-05-13T11:37:36 ckpt.6
     5     YES   2020-05-13T11:37:36 ckpt.5
```