### PR TITLE
add SCR_CURRENT

### DIFF
--- a/src/scr.c
+++ b/src/scr.c
@@ -770,6 +770,11 @@ static int scr_get_params()
     scr_fetch_width = atoi(value);
   }
 
+  /* allow user to specify checkpoint to start with on fetch */
+  if ((value = scr_param_get("SCR_CURRENT")) != NULL) {
+    scr_fetch_current = strdup(value);
+  }
+
   /* specify how often we should flush files */
   if ((value = scr_param_get("SCR_FLUSH")) != NULL) {
     scr_flush = atoi(value);
@@ -2091,6 +2096,7 @@ int SCR_Finalize()
   }
 
   /* free memory allocated for variables */
+  scr_free(&scr_fetch_current);
   scr_free(&scr_username);
   scr_free(&scr_jobid);
   scr_free(&scr_jobname);

--- a/src/scr_cache_index.c
+++ b/src/scr_cache_index.c
@@ -35,10 +35,11 @@
 #include "kvtree.h"
 #include "kvtree_util.h"
 
+#define SCR_CINDEX_KEY_CURRENT ("CURRENT")
 #define SCR_CINDEX_KEY_DSET    ("DSET")
-#define SCR_CINDEX_KEY_DATA    ("DSETDESC")
-#define SCR_CINDEX_KEY_PATH    ("PATH")
-#define SCR_CINDEX_KEY_BYPASS  ("BYPASS")
+#define SCR_CINDEX_KEY_DATA      ("DSETDESC")
+#define SCR_CINDEX_KEY_PATH      ("PATH")
+#define SCR_CINDEX_KEY_BYPASS    ("BYPASS")
 
 /* returns the DSET hash */
 static kvtree* scr_cache_index_get_dh(const kvtree* h)
@@ -73,6 +74,23 @@ static int scr_cache_index_unset_if_empty(scr_cache_index* cindex, int dset)
     kvtree_unset_kv_int(cindex, SCR_CINDEX_KEY_DSET, dset);
   }
 
+  return SCR_SUCCESS;
+}
+
+/* returns the CURRENT name */
+int scr_cache_index_get_current(const kvtree* h, char** current)
+{
+  int kvtree_rc = kvtree_util_get_str(h, SCR_CINDEX_KEY_CURRENT, current);
+  int rc = (kvtree_rc == KVTREE_SUCCESS) ? SCR_SUCCESS : SCR_FAILURE;
+  return rc;
+}
+
+/* set the CURRENT name, used to rememeber if we already proccessed
+ * a SCR_CURRENT name a user may have provided to set the current value,
+ * we ignore that request in later runs and use this marker to remember */
+int scr_cache_index_set_current(const kvtree* h, const char* current)
+{
+  kvtree_util_set_str(h, SCR_CINDEX_KEY_CURRENT, current);
   return SCR_SUCCESS;
 }
 

--- a/src/scr_cache_index.h
+++ b/src/scr_cache_index.h
@@ -49,6 +49,14 @@ Cache index set/get/unset data functions
 =========================================
 */
 
+/* returns the CURRENT name */
+int scr_cache_index_get_current(const kvtree* h, char** current);
+
+/* set the CURRENT name, used to rememeber if we already proccessed
+ * a SCR_CURRENT name a user may have provided to set the current value,
+ * we ignore that request in later runs and use this marker to remember */
+int scr_cache_index_set_current(const kvtree* h, const char* current);
+
 /* sets the dataset hash for the given dataset id */
 int scr_cache_index_set_dataset(scr_cache_index* cindex, int dset, kvtree* hash);
 

--- a/src/scr_globals.c
+++ b/src/scr_globals.c
@@ -104,14 +104,15 @@ size_t scr_file_buf_size = SCR_FILE_BUF_SIZE; /* set buffer size to chunk file c
 int scr_halt_seconds     = SCR_HALT_SECONDS; /* secs remaining in allocation before job should be halted */
 int scr_halt_enabled     = SCR_HALT_ENABLED; /* whether SCR will exit job if halt condition is detected */
 
-int scr_distribute       = SCR_DISTRIBUTE;       /* whether to call scr_distribute_files during SCR_Init */
-int scr_fetch            = SCR_FETCH;            /* whether to call scr_fetch_files during SCR_Init */
-int scr_fetch_width      = SCR_FETCH_WIDTH;      /* specify number of processes to read files simultaneously */
-int scr_fetch_bypass     = SCR_FETCH_BYPASS;     /* whether to use implied bypass mode on fetch */
-int scr_flush            = SCR_FLUSH;            /* how many checkpoints between flushes */
-int scr_flush_width      = SCR_FLUSH_WIDTH;      /* specify number of processes to write files simultaneously */
-int scr_flush_on_restart = SCR_FLUSH_ON_RESTART; /* specify whether to flush cache on restart */
-int scr_global_restart   = SCR_GLOBAL_RESTART;   /* set if code must be restarted from parallel file system */
+int   scr_distribute       = SCR_DISTRIBUTE;       /* whether to call scr_distribute_files during SCR_Init */
+int   scr_fetch            = SCR_FETCH;            /* whether to call scr_fetch_files during SCR_Init */
+int   scr_fetch_width      = SCR_FETCH_WIDTH;      /* specify number of processes to read files simultaneously */
+int   scr_fetch_bypass     = SCR_FETCH_BYPASS;     /* whether to use implied bypass mode on fetch */
+char* scr_fetch_current    = NULL;                 /* name of checkpoint to start with during fetch */
+int   scr_flush            = SCR_FLUSH;            /* how many checkpoints between flushes */
+int   scr_flush_width      = SCR_FLUSH_WIDTH;      /* specify number of processes to write files simultaneously */
+int   scr_flush_on_restart = SCR_FLUSH_ON_RESTART; /* specify whether to flush cache on restart */
+int   scr_global_restart   = SCR_GLOBAL_RESTART;   /* set if code must be restarted from parallel file system */
 
 int    scr_flush_async             = SCR_FLUSH_ASYNC;         /* whether to use asynchronous flush */
 double scr_flush_async_bw          = SCR_FLUSH_ASYNC_BW;      /* bandwidth limit imposed during async flush */

--- a/src/scr_globals.h
+++ b/src/scr_globals.h
@@ -160,14 +160,15 @@ extern size_t scr_file_buf_size; /* set buffer size to chunk file copies to/from
 extern int scr_halt_seconds; /* secs remaining in allocation before job should be halted */
 extern int scr_halt_enabled; /* whether SCR will exit job if halt condition is detected */
 
-extern int scr_distribute;       /* whether to call scr_distribute_files during SCR_Init */
-extern int scr_fetch;            /* whether to call scr_fetch_files during SCR_Init */
-extern int scr_fetch_width;      /* specify number of processes to read files simultaneously */
-extern int scr_fetch_bypass;     /* whether to use implied bypass on fetch operations */
-extern int scr_flush;            /* how many checkpoints between flushes */
-extern int scr_flush_width;      /* specify number of processes to write files simultaneously */
-extern int scr_flush_on_restart; /* specify whether to flush cache on restart */
-extern int scr_global_restart;   /* set if code must be restarted from parallel file system */
+extern int   scr_distribute;       /* whether to call scr_distribute_files during SCR_Init */
+extern int   scr_fetch;            /* whether to call scr_fetch_files during SCR_Init */
+extern int   scr_fetch_width;      /* specify number of processes to read files simultaneously */
+extern int   scr_fetch_bypass;     /* whether to use implied bypass on fetch operations */
+extern char* scr_fetch_current;    /* specify name of checkpoint to start with in fetch_latest */
+extern int   scr_flush;            /* how many checkpoints between flushes */
+extern int   scr_flush_width;      /* specify number of processes to write files simultaneously */
+extern int   scr_flush_on_restart; /* specify whether to flush cache on restart */
+extern int   scr_global_restart;   /* set if code must be restarted from parallel file system */
 
 extern int scr_flush_async;             /* whether to use asynchronous flush */
 extern double scr_flush_async_bw;       /* bandwidth limit imposed during async flush */


### PR DESCRIPTION
This defines a new SCR_CURRENT configuration parameter that can be used to name the checkpoint SCR should restart from.  If set, it sets the "current" maker within the index file under the prefix directory, overwriting any existing setting that might already be there.  This is most typically used to restart from a checkpoint that is older than the most recent available.

This provides an alternative to having to execute the ```scr_index --current <name>``` command before starting the job.  One can now set SCR_CURRENT as an environment variable or in a config file and soon through ```SCR_Config()```.

Given that this might be set in a config file or implied in the application command line throughout the duration of a job, we need to be careful to only process this once within the job allocation.  If a user names a checkpoint to start the job, that job may write a newer checkpoint after it has started.  If that job then dies and gets restarted in the same job allocation, we want to restart from the latest checkpoint, not the old one still named in SCR_CURRENT.  To handle this, we write a marker into the cache index file within the control directory on each node.  We set the marker after processing SCR_CURRENT, and skip processing SCR_CURRENT in any job where we detect the marker.

By placing this file in the control directory, rather than the prefix directory, the marker should be deleted by the system at the end of the job allocation.  A job in a new allocation should once again process any SCR_CURRENT setting on its first run.

Because this file is in the control directory, we need to restore its value on all nodes while rebuilding the cache.  If we restart using a spare node, we need that node to get a copy of the marker.  We take the value of the smallest rank that has a value defined.