### PR TITLE
Logfix

### DIFF
--- a/src/scr.c
+++ b/src/scr.c
@@ -2113,6 +2113,10 @@ int SCR_Finalize()
     return SCR_FAILURE;
   }
 
+  /* this is not required, but it helps ensure apps
+   * are calling this as a collective */
+  MPI_Barrier(scr_comm_world);
+
   if (scr_my_rank_world == 0) {
     /* stop the clock for measuring the compute time */
     scr_time_compute_end = MPI_Wtime();
@@ -2299,6 +2303,10 @@ int SCR_Need_checkpoint(int* flag)
     );
     return SCR_FAILURE;
   }
+
+  /* this is not required, but it helps ensure apps
+   * are calling this as a collective */
+  MPI_Barrier(scr_comm_world);
 
   /* track the number of times a user has called SCR_Need_checkpoint */
   scr_need_checkpoint_count++;
@@ -2723,6 +2731,10 @@ int SCR_Have_restart(int* flag, char* name)
     return SCR_FAILURE;
   }
 
+  /* this is not required, but it helps ensure apps
+   * are calling this as a collective */
+  MPI_Barrier(scr_comm_world);
+
   /* TODO: a more proper check would be to examine the filemap, perhaps across ranks */
 
   /* set flag depending on whether checkpoint_id is greater than 0,
@@ -2772,6 +2784,10 @@ int SCR_Start_restart(char* name)
     );
     return SCR_FAILURE;
   }
+
+  /* this is not required, but it helps ensure apps
+   * are calling this as a collective */
+  MPI_Barrier(scr_comm_world);
 
   /* bail out if there is no checkpoint to restart from */
   if (! scr_have_restart) {
@@ -2968,6 +2984,10 @@ int SCR_Should_exit(int* flag)
     );
     return SCR_FAILURE;
   }
+
+  /* this is not required, but it helps ensure apps
+   * are calling this as a collective */
+  MPI_Barrier(scr_comm_world);
 
   /* check that we have a flag variable to write to */
   if (flag == NULL) {

--- a/src/scr.c
+++ b/src/scr.c
@@ -151,7 +151,9 @@ static int scr_halt(const char* reason)
   }
 
   /* log the halt condition */
-  scr_log_halt(reason);
+  if (scr_log_enable) {
+    scr_log_halt(reason);
+  }
 
   /* and write out the halt file */
   int rc = scr_halt_sync_and_decrement(scr_halt_file, scr_halt_hash, 0);


### PR DESCRIPTION
Two commits here.

The first is to force people to call the collective APIs as a collective.  Some would work even with a single process, so that someone might only call with rank 0 and think they have a valid implementation.  This adds some extra communication, but it should help enforce people are using the API appropriately.

The second adds a missing check that logging is enabled before trying to add an entry for a halt event.