### PR TITLE
Add RPM dependencies for Fedora 32 in docs

### DIFF
--- a/doc/rst/users/build.rst
+++ b/doc/rst/users/build.rst
@@ -19,6 +19,13 @@ not available some features of SCR may not be available.
 * libyogrt (optional, used for determining length of time left in the current allocation) (https://github.com/llnl/libyogrt)
 * MySQL (optional, used for logging SCR activities)
 
+On Fedora, you can install the required dependencies with:
+
+  sudo dnf groupinstall "Development Tools"
+  sudo dnf install cmake gcc-c++ mpi mpi-devel environment-modules zlib-devel pdsh
+  [restart shell]
+  module load mpi
+
 Spack
 -----
 

--- a/doc/rst/users/quick.rst
+++ b/doc/rst/users/quick.rst
@@ -27,6 +27,13 @@ dependencies in this quick start guide, which can be automatically
 obtained with either Spack or CMake. For more help on installing
 dependencies of SCR or building SCR, please see Section :ref:`sec-library`.
 
+On Fedora, you can install the required dependencies with:
+
+  sudo dnf groupinstall "Development Tools"
+  sudo dnf install cmake gcc-c++ mpi mpi-devel environment-modules zlib-devel pdsh
+  [restart shell]
+  module load mpi
+
 Spack
 ^^^^^
 


### PR DESCRIPTION
Add instructions for installing the dependencies for SCR on Fedora.  This should install all the required packages except pdsh.
```
  sudo dnf groupinstall "Development Tools"
  sudo dnf install cmake gcc-c++ mpi mpi-devel environment-modules zlib-devel
  [restart shell]
  module load mpi
```