### PR TITLE
add simple text file and syslog as log options

### DIFF
--- a/scripts/LSF/scr_jsrun.in
+++ b/scripts/LSF/scr_jsrun.in
@@ -225,7 +225,7 @@ while [ 1 ] ; do
 
   # launch the job, make sure we include the script node and exclude down nodes
   start_secs=`date +%s`
-  $bindir/scr_log_event -T "RUN STARTED" -N "Job=$jobid, Run=$attempts" -S $start_secs
+  $bindir/scr_log_event -p $prefix -T "RUN STARTED" -N "Job=$jobid, Run=$attempts" -S $start_secs
 
   if [ $use_scr_watchdog -eq 0 ]; then
      $launcher $exclude_hosts $launch_cmd
@@ -256,7 +256,7 @@ while [ 1 ] ; do
   $bindir/scr_list_down_nodes $keep_down --log --reason --secs $run_secs
 
   # log stats on the latest run attempt
-  $bindir/scr_log_event -T "RUN ENDED" -N "Job=$jobid, Run=$attempts" -S $end_secs -L $run_secs
+  $bindir/scr_log_event -p $prefix -T "RUN ENDED" -N "Job=$jobid, Run=$attempts" -S $end_secs -L $run_secs
 
   # any retry attempts left?
   if [ $runs -gt -1 ] ; then

--- a/scripts/LSF/scr_jsrun.in
+++ b/scripts/LSF/scr_jsrun.in
@@ -225,7 +225,7 @@ while [ 1 ] ; do
 
   # launch the job, make sure we include the script node and exclude down nodes
   start_secs=`date +%s`
-  $bindir/scr_log_event -p $prefix -T "RUN STARTED" -N "Job=$jobid, Run=$attempts" -S $start_secs
+  $bindir/scr_log_event -i $jobid -p $prefix -T "RUN_START" -N "run=$attempts" -S $start_secs
 
   if [ $use_scr_watchdog -eq 0 ]; then
      $launcher $exclude_hosts $launch_cmd
@@ -256,7 +256,7 @@ while [ 1 ] ; do
   $bindir/scr_list_down_nodes $keep_down --log --reason --secs $run_secs
 
   # log stats on the latest run attempt
-  $bindir/scr_log_event -p $prefix -T "RUN ENDED" -N "Job=$jobid, Run=$attempts" -S $end_secs -L $run_secs
+  $bindir/scr_log_event -i $jobid -p $prefix -T "RUN_END" -N "run=$attempts" -S $end_secs -L $run_secs
 
   # any retry attempts left?
   if [ $runs -gt -1 ] ; then

--- a/scripts/LSF/scr_list_down_nodes.in
+++ b/scripts/LSF/scr_list_down_nodes.in
@@ -65,6 +65,9 @@ if ($conf{help} or not $rc) {
   print_usage();
 }
 
+# get prefix directory
+my $prefix = `$bindir/scr_prefix`
+
 # read the nodeset from command line or environment
 my $nodeset = undef;
 if (@ARGV) {
@@ -302,7 +305,7 @@ if (@failed_nodes) {
       if (defined $conf{runtime_secs}) {
         $duration = "-D $conf{runtime_secs}";
       }
-      `$bindir/scr_log_event -T 'FAILED NODE' -N '$node: $reason{$node}' -S $start_time $duration`;
+      `$bindir/scr_log_event -p $prefix -T 'FAILED NODE' -N '$node: $reason{$node}' -S $start_time $duration`;
     }
   }
 

--- a/scripts/LSF/scr_list_down_nodes.in
+++ b/scripts/LSF/scr_list_down_nodes.in
@@ -68,6 +68,9 @@ if ($conf{help} or not $rc) {
 # get prefix directory
 my $prefix = `$bindir/scr_prefix`
 
+# get jobid
+my $jobid = `$bindir/scr_env --jobid`;
+
 # read the nodeset from command line or environment
 my $nodeset = undef;
 if (@ARGV) {
@@ -305,7 +308,7 @@ if (@failed_nodes) {
       if (defined $conf{runtime_secs}) {
         $duration = "-D $conf{runtime_secs}";
       }
-      `$bindir/scr_log_event -p $prefix -T 'FAILED NODE' -N '$node: $reason{$node}' -S $start_time $duration`;
+      `$bindir/scr_log_event -i $jobid -p $prefix -T 'NODE_FAIL' -N '$node: $reason{$node}' -S $start_time $duration`;
     }
   }
 

--- a/scripts/LSF/scr_lrun.in
+++ b/scripts/LSF/scr_lrun.in
@@ -225,7 +225,7 @@ while [ 1 ] ; do
 
   # launch the job, make sure we include the script node and exclude down nodes
   start_secs=`date +%s`
-  $bindir/scr_log_event -T "RUN STARTED" -N "Job=$jobid, Run=$attempts" -S $start_secs
+  $bindir/scr_log_event -p $prefix -T "RUN STARTED" -N "Job=$jobid, Run=$attempts" -S $start_secs
 
   if [ $use_scr_watchdog -eq 0 ]; then
      $launcher $exclude_hosts $launch_cmd
@@ -256,7 +256,7 @@ while [ 1 ] ; do
   $bindir/scr_list_down_nodes $keep_down --log --reason --secs $run_secs
 
   # log stats on the latest run attempt
-  $bindir/scr_log_event -T "RUN ENDED" -N "Job=$jobid, Run=$attempts" -S $end_secs -L $run_secs
+  $bindir/scr_log_event -p $prefix -T "RUN ENDED" -N "Job=$jobid, Run=$attempts" -S $end_secs -L $run_secs
 
   # any retry attempts left?
   if [ $runs -gt -1 ] ; then

--- a/scripts/LSF/scr_lrun.in
+++ b/scripts/LSF/scr_lrun.in
@@ -225,7 +225,7 @@ while [ 1 ] ; do
 
   # launch the job, make sure we include the script node and exclude down nodes
   start_secs=`date +%s`
-  $bindir/scr_log_event -p $prefix -T "RUN STARTED" -N "Job=$jobid, Run=$attempts" -S $start_secs
+  $bindir/scr_log_event -i $jobid -p $prefix -T "RUN_START" -N "run=$attempts" -S $start_secs
 
   if [ $use_scr_watchdog -eq 0 ]; then
      $launcher $exclude_hosts $launch_cmd
@@ -256,7 +256,7 @@ while [ 1 ] ; do
   $bindir/scr_list_down_nodes $keep_down --log --reason --secs $run_secs
 
   # log stats on the latest run attempt
-  $bindir/scr_log_event -p $prefix -T "RUN ENDED" -N "Job=$jobid, Run=$attempts" -S $end_secs -L $run_secs
+  $bindir/scr_log_event -i $jobid -p $prefix -T "RUN_END" -N "run=$attempts" -S $end_secs -L $run_secs
 
   # any retry attempts left?
   if [ $runs -gt -1 ] ; then

--- a/scripts/LSF/scr_mpirun.in
+++ b/scripts/LSF/scr_mpirun.in
@@ -228,7 +228,7 @@ while [ 1 ] ; do
 
   # launch the job, make sure we include the script node and exclude down nodes
   start_secs=`date +%s`
-  $bindir/scr_log_event -T "RUN STARTED" -N "Job=$jobid, Run=$attempts" -S $start_secs
+  $bindir/scr_log_event -i $jobid -p $prefix -T "RUN_START" -N "run=$attempts" -S $start_secs
 
   if [ $use_scr_watchdog -eq 0 ]; then
      echo "$target_hosts" > $hostfile
@@ -261,7 +261,7 @@ while [ 1 ] ; do
   $bindir/scr_list_down_nodes $keep_down --log --reason --secs $run_secs
 
   # log stats on the latest run attempt
-  $bindir/scr_log_event -T "RUN ENDED" -N "Job=$jobid, Run=$attempts" -S $end_secs -L $run_secs
+  $bindir/scr_log_event -i $jobid -p $prefix -T "RUN_END" -N "run=$attempts" -S $end_secs -L $run_secs
 
   # any retry attempts left?
   if [ $runs -gt -1 ] ; then

--- a/scripts/LSF/scr_run.in
+++ b/scripts/LSF/scr_run.in
@@ -225,7 +225,7 @@ while [ 1 ] ; do
 
   # launch the job, make sure we include the script node and exclude down nodes
   start_secs=`date +%s`
-  $bindir/scr_log_event -T "RUN STARTED" -N "Job=$jobid, Run=$attempts" -S $start_secs
+  $bindir/scr_log_event -p $prefix -T "RUN STARTED" -N "Job=$jobid, Run=$attempts" -S $start_secs
 
   if [ $use_scr_watchdog -eq 0 ]; then
      $launcher $exclude_hosts $launch_cmd
@@ -256,7 +256,7 @@ while [ 1 ] ; do
   $bindir/scr_list_down_nodes $keep_down --log --reason --secs $run_secs
 
   # log stats on the latest run attempt
-  $bindir/scr_log_event -T "RUN ENDED" -N "Job=$jobid, Run=$attempts" -S $end_secs -L $run_secs
+  $bindir/scr_log_event -p $prefix -T "RUN ENDED" -N "Job=$jobid, Run=$attempts" -S $end_secs -L $run_secs
 
   # any retry attempts left?
   if [ $runs -gt -1 ] ; then

--- a/scripts/LSF/scr_run.in
+++ b/scripts/LSF/scr_run.in
@@ -225,7 +225,7 @@ while [ 1 ] ; do
 
   # launch the job, make sure we include the script node and exclude down nodes
   start_secs=`date +%s`
-  $bindir/scr_log_event -p $prefix -T "RUN STARTED" -N "Job=$jobid, Run=$attempts" -S $start_secs
+  $bindir/scr_log_event -i $jobid -p $prefix -T "RUN_START" -N "run=$attempts" -S $start_secs
 
   if [ $use_scr_watchdog -eq 0 ]; then
      $launcher $exclude_hosts $launch_cmd
@@ -256,7 +256,7 @@ while [ 1 ] ; do
   $bindir/scr_list_down_nodes $keep_down --log --reason --secs $run_secs
 
   # log stats on the latest run attempt
-  $bindir/scr_log_event -p $prefix -T "RUN ENDED" -N "Job=$jobid, Run=$attempts" -S $end_secs -L $run_secs
+  $bindir/scr_log_event -i $jobid -p $prefix -T "RUN_END" -N "run=$attempts" -S $end_secs -L $run_secs
 
   # any retry attempts left?
   if [ $runs -gt -1 ] ; then

--- a/scripts/LSF/scr_scavenge.in
+++ b/scripts/LSF/scr_scavenge.in
@@ -125,7 +125,7 @@ my $error  = "$prefixdir/.scr/scr.dataset.$dset/$prog.pdsh.e" . $jobid;
 my $cmd = undef;
 
 # log the start of the scavenge operation
-`$bindir/scr_log_event -p $prefixdir -T 'SCAVENGE STARTED' -D $dset -S $start_time`;
+`$bindir/scr_log_event -i $jobid -p $prefixdir -T 'SCAVENGE_START' -D $dset -S $start_time`;
 
 # gather files via pdsh
 my $partner_flag = "";
@@ -280,6 +280,6 @@ if (@copy_failed > 0 or @pdsh_failed > 0) {
 # get a timestamp for logging timing values
 my $end_time = time();
 my $diff_time = $end_time - $start_time;
-`$bindir/scr_log_event -p $prefixdir -T 'SCAVENGE COMPLETED' -D $dset -S $start_time -L $diff_time`;
+`$bindir/scr_log_event -i $jobid -p $prefixdir -T 'SCAVENGE_END' -D $dset -S $start_time -L $diff_time`;
 
 exit 0;

--- a/scripts/LSF/scr_scavenge.in
+++ b/scripts/LSF/scr_scavenge.in
@@ -125,7 +125,7 @@ my $error  = "$prefixdir/.scr/scr.dataset.$dset/$prog.pdsh.e" . $jobid;
 my $cmd = undef;
 
 # log the start of the scavenge operation
-`$bindir/scr_log_event -T 'SCAVENGE STARTED' -D $dset -S $start_time`;
+`$bindir/scr_log_event -p $prefixdir -T 'SCAVENGE STARTED' -D $dset -S $start_time`;
 
 # gather files via pdsh
 my $partner_flag = "";
@@ -280,6 +280,6 @@ if (@copy_failed > 0 or @pdsh_failed > 0) {
 # get a timestamp for logging timing values
 my $end_time = time();
 my $diff_time = $end_time - $start_time;
-`$bindir/scr_log_event -T 'SCAVENGE COMPLETED' -D $dset -S $start_time -L $diff_time`;
+`$bindir/scr_log_event -p $prefixdir -T 'SCAVENGE COMPLETED' -D $dset -S $start_time -L $diff_time`;
 
 exit 0;

--- a/scripts/PMIX/scr_list_down_nodes.in
+++ b/scripts/PMIX/scr_list_down_nodes.in
@@ -71,6 +71,9 @@ if ($conf{help} or not $rc) {
 # get prefix directory
 my $prefix = `$bindir/scr_prefix`;
 
+# get jobid
+my $jobid = `$bindir/scr_env --jobid`;
+
 # read the nodeset from command line or environment
 my $nodeset = undef;
 if (@ARGV) {
@@ -268,7 +271,7 @@ if (@failed_nodes) {
       if (defined $conf{runtime_secs}) {
         $duration = "-D $conf{runtime_secs}";
       }
-      `$bindir/scr_log_event -p $prefix -T 'FAILED NODE' -N '$node: $reason{$node}' -S $start_time $duration`;
+      `$bindir/scr_log_event -i $jobid -p $prefix -T 'NODE_FAIL' -N '$node: $reason{$node}' -S $start_time $duration`;
     }
   }
 

--- a/scripts/PMIX/scr_list_down_nodes.in
+++ b/scripts/PMIX/scr_list_down_nodes.in
@@ -68,6 +68,9 @@ if ($conf{help} or not $rc) {
   print_usage();
 }
 
+# get prefix directory
+my $prefix = `$bindir/scr_prefix`;
+
 # read the nodeset from command line or environment
 my $nodeset = undef;
 if (@ARGV) {
@@ -265,7 +268,7 @@ if (@failed_nodes) {
       if (defined $conf{runtime_secs}) {
         $duration = "-D $conf{runtime_secs}";
       }
-      `$bindir/scr_log_event -T 'FAILED NODE' -N '$node: $reason{$node}' -S $start_time $duration`;
+      `$bindir/scr_log_event -p $prefix -T 'FAILED NODE' -N '$node: $reason{$node}' -S $start_time $duration`;
     }
   }
 

--- a/scripts/PMIX/scr_run.in
+++ b/scripts/PMIX/scr_run.in
@@ -220,7 +220,7 @@ while [ 1 ] ; do
 
   # launch the job, make sure we include the script node and exclude down nodes
   start_secs=`date +%s`
-  $bindir/scr_log_event -p $prefix -T "RUN STARTED" -N "Job=$jobid, Run=$attempts" -S $start_secs
+  $bindir/scr_log_event -i $jobid -p $prefix -T "RUN_START" -N "run=$attempts" -S $start_secs
 
   if [ $use_scr_watchdog -eq 0 ]; then
       #todo pmix: need to remove the -B 15 once pmix supports properly blocking for a process
@@ -253,7 +253,7 @@ while [ 1 ] ; do
   $bindir/scr_list_down_nodes $keep_down --log --reason --secs $run_secs
 
   # log stats on the latest run attempt
-  $bindir/scr_log_event -p $prefix -T "RUN ENDED" -N "Job=$jobid, Run=$attempts" -S $end_secs -L $run_secs
+  $bindir/scr_log_event -i $jobid -p $prefix -T "RUN_END" -N "run=$attempts" -S $end_secs -L $run_secs
 
   # any retry attempts left?
   if [ $runs -gt -1 ] ; then

--- a/scripts/PMIX/scr_run.in
+++ b/scripts/PMIX/scr_run.in
@@ -220,7 +220,7 @@ while [ 1 ] ; do
 
   # launch the job, make sure we include the script node and exclude down nodes
   start_secs=`date +%s`
-  $bindir/scr_log_event -T "RUN STARTED" -N "Job=$jobid, Run=$attempts" -S $start_secs
+  $bindir/scr_log_event -p $prefix -T "RUN STARTED" -N "Job=$jobid, Run=$attempts" -S $start_secs
 
   if [ $use_scr_watchdog -eq 0 ]; then
       #todo pmix: need to remove the -B 15 once pmix supports properly blocking for a process
@@ -253,7 +253,7 @@ while [ 1 ] ; do
   $bindir/scr_list_down_nodes $keep_down --log --reason --secs $run_secs
 
   # log stats on the latest run attempt
-  $bindir/scr_log_event -T "RUN ENDED" -N "Job=$jobid, Run=$attempts" -S $end_secs -L $run_secs
+  $bindir/scr_log_event -p $prefix -T "RUN ENDED" -N "Job=$jobid, Run=$attempts" -S $end_secs -L $run_secs
 
   # any retry attempts left?
   if [ $runs -gt -1 ] ; then

--- a/scripts/PMIX/scr_scavenge.in
+++ b/scripts/PMIX/scr_scavenge.in
@@ -147,7 +147,7 @@ my $error  = "$prefixdir/.scr/scr.dataset.$dset/$prog.pdsh.e" . $jobid;
 my $cmd = undef;
 
 # log the start of the scavenge operation
-`$bindir/scr_log_event -T 'SCAVENGE STARTED' -D $dset -S $start_time`;
+`$bindir/scr_log_event -p $prefixdir -T 'SCAVENGE STARTED' -D $dset -S $start_time`;
 
 # gather files via pdsh
 my $partner_flag = "";
@@ -304,6 +304,6 @@ if (@copy_failed > 0 or @pdsh_failed > 0) {
 # get a timestamp for logging timing values
 my $end_time = time();
 my $diff_time = $end_time - $start_time;
-`$bindir/scr_log_event -T 'SCAVENGE COMPLETED' -D $dset -S $start_time -L $diff_time`;
+`$bindir/scr_log_event -p $prefixdir -T 'SCAVENGE COMPLETED' -D $dset -S $start_time -L $diff_time`;
 
 exit 0;

--- a/scripts/PMIX/scr_scavenge.in
+++ b/scripts/PMIX/scr_scavenge.in
@@ -147,7 +147,7 @@ my $error  = "$prefixdir/.scr/scr.dataset.$dset/$prog.pdsh.e" . $jobid;
 my $cmd = undef;
 
 # log the start of the scavenge operation
-`$bindir/scr_log_event -p $prefixdir -T 'SCAVENGE STARTED' -D $dset -S $start_time`;
+`$bindir/scr_log_event -i $jobid -p $prefixdir -T 'SCAVENGE_START' -D $dset -S $start_time`;
 
 # gather files via pdsh
 my $partner_flag = "";
@@ -304,6 +304,6 @@ if (@copy_failed > 0 or @pdsh_failed > 0) {
 # get a timestamp for logging timing values
 my $end_time = time();
 my $diff_time = $end_time - $start_time;
-`$bindir/scr_log_event -p $prefixdir -T 'SCAVENGE COMPLETED' -D $dset -S $start_time -L $diff_time`;
+`$bindir/scr_log_event -i $jobid -p $prefixdir -T 'SCAVENGE_END' -D $dset -S $start_time -L $diff_time`;
 
 exit 0;

--- a/scripts/TLCC/scr_list_down_nodes.in
+++ b/scripts/TLCC/scr_list_down_nodes.in
@@ -68,6 +68,9 @@ if ($conf{help} or not $rc) {
 # get prefix directory
 my $prefix = `$bindir/scr_prefix`;
 
+# get jobid
+my $jobid = `$bindir/scr_env --jobid`;
+
 # read the nodeset from command line or environment
 my $nodeset = undef;
 if (@ARGV) {
@@ -267,7 +270,7 @@ if (@failed_nodes) {
       if (defined $conf{runtime_secs}) {
         $duration = "-D $conf{runtime_secs}";
       }
-      `$bindir/scr_log_event -p $prefix -T 'FAILED NODE' -N '$node: $reason{$node}' -S $start_time $duration`;
+      `$bindir/scr_log_event -i $jobid -p $prefix -T 'NODE_FAIL' -N '$node: $reason{$node}' -S $start_time $duration`;
     }
   }
 

--- a/scripts/TLCC/scr_list_down_nodes.in
+++ b/scripts/TLCC/scr_list_down_nodes.in
@@ -65,6 +65,9 @@ if ($conf{help} or not $rc) {
   print_usage();
 }
 
+# get prefix directory
+my $prefix = `$bindir/scr_prefix`;
+
 # read the nodeset from command line or environment
 my $nodeset = undef;
 if (@ARGV) {
@@ -264,7 +267,7 @@ if (@failed_nodes) {
       if (defined $conf{runtime_secs}) {
         $duration = "-D $conf{runtime_secs}";
       }
-      `$bindir/scr_log_event -T 'FAILED NODE' -N '$node: $reason{$node}' -S $start_time $duration`;
+      `$bindir/scr_log_event -p $prefix -T 'FAILED NODE' -N '$node: $reason{$node}' -S $start_time $duration`;
     }
   }
 

--- a/scripts/TLCC/scr_run.in
+++ b/scripts/TLCC/scr_run.in
@@ -218,7 +218,7 @@ while [ 1 ] ; do
 
   # launch the job, make sure we include the script node and exclude down nodes
   start_secs=`date +%s`
-  $bindir/scr_log_event -p $prefix -T "RUN STARTED" -N "Job=$jobid, Run=$attempts" -S $start_secs
+  $bindir/scr_log_event -i $jobid -p $prefix -T "RUN_START" -N "run=$attempts" -S $start_secs
 
   if [ $use_scr_watchdog -eq 0 ]; then
      $launcher $exclude $launch_cmd
@@ -249,7 +249,7 @@ while [ 1 ] ; do
   $bindir/scr_list_down_nodes $keep_down --log --reason --secs $run_secs
 
   # log stats on the latest run attempt
-  $bindir/scr_log_event -p $prefix -T "RUN ENDED" -N "Job=$jobid, Run=$attempts" -S $end_secs -L $run_secs
+  $bindir/scr_log_event -i $jobid -p $prefix -T "RUN_END" -N "run=$attempts" -S $end_secs -L $run_secs
 
   # any retry attempts left?
   if [ $runs -gt -1 ] ; then

--- a/scripts/TLCC/scr_run.in
+++ b/scripts/TLCC/scr_run.in
@@ -218,7 +218,7 @@ while [ 1 ] ; do
 
   # launch the job, make sure we include the script node and exclude down nodes
   start_secs=`date +%s`
-  $bindir/scr_log_event -T "RUN STARTED" -N "Job=$jobid, Run=$attempts" -S $start_secs
+  $bindir/scr_log_event -p $prefix -T "RUN STARTED" -N "Job=$jobid, Run=$attempts" -S $start_secs
 
   if [ $use_scr_watchdog -eq 0 ]; then
      $launcher $exclude $launch_cmd
@@ -249,7 +249,7 @@ while [ 1 ] ; do
   $bindir/scr_list_down_nodes $keep_down --log --reason --secs $run_secs
 
   # log stats on the latest run attempt
-  $bindir/scr_log_event -T "RUN ENDED" -N "Job=$jobid, Run=$attempts" -S $end_secs -L $run_secs
+  $bindir/scr_log_event -p $prefix -T "RUN ENDED" -N "Job=$jobid, Run=$attempts" -S $end_secs -L $run_secs
 
   # any retry attempts left?
   if [ $runs -gt -1 ] ; then

--- a/scripts/TLCC/scr_scavenge.in
+++ b/scripts/TLCC/scr_scavenge.in
@@ -125,7 +125,7 @@ my $error  = "$prefixdir/.scr/scr.dataset.$dset/$prog.pdsh.e" . $jobid;
 my $cmd = undef;
 
 # log the start of the scavenge operation
-`$bindir/scr_log_event -p $prefixdir -T 'SCAVENGE STARTED' -D $dset -S $start_time`;
+`$bindir/scr_log_event -i $jobid -p $prefixdir -T 'SCAVENGE_START' -D $dset -S $start_time`;
 
 # gather files via pdsh
 my $partner_flag = "";
@@ -283,6 +283,6 @@ if (@copy_failed > 0 or @pdsh_failed > 0) {
 # get a timestamp for logging timing values
 my $end_time = time();
 my $diff_time = $end_time - $start_time;
-`$bindir/scr_log_event -p $prefixdir -T 'SCAVENGE COMPLETED' -D $dset -S $start_time -L $diff_time`;
+`$bindir/scr_log_event -i $jobid -p $prefixdir -T 'SCAVENGE_END' -D $dset -S $start_time -L $diff_time`;
 
 exit 0;

--- a/scripts/TLCC/scr_scavenge.in
+++ b/scripts/TLCC/scr_scavenge.in
@@ -125,7 +125,7 @@ my $error  = "$prefixdir/.scr/scr.dataset.$dset/$prog.pdsh.e" . $jobid;
 my $cmd = undef;
 
 # log the start of the scavenge operation
-`$bindir/scr_log_event -T 'SCAVENGE STARTED' -D $dset -S $start_time`;
+`$bindir/scr_log_event -p $prefixdir -T 'SCAVENGE STARTED' -D $dset -S $start_time`;
 
 # gather files via pdsh
 my $partner_flag = "";
@@ -283,6 +283,6 @@ if (@copy_failed > 0 or @pdsh_failed > 0) {
 # get a timestamp for logging timing values
 my $end_time = time();
 my $diff_time = $end_time - $start_time;
-`$bindir/scr_log_event -T 'SCAVENGE COMPLETED' -D $dset -S $start_time -L $diff_time`;
+`$bindir/scr_log_event -p $prefixdir -T 'SCAVENGE COMPLETED' -D $dset -S $start_time -L $diff_time`;
 
 exit 0;

--- a/scripts/cray_xt/scr_list_down_nodes.in
+++ b/scripts/cray_xt/scr_list_down_nodes.in
@@ -65,6 +65,9 @@ if ($conf{help} or not $rc) {
   print_usage();
 }
 
+# get prefix directory
+my $prefix = `$bindir/scr_prefix`;
+
 # read the nodeset from command line or environment
 my $nodeset = undef;
 if (@ARGV) {
@@ -265,7 +268,7 @@ if (@failed_nodes) {
       if (defined $conf{runtime_secs}) {
         $duration = "-D $conf{runtime_secs}";
       }
-      `$bindir/scr_log_event -T 'FAILED NODE' -N '$node: $reason{$node}' -S $start_time $duration`;
+      `$bindir/scr_log_event -p $prefix -T 'FAILED NODE' -N '$node: $reason{$node}' -S $start_time $duration`;
     }
   }
 

--- a/scripts/cray_xt/scr_list_down_nodes.in
+++ b/scripts/cray_xt/scr_list_down_nodes.in
@@ -68,6 +68,9 @@ if ($conf{help} or not $rc) {
 # get prefix directory
 my $prefix = `$bindir/scr_prefix`;
 
+# get jobid
+my $jobid = `$bindir/scr_env --jobid`;
+
 # read the nodeset from command line or environment
 my $nodeset = undef;
 if (@ARGV) {
@@ -268,7 +271,7 @@ if (@failed_nodes) {
       if (defined $conf{runtime_secs}) {
         $duration = "-D $conf{runtime_secs}";
       }
-      `$bindir/scr_log_event -p $prefix -T 'FAILED NODE' -N '$node: $reason{$node}' -S $start_time $duration`;
+      `$bindir/scr_log_event -i $jobid -p $prefix -T 'NODE_FAIL' -N '$node: $reason{$node}' -S $start_time $duration`;
     }
   }
 

--- a/scripts/cray_xt/scr_run.in
+++ b/scripts/cray_xt/scr_run.in
@@ -225,7 +225,7 @@ while [ 1 ] ; do
 
   # launch the job, make sure we include the script node and exclude down nodes
   start_secs=`date +%s`
-  $bindir/scr_log_event -p $prefix -T "RUN STARTED" -N "Job=$jobid, Run=$attempts" -S $start_secs
+  $bindir/scr_log_event -i $jobid -p $prefix -T "RUN_START" -N "run=$attempts" -S $start_secs
 
   #original srun command to emulate
   #srun $exclude "$@"
@@ -279,7 +279,7 @@ while [ 1 ] ; do
   $bindir/scr_list_down_nodes $keep_down --log --reason --secs $run_secs
 
   # log stats on the latest run attempt
-  $bindir/scr_log_event -p $prefix -T "RUN ENDED" -N "Job=$jobid, Run=$attempts" -S $end_secs -D $run_secs
+  $bindir/scr_log_event -i $jobid -p $prefix -T "RUN_END" -N "run=$attempts" -S $end_secs -D $run_secs
 
   # any retry attempts left?
   if [ $runs -gt -1 ] ; then

--- a/scripts/cray_xt/scr_run.in
+++ b/scripts/cray_xt/scr_run.in
@@ -225,7 +225,7 @@ while [ 1 ] ; do
 
   # launch the job, make sure we include the script node and exclude down nodes
   start_secs=`date +%s`
-  $bindir/scr_log_event -T "RUN STARTED" -N "Job=$jobid, Run=$attempts" -S $start_secs
+  $bindir/scr_log_event -p $prefix -T "RUN STARTED" -N "Job=$jobid, Run=$attempts" -S $start_secs
 
   #original srun command to emulate
   #srun $exclude "$@"
@@ -279,7 +279,7 @@ while [ 1 ] ; do
   $bindir/scr_list_down_nodes $keep_down --log --reason --secs $run_secs
 
   # log stats on the latest run attempt
-  $bindir/scr_log_event -T "RUN ENDED" -N "Job=$jobid, Run=$attempts" -S $end_secs -D $run_secs
+  $bindir/scr_log_event -p $prefix -T "RUN ENDED" -N "Job=$jobid, Run=$attempts" -S $end_secs -D $run_secs
 
   # any retry attempts left?
   if [ $runs -gt -1 ] ; then

--- a/scripts/cray_xt/scr_scavenge.in
+++ b/scripts/cray_xt/scr_scavenge.in
@@ -133,7 +133,7 @@ my $error  = "$prefixdir/.scr/scr.dataset.$dset/$prog.pdsh.e" . $jobid;
 my $cmd = undef;
 
 # log the start of the scavenge operation
-`$bindir/scr_log_event -T 'SCAVENGE STARTED' -D $dset -S $start_time`;
+`$bindir/scr_log_event -p $prefixdir -T 'SCAVENGE STARTED' -D $dset -S $start_time`;
 
 # gather files via pdsh
 my $partner_flag = "";
@@ -298,6 +298,6 @@ if (@copy_failed > 0 or @pdsh_failed > 0) {
 # get a timestamp for logging timing values
 my $end_time = time();
 my $diff_time = $end_time - $start_time;
-`$bindir/scr_log_event -T 'SCAVENGE COMPLETED' -D $dset -S $start_time -L $diff_time`;
+`$bindir/scr_log_event -p $prefixdir -T 'SCAVENGE COMPLETED' -D $dset -S $start_time -L $diff_time`;
 
 exit 0;

--- a/scripts/cray_xt/scr_scavenge.in
+++ b/scripts/cray_xt/scr_scavenge.in
@@ -133,7 +133,7 @@ my $error  = "$prefixdir/.scr/scr.dataset.$dset/$prog.pdsh.e" . $jobid;
 my $cmd = undef;
 
 # log the start of the scavenge operation
-`$bindir/scr_log_event -p $prefixdir -T 'SCAVENGE STARTED' -D $dset -S $start_time`;
+`$bindir/scr_log_event -i $jobid -p $prefixdir -T 'SCAVENGE_START' -D $dset -S $start_time`;
 
 # gather files via pdsh
 my $partner_flag = "";
@@ -298,6 +298,6 @@ if (@copy_failed > 0 or @pdsh_failed > 0) {
 # get a timestamp for logging timing values
 my $end_time = time();
 my $diff_time = $end_time - $start_time;
-`$bindir/scr_log_event -p $prefixdir -T 'SCAVENGE COMPLETED' -D $dset -S $start_time -L $diff_time`;
+`$bindir/scr_log_event -i $jobid -p $prefixdir -T 'SCAVENGE_END' -D $dset -S $start_time -L $diff_time`;
 
 exit 0;

--- a/src/scr.c
+++ b/src/scr.c
@@ -598,26 +598,26 @@ static int scr_get_params()
   }
 
   /* check whether SCR logging DB is enabled */
-  if ((value = scr_param_get("SCR_DB_ENABLE")) != NULL) {
+  if ((value = scr_param_get("SCR_LOG_DB_ENABLE")) != NULL) {
     scr_log_db_enable = atoi(value);
   }
 
   /* read in the debug level for database log messages */
-  if ((value = scr_param_get("SCR_DB_DEBUG")) != NULL) {
+  if ((value = scr_param_get("SCR_LOG_DB_DEBUG")) != NULL) {
     scr_log_db_debug = atoi(value);
   }
 
   /* SCR log DB connection parameters */
-  if ((value = scr_param_get("SCR_DB_HOST")) != NULL) {
+  if ((value = scr_param_get("SCR_LOG_DB_HOST")) != NULL) {
     scr_log_db_host = strdup(value);
   }
-  if ((value = scr_param_get("SCR_DB_USER")) != NULL) {
+  if ((value = scr_param_get("SCR_LOG_DB_USER")) != NULL) {
     scr_log_db_user = strdup(value);
   }
-  if ((value = scr_param_get("SCR_DB_PASS")) != NULL) {
+  if ((value = scr_param_get("SCR_LOG_DB_PASS")) != NULL) {
     scr_log_db_pass = strdup(value);
   }
-  if ((value = scr_param_get("SCR_DB_NAME")) != NULL) {
+  if ((value = scr_param_get("SCR_LOG_DB_NAME")) != NULL) {
     scr_log_db_name = strdup(value);
   }
 

--- a/src/scr.c
+++ b/src/scr.c
@@ -902,7 +902,7 @@ static int scr_get_params()
    * config file, which in turn requires a bcast.  However, only rank 0 calls scr_log_init(),
    * so the bcast would fail if scr_param_init really had to read the config file again. */
   if (scr_my_rank_world == 0 && scr_log_enable) {
-    if (scr_log_init() != SCR_SUCCESS) {
+    if (scr_log_init(scr_prefix) != SCR_SUCCESS) {
       scr_warn("Failed to initialize SCR logging, disabling logging @ %s:%d",
               __FILE__, __LINE__
       );
@@ -1714,29 +1714,6 @@ int SCR_Init()
     );
   }
 
-  /* register this job in the logging database */
-  if (scr_my_rank_world == 0 && scr_log_enable) {
-    if (scr_username != NULL && scr_jobname != NULL) {
-      time_t job_start = scr_log_seconds();
-      if (scr_log_job(scr_username, scr_jobname, job_start) == SCR_SUCCESS) {
-        /* record the start time for this run */
-        scr_log_run(job_start);
-      } else {
-        scr_warn("Failed to log job for username %s and jobname %s, disabling logging @ %s:%d",
-          scr_username, scr_jobname, __FILE__, __LINE__
-        );
-        scr_log_enable = 0;
-      }
-    } else {
-      scr_warn("Failed to read username or jobname from environment, disabling logging @ %s:%d",
-        __FILE__, __LINE__
-      );
-      scr_log_enable = 0;
-    }
-  }
-
-  /* TODO MEMFS: mount storage for control directory */
-
   /* check that scr_prefix is set */
   if (scr_prefix == NULL || strcmp(scr_prefix, "") == 0) {
     if (scr_my_rank_world == 0) {
@@ -1761,6 +1738,29 @@ int SCR_Init()
       );
     }
   }
+
+  /* register this job in the logging database */
+  if (scr_my_rank_world == 0 && scr_log_enable) {
+    if (scr_username != NULL && scr_jobname != NULL) {
+      time_t job_start = scr_log_seconds();
+      if (scr_log_job(scr_username, scr_jobname, job_start) == SCR_SUCCESS) {
+        /* record the start time for this run */
+        scr_log_run(job_start);
+      } else {
+        scr_warn("Failed to log job for username %s and jobname %s, disabling logging @ %s:%d",
+          scr_username, scr_jobname, __FILE__, __LINE__
+        );
+        scr_log_enable = 0;
+      }
+    } else {
+      scr_warn("Failed to read username or jobname from environment, disabling logging @ %s:%d",
+        __FILE__, __LINE__
+      );
+      scr_log_enable = 0;
+    }
+  }
+
+  /* TODO MEMFS: mount storage for control directory */
 
   /* build the control directory name: CNTL_BASE/username/scr.jobid */
   spath* path_cntl_prefix = spath_from_str(scr_cntl_base);

--- a/src/scr_cache_rebuild.c
+++ b/src/scr_cache_rebuild.c
@@ -171,10 +171,9 @@ int scr_cache_rebuild(scr_cache_index* cindex)
 {
   int rc = SCR_FAILURE;
 
-  double time_start, time_end, time_diff;
-
   /* start timer */
   time_t time_t_start;
+  double time_start;
   if (scr_my_rank_world == 0) {
     time_t_start = scr_log_seconds();
     time_start = MPI_Wtime();
@@ -246,8 +245,7 @@ int scr_cache_rebuild(scr_cache_index* cindex)
       if (scr_my_rank_world == 0) {
         scr_dbg(1, "Attempting to distribute and rebuild dataset %d", current_id);
         if (scr_log_enable) {
-          time_t now = scr_log_seconds();
-          scr_log_event("REBUILD STARTED", NULL, &current_id, &now, NULL);
+          scr_log_event("REBUILD_START", NULL, &current_id, NULL, NULL, NULL);
         }
       }
 
@@ -334,8 +332,7 @@ int scr_cache_rebuild(scr_cache_index* cindex)
         if (scr_my_rank_world == 0) {
           scr_dbg(1, "Failed to rebuild dataset %d", current_id);
           if (scr_log_enable) {
-            time_t now = scr_log_seconds();
-            scr_log_event("REBUILD FAILED", NULL, &current_id, &now, NULL);
+            scr_log_event("REBUILD_FAIL", NULL, &current_id, NULL, NULL, NULL);
           }
         }
 
@@ -351,8 +348,7 @@ int scr_cache_rebuild(scr_cache_index* cindex)
         if (scr_my_rank_world == 0) {
           scr_dbg(1, "Rebuilt dataset %d", current_id);
           if (scr_log_enable) {
-            time_t now = scr_log_seconds();
-            scr_log_event("REBUILD SUCCEEDED", NULL, &current_id, &now, NULL);
+            scr_log_event("REBUILD_SUCCESS", NULL, &current_id, NULL, NULL, NULL);
           }
         }
       }
@@ -384,8 +380,8 @@ int scr_cache_rebuild(scr_cache_index* cindex)
 
   /* stop timer and report performance */
   if (scr_my_rank_world == 0) {
-    time_end = MPI_Wtime();
-    time_diff = time_end - time_start;
+    double time_end = MPI_Wtime();
+    double time_diff = time_end - time_start;
 
     if (distribute_attempted) {
       if (rc == SCR_SUCCESS) {
@@ -393,13 +389,13 @@ int scr_cache_rebuild(scr_cache_index* cindex)
           scr_checkpoint_id, time_diff
         );
         if (scr_log_enable) {
-          scr_log_event("RESTART SUCCEEDED", NULL, &scr_checkpoint_id, &time_t_start, &time_diff);
+          scr_log_event("RESTART_SUCCESS", NULL, &scr_dataset_id, NULL, &time_t_start, &time_diff);
         }
       } else {
         /* scr_checkpoint_id is not defined */
         scr_dbg(1, "Scalable restart failed, took %f secs", time_diff);
         if (scr_log_enable) {
-          scr_log_event("RESTART FAILED", NULL, NULL, &time_t_start, &time_diff);
+          scr_log_event("RESTART_FAIL", NULL, NULL, NULL, &time_t_start, &time_diff);
         }
       }
     }

--- a/src/scr_conf.h
+++ b/src/scr_conf.h
@@ -46,6 +46,31 @@
 #define SCR_LOG_ENABLE (0)
 #endif
 
+/* whether to enable text file logging in SCR */
+#ifndef SCR_LOG_TXT_ENABLE
+#define SCR_LOG_TXT_ENABLE (1)
+#endif
+
+/* whether to enable syslog logging in SCR */
+#ifndef SCR_LOG_SYSLOG_ENABLE
+#define SCR_LOG_SYSLOG_ENABLE (1)
+#endif
+
+/* text to prepend to syslog messages */
+#ifndef SCR_LOG_SYSLOG_PREFIX
+#define SCR_LOG_SYSLOG_PREFIX "SCR"
+#endif
+
+/* syslog facility */
+#ifndef SCR_LOG_SYSLOG_FACILITY
+#define SCR_LOG_SYSLOG_FACILITY LOG_LOCAL7
+#endif
+
+/* syslog level */
+#ifndef SCR_LOG_SYSLOG_LEVEL
+#define SCR_LOG_SYSLOG_LEVEL LOG_INFO
+#endif
+
 /* default number of halt seconds to apply to a job */
 #ifndef SCR_HALT_SECONDS
 #define SCR_HALT_SECONDS (0)

--- a/src/scr_copy.c
+++ b/src/scr_copy.c
@@ -385,8 +385,7 @@ static int copy_files_for_filemap(
              * rank 0 can write log entries */
             /*
             if (scr_log_enable) {
-              time_t now = scr_log_seconds();
-              scr_log_event("CRC32 MISMATCH", my_flushed_file, NULL, &now, NULL);
+              scr_log_event("CRC32_MISMATCH", my_flushed_file, NULL, NULL, NULL);
             }
             */
           }

--- a/src/scr_globals.c
+++ b/src/scr_globals.c
@@ -89,8 +89,17 @@ int scr_in_output     = 0;              /* flag tracks whether we are between st
 int scr_initialized   = 0;              /* indicates whether the library has been initialized */
 int scr_enabled       = SCR_ENABLE;     /* indicates whether the library is enabled */
 int scr_debug         = SCR_DEBUG;      /* set debug verbosity */
-int scr_log_enable    = SCR_LOG_ENABLE; /* whether to log SCR events */
 int scr_page_size     = 0;              /* records block size for aligning MPI and file buffers */
+
+int scr_log_enable        = SCR_LOG_ENABLE; /* whether to log SCR events at all */
+int scr_log_txt_enable    = 1;              /* whether to log SCR events to text file */
+int scr_log_syslog_enable = 0;              /* whether to log SCR events to syslog */
+int scr_log_db_enable     = 0;              /* whether to log SCR events to database */
+int scr_log_db_debug      = 0;              /* debug level for logging to database */
+char* scr_log_db_host     = NULL;           /* mysql host name */
+char* scr_log_db_user     = NULL;           /* mysql user name */
+char* scr_log_db_pass     = NULL;           /* mysql password */
+char* scr_log_db_name     = NULL;           /* mysql database name */
 
 int scr_cache_size    = SCR_CACHE_SIZE;   /* set number of checkpoints to keep at one time */
 int scr_copy_type     = SCR_COPY_TYPE;    /* select which redundancy algorithm to use */

--- a/src/scr_globals.c
+++ b/src/scr_globals.c
@@ -157,8 +157,7 @@ MPI_Comm scr_comm_world = MPI_COMM_NULL; /* dup of MPI_COMM_WORLD */
 int scr_ranks_world     = 0;             /* number of ranks in the job */
 int  scr_my_rank_world  = MPI_PROC_NULL; /* my rank in world */
 
-MPI_Comm scr_comm_node        = MPI_COMM_NULL; /* communicator of all tasks on the same node */
-MPI_Comm scr_comm_node_across = MPI_COMM_NULL; /* communicator of tasks with same rank on each node */
+MPI_Comm scr_comm_node = MPI_COMM_NULL; /* communicator of all tasks on the same node */
 
 kvtree* scr_groupdesc_hash = NULL; /* hash defining group descriptors to be used */
 kvtree* scr_storedesc_hash = NULL; /* hash defining store descriptors to be used */

--- a/src/scr_globals.c
+++ b/src/scr_globals.c
@@ -91,15 +91,15 @@ int scr_enabled       = SCR_ENABLE;     /* indicates whether the library is enab
 int scr_debug         = SCR_DEBUG;      /* set debug verbosity */
 int scr_page_size     = 0;              /* records block size for aligning MPI and file buffers */
 
-int scr_log_enable        = SCR_LOG_ENABLE; /* whether to log SCR events at all */
-int scr_log_txt_enable    = 1;              /* whether to log SCR events to text file */
-int scr_log_syslog_enable = 0;              /* whether to log SCR events to syslog */
-int scr_log_db_enable     = 0;              /* whether to log SCR events to database */
-int scr_log_db_debug      = 0;              /* debug level for logging to database */
-char* scr_log_db_host     = NULL;           /* mysql host name */
-char* scr_log_db_user     = NULL;           /* mysql user name */
-char* scr_log_db_pass     = NULL;           /* mysql password */
-char* scr_log_db_name     = NULL;           /* mysql database name */
+int scr_log_enable        = SCR_LOG_ENABLE;        /* whether to log SCR events at all */
+int scr_log_txt_enable    = SCR_LOG_TXT_ENABLE;    /* whether to log SCR events to text file */
+int scr_log_syslog_enable = SCR_LOG_SYSLOG_ENABLE; /* whether to log SCR events to syslog */
+int scr_log_db_enable     = 0;                     /* whether to log SCR events to database */
+int scr_log_db_debug      = 0;                     /* debug level for logging to database */
+char* scr_log_db_host     = NULL;                  /* mysql host name */
+char* scr_log_db_user     = NULL;                  /* mysql user name */
+char* scr_log_db_pass     = NULL;                  /* mysql password */
+char* scr_log_db_name     = NULL;                  /* mysql database name */
 
 int scr_cache_size    = SCR_CACHE_SIZE;   /* set number of checkpoints to keep at one time */
 int scr_copy_type     = SCR_COPY_TYPE;    /* select which redundancy algorithm to use */
@@ -140,14 +140,6 @@ double scr_checkpoint_overhead = SCR_CHECKPOINT_OVERHEAD; /* max allowed overhea
 int    scr_need_checkpoint_count = 0;   /* tracks the number of times Need_checkpoint has been called */
 double scr_time_checkpoint_total = 0.0; /* keeps a running total of the time spent to checkpoint */
 int    scr_time_checkpoint_count = 0;   /* keeps a running count of the number of checkpoints taken */
-
-time_t scr_timestamp_checkpoint_start;  /* record timestamp of start of checkpoint */
-double scr_time_checkpoint_start;       /* records the start time of the current checkpoint */
-double scr_time_checkpoint_end;         /* records the end time of the current checkpoint */
-
-time_t scr_timestamp_compute_start;     /* record timestamp of start of compute phase */
-double scr_time_compute_start;          /* records the start time of the current compute phase */
-double scr_time_compute_end;            /* records the end time of the current compute phase */
 
 char* scr_my_hostname  = NULL; /* hostname of local process */
 int   scr_my_hostid    = MPI_PROC_NULL; /* unique identifier of the node on which this rank resides */

--- a/src/scr_globals.h
+++ b/src/scr_globals.h
@@ -213,8 +213,7 @@ extern MPI_Comm scr_comm_world;   /* dup of MPI_COMM_WORLD */
 extern int scr_ranks_world;       /* number of ranks in the job */
 extern int  scr_my_rank_world;    /* my rank in world */
 
-extern MPI_Comm scr_comm_node;        /* communicator of all tasks on the same node */
-extern MPI_Comm scr_comm_node_across; /* communicator of tasks with same rank on each node */
+extern MPI_Comm scr_comm_node; /* communicator of all tasks on the same node */
 
 extern kvtree* scr_groupdesc_hash; /* hash defining group descriptors to be used */
 extern kvtree* scr_storedesc_hash; /* hash defining store descriptors to be used */

--- a/src/scr_globals.h
+++ b/src/scr_globals.h
@@ -145,8 +145,17 @@ extern int scr_in_output;     /* flag tracks whether we are between start and co
 extern int scr_initialized;   /* indicates whether the library has been initialized */
 extern int scr_enabled;       /* indicates whether the library is enabled */
 extern int scr_debug;         /* set debug verbosity */
-extern int scr_log_enable;    /* whether to log SCR events */
 extern int scr_page_size;     /* records block size for aligning MPI and file buffers */
+
+extern int scr_log_enable;        /* whether to log SCR events at all */
+extern int scr_log_txt_enable;    /* whether to log SCR events to text file */
+extern int scr_log_syslog_enable; /* whether to log SCR events to syslog */
+extern int scr_log_db_enable;     /* whether to log SCR events to database */
+extern int scr_log_db_debug;      /* debug level for logging to database */
+extern char* scr_log_db_host;     /* mysql host name */
+extern char* scr_log_db_user;     /* mysql user name */
+extern char* scr_log_db_pass;     /* mysql password */
+extern char* scr_log_db_name;     /* mysql database name */
 
 extern int scr_cache_size;    /* number of checkpoints to keep in cache at one time */
 extern int scr_copy_type;     /* select which redundancy algorithm to use */

--- a/src/scr_globals.h
+++ b/src/scr_globals.h
@@ -197,14 +197,6 @@ extern int    scr_need_checkpoint_count; /* tracks the number of times Need_chec
 extern double scr_time_checkpoint_total; /* keeps a running total of the time spent to checkpoint */
 extern int    scr_time_checkpoint_count; /* keeps a running count of the number of checkpoints taken */
 
-extern time_t scr_timestamp_checkpoint_start; /* record timestamp of start of checkpoint */
-extern double scr_time_checkpoint_start;      /* records the start time of the current checkpoint */
-extern double scr_time_checkpoint_end;        /* records the end time of the current checkpoint */
-
-extern time_t scr_timestamp_compute_start;    /* record timestamp of start of compute phase */
-extern double scr_time_compute_start;         /* records the start time of the current compute phase */
-extern double scr_time_compute_end;           /* records the end time of the current compute phase */
-
 extern char* scr_my_hostname; /* hostname of local process */
 extern int   scr_my_hostid;   /* unique id of the node on which this rank resides */
 extern int   scr_my_rank_host; /* my rank within the node */

--- a/src/scr_log.c
+++ b/src/scr_log.c
@@ -846,26 +846,26 @@ int scr_log_init(const char* prefix)
   }
 
   /* check whether SCR logging DB is enabled */
-  if ((value = scr_param_get("SCR_DB_ENABLE")) != NULL) {
+  if ((value = scr_param_get("SCR_LOG_DB_ENABLE")) != NULL) {
     db_enable = atoi(value);
   }
 
   /* read in the debug level for database log messages */
-  if ((value = scr_param_get("SCR_DB_DEBUG")) != NULL) {
+  if ((value = scr_param_get("SCR_LOG_DB_DEBUG")) != NULL) {
     db_debug = atoi(value);
   }
 
   /* SCR log DB connection parameters */
-  if ((value = scr_param_get("SCR_DB_HOST")) != NULL) {
+  if ((value = scr_param_get("SCR_LOG_DB_HOST")) != NULL) {
     db_host = strdup(value);
   }
-  if ((value = scr_param_get("SCR_DB_USER")) != NULL) {
+  if ((value = scr_param_get("SCR_LOG_DB_USER")) != NULL) {
     db_user = strdup(value);
   }
-  if ((value = scr_param_get("SCR_DB_PASS")) != NULL) {
+  if ((value = scr_param_get("SCR_LOG_DB_PASS")) != NULL) {
     db_pass = strdup(value);
   }
-  if ((value = scr_param_get("SCR_DB_NAME")) != NULL) {
+  if ((value = scr_param_get("SCR_LOG_DB_NAME")) != NULL) {
     db_name = strdup(value);
   }
 

--- a/src/scr_log.h
+++ b/src/scr_log.h
@@ -47,6 +47,21 @@ extern char* scr_db_name;
 /* returns the current linux timestamp */
 time_t scr_log_seconds(void);
 
+/* initialize text file logging in prefix directory */
+int scr_log_init_txt(const char* prefix);
+
+/* initialize syslog logging */
+int scr_log_init_syslog(void);
+
+/* initialize the mysql database logging */
+int scr_log_init_db(
+  int debug,
+  const char* host,
+  const char* user,
+  const char* pass,
+  const char* name
+);
+
 /* initialize the logging */
 int scr_log_init(const char* prefix);
 

--- a/src/scr_log.h
+++ b/src/scr_log.h
@@ -68,27 +68,51 @@ int scr_log_init(const char* prefix);
 /* shut down the logging */
 int scr_log_finalize(void);
 
-/* given a username, a jobname, and a start time, lookup (or create) the id for this job */
-int scr_log_job(const char* username, const char* jobname, time_t start);
+/* register a job with a username and prefix directory,
+ * also take the hostname, jobid, and start time to capture
+ * some state of the current run */
+int scr_log_job(
+  const char* username,
+  const char* hostname,
+  const char* jobid,
+  const char* prefix,
+  time_t start
+);
 
-/* log start time of current run */
-int scr_log_run(time_t start);
+/* log start time of current run along with
+ * its number of procs and nodes */
+int scr_log_run(
+  time_t start,
+  int procs,
+  int nodes
+);
 
 /* log reason and time for halting current run */
-int scr_log_halt(const char* reason, const int* ckpt);
+int scr_log_halt(
+  const char* reason
+);
 
 /* log an event */
-int scr_log_event(const char* type, const char* note, const int* ckpt, const time_t* start, const double* secs);
+int scr_log_event(
+  const char* type,
+  const char* note,
+  const int* dset,
+  const char* name,
+  const time_t* start,
+  const double* secs
+);
 
 /* log a transfer: copy / checkpoint / fetch / flush */
 int scr_log_transfer(
   const char* type,
   const char* from,
   const char* to,
-  const int* ckpt_id,
+  const int* dset,
+  const char* name,
   const time_t* start,
   const double* secs,
-  const double* bytes
+  const double* bytes,
+  const int* files
 );
 
 #endif

--- a/src/scr_log.h
+++ b/src/scr_log.h
@@ -48,7 +48,7 @@ extern char* scr_db_name;
 time_t scr_log_seconds(void);
 
 /* initialize the logging */
-int scr_log_init(void);
+int scr_log_init(const char* prefix);
 
 /* shut down the logging */
 int scr_log_finalize(void);
@@ -66,7 +66,14 @@ int scr_log_halt(const char* reason, const int* ckpt);
 int scr_log_event(const char* type, const char* note, const int* ckpt, const time_t* start, const double* secs);
 
 /* log a transfer: copy / checkpoint / fetch / flush */
-int scr_log_transfer(const char* type, const char* from, const char* to,
-                     const int* ckpt_id, const time_t* start, const double* secs, const double* bytes);
+int scr_log_transfer(
+  const char* type,
+  const char* from,
+  const char* to,
+  const int* ckpt_id,
+  const time_t* start,
+  const double* secs,
+  const double* bytes
+);
 
 #endif

--- a/src/scr_reddesc.h
+++ b/src/scr_reddesc.h
@@ -105,12 +105,11 @@ scr_storedesc* scr_reddesc_get_store(
   const scr_reddesc* desc
 );
 
-/* apply redundancy scheme to file and return number of bytes copied in bytes parameter */
+/* apply redundancy scheme to files */
 int scr_reddesc_apply(
   scr_filemap* map,
   const scr_reddesc* c,
-  int id,
-  double* bytes
+  int id
 );
 
 /* rebuilds files for specified dataset id using specified redundancy descriptor,


### PR DESCRIPTION
This adds a simple text file as a log option, enabled with ```SCR_LOG_TXT_ENABLE=1```.  The text file will live in the hidden .scr directory of the job's prefix directory.  Records are appended one line at a time.  Example output:
```
>>: cat $SCR_PREFIX/.scr/log
2020-05-26T23:19:40: host=quartz28, jobid=5275576, event="START"
2020-05-26T23:19:40: host=quartz28, jobid=5275576, event="COMPUTE STARTED", note="(null)", dset=1, secs=0.000000
2020-05-26T23:19:40: host=quartz28, jobid=5275576, event="COMPUTE COMPLETED", note="(null)", dset=1, secs=0.002699
2020-05-26T23:19:40: host=quartz28, jobid=5275576, event="CHECKPOINT STARTED", note="/dev/shm", dset=1, secs=0.000000
2020-05-26T23:19:40: host=quartz28, jobid=5275576, event="CHECKPOINT COMPLETED", note="/dev/shm", dset=1, secs=0.029750
2020-05-26T23:19:40: host=quartz28, jobid=5275576, xfer="CHECKPOINT", from="/dev/shm", to="/dev/shm/user1/scr.5275576/scr.dataset.1", dset=1 secs=0.029750, bytes=0.000000
2020-05-26T23:19:40: host=quartz28, jobid=5275576, event="FLUSH STARTED", note="(null)", dset=1, secs=0.000000
2020-05-26T23:19:40: host=quartz28, jobid=5275576, event="FLUSH SUCCEEDED", note="(null)", dset=1, secs=0.030232
...
2020-05-26T23:19:40: host=quartz28, jobid=5275576, event="HALT", note="SCR_FINALIZE_CALLED", dset=6
```

Adds a syslog option, enabled by ```SCR_LOG_SYSLOG_ENABLE=1```.

Resolves: https://github.com/LLNL/scr/issues/50