### PR TITLE
scr_index: define --add option to insert dataset into index

### DIFF
--- a/doc/rst/users/manage.rst
+++ b/doc/rst/users/manage.rst
@@ -25,23 +25,41 @@ or otherwise, one may specify a prefix directory using the ":code:`--prefix`" op
 The default behavior of :code:`scr_index` is to list the contents of the index file, e.g.::
 
   >>: scr_index
-     DSET VALID FLUSHED             NAME
-  *    18 YES   2014-01-14T11:26:06 ckpt.18
-       12 YES   2014-01-14T10:28:23 ckpt.12
-        6 YES   2014-01-14T09:27:15 ckpt.6
+  DSET VALID FLUSHED             CUR NAME
+    18 YES   2014-01-14T11:26:06   * ckpt.18
+    12 YES   2014-01-14T10:28:23     ckpt.12
+     6 YES   2014-01-14T09:27:15     ckpt.6
 
-When listing datasets, the internal SCR dataset id is shown,
-followed by a field indicating whether the dataset is valid,
+When listing datasets, :code:`scr_index` lists a field indicating whether the dataset is valid,
 the time it was flushed to the parallel file system,
 and finally the dataset name.
 
 One checkpoint may also be marked as "current".
 When restarting a job, the SCR library starts from the current dataset and works backwards.
-The current dataset is denoted with a leading :code:`*` character.
+The current dataset is denoted with a leading :code:`*` character in the :code:`CUR` column.
 One can change the current checkpoint using the :code:`--current` option,
 providing the dataset name as an argument.::
 
   scr_index --current ckpt.12
+
+If no dataset is marked as current,
+SCR starts with most recent checkpoint that is valid.
+
+One may drop entries from the index file using the ":code:`--drop`" option.
+This operation does not delete the corresponding dataset files.
+It only drops the entry from the :code:`index.scr` file.::
+
+  scr_index --drop ckpt.50
+
+This is useful if one deletes a dataset from the parallel file system
+and then wishes to update the index.
+
+If an entry is removed inadvertently, one may add it back with::
+
+  scr_index --add ckpt.50
+
+This requires all SCR metadata files to exist in their associated :code:`scr.dataset` subdirectory
+within the hidden :code:`.scr` directory within the prefix directory.
 
 In most cases, the SCR library or the SCR commands add all necessary entries to the index file.
 However, there are cases where they may fail.
@@ -49,7 +67,7 @@ In particular, if the :code:`scr_postrun` command successfully scavenges a datas
 but the resource allocation ends before the command can rebuild missing files,
 an entry may be missing from the index file.
 In such cases, one may manually add the corresponding entry
-using the ":code:`--add`" option.
+using the ":code:`--build`" option.
 
 When adding a new dataset to the index file,
 the :code:`scr_index` command checks whether the files in a dataset
@@ -60,13 +78,5 @@ One must provide the SCR dataset id as an argument.
 To obtain the SCR dataset id value, lookup the trailing integer on the names of :code:`scr.dataset` subdirectories
 in the hidden :code:`.scr` directory within the prefix directory.::
 
-  scr_index --add 50
+  scr_index --build 50
 
-One may remove entries from the index file using the ":code:`--remove`" option.
-This operation does not delete the corresponding dataset files.
-It only deletes the entry from the :code:`index.scr` file.::
-
-  scr_index --remove ckpt.50
-
-This is useful if one deletes a dataset from the parallel file system
-and then wishes to update the index.

--- a/examples/test_api.c
+++ b/examples/test_api.c
@@ -380,7 +380,6 @@ void print_usage()
   printf("    -p, --path=<DIR>     Directory to create and write files to\n");
   printf("    -f, --flush=<COUNT>  Mark every Nth write as checkpoint+output (default %d)\n", ckptout);
   printf("    -o, --output=<COUNT> Mark every Nth write as pure output (default %d)\n", output);
-  printf("    -o, --output=<COUNT> Mark every Nth write as pure output (default %d)\n", output);
   printf("    -a, --config-api=<BOOL> Use SCR_Config to set values (default %s)\n", btoa(use_config_api));
   printf("    -c, --conf-file=<BOOL> Use SCR_CONF_FILE file to set values (default %s)\n", btoa(use_conf_file));
   printf("    -h, --help           Print usage\n");

--- a/scripts/common/scr_postrun.in
+++ b/scripts/common/scr_postrun.in
@@ -141,8 +141,8 @@ if [ "$UPNODES" != "" ] ; then
           # if not, don't update current marker
           update_current=1
           echo "$prog: Checking that dataset is complete"
-          echo "$bindir/scr_index --prefix $pardir --add $d"
-          $bindir/scr_index --prefix $pardir --add $d
+          echo "$bindir/scr_index --prefix $pardir --build $d"
+          $bindir/scr_index --prefix $pardir --build $d
           if [ $? -ne 0 ] ; then
             # failed to get dataset, stop trying for later sets
             failed_dataset=$d
@@ -215,8 +215,8 @@ if [ "$UPNODES" != "" ] ; then
           # if not, don't update current marker
           update_current=1
           echo "$prog: Checking that dataset is complete"
-          echo "$bindir/scr_index --prefix $pardir --add $d"
-          $bindir/scr_index --prefix $pardir --add $d
+          echo "$bindir/scr_index --prefix $pardir --build $d"
+          $bindir/scr_index --prefix $pardir --build $d
           if [ $? -ne 0 ] ; then
             # incomplete dataset, don't update current marker
             update_current=0


### PR DESCRIPTION
Picks up changes to scr_index output which started here https://github.com/LLNL/scr/pull/176

After discussions with some users, having a way to expose the DSET id could be helpful.  Adding it back for now.

Current output looks like:
```
DSET VALID FLUSHED             CUR NAME
   6 YES   2020-06-27T15:05:36   * ckpt.6
   5 YES   2020-06-27T15:05:36     ckpt.5
```
TODO: We should probably list which items are checkpoints vs pure output in some field.  It might also be handy to show size and number of files (to encourage people to delete stuff).