### PR TITLE
Pfsdelete

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -35,6 +35,7 @@ LIST(APPEND libscr_srcs
 	scr.c
 	scr_cache.c
 	scr_cache_rebuild.c
+	scr_cache_index.c
 	scr_config.c
 	scr_config_mpi.c
 	scr_dataset.c
@@ -42,7 +43,6 @@ LIST(APPEND libscr_srcs
 	scr_env.c
 	scr_err_mpi.c
 	scr_fetch.c
-	scr_cache_index.c
 	scr_filemap.c
 	scr_flush.c
 	scr_flush_file_mpi.c
@@ -56,6 +56,7 @@ LIST(APPEND libscr_srcs
 	scr_log.c
 	scr_meta.c
 	scr_param.c
+	scr_prefix.c
 	scr_reddesc.c
 	scr_storedesc.c
 	scr_summary.c

--- a/src/scr.h
+++ b/src/scr.h
@@ -104,6 +104,16 @@ int SCR_Start_output(const char* name, int flags);
 int SCR_Complete_output(int valid);
 
 /*****************
+ * Dataset management routines
+ ****************/
+
+/* drop named dataset from index */
+int SCR_Drop(const char* name);
+
+/* delete files for named dataset */
+int SCR_Delete(const char* name);
+
+/*****************
  * Environment and configuration routines
  ****************/
 

--- a/src/scr_cache.h
+++ b/src/scr_cache.h
@@ -44,6 +44,9 @@ int scr_cache_dir_create(const scr_reddesc* reddesc, int id);
 /* remove all files associated with specified dataset */
 int scr_cache_delete(scr_cache_index* cindex, int id);
 
+/* delete dataset with matching name from cache, if one exists */
+int scr_cache_delete_by_name(scr_cache_index* cindex, const char* name);
+
 /* each process passes in an ordered list of dataset ids along with a current
  * index, this function identifies the next smallest id across all processes
  * and returns this id in current, it also updates index on processes as

--- a/src/scr_cache_index.c
+++ b/src/scr_cache_index.c
@@ -77,14 +77,6 @@ static int scr_cache_index_unset_if_empty(scr_cache_index* cindex, int dset)
   return SCR_SUCCESS;
 }
 
-/* returns the CURRENT name */
-int scr_cache_index_get_current(const kvtree* h, char** current)
-{
-  int kvtree_rc = kvtree_util_get_str(h, SCR_CINDEX_KEY_CURRENT, current);
-  int rc = (kvtree_rc == KVTREE_SUCCESS) ? SCR_SUCCESS : SCR_FAILURE;
-  return rc;
-}
-
 /* set the CURRENT name, used to rememeber if we already proccessed
  * a SCR_CURRENT name a user may have provided to set the current value,
  * we ignore that request in later runs and use this marker to remember */
@@ -92,6 +84,14 @@ int scr_cache_index_set_current(const kvtree* h, const char* current)
 {
   kvtree_util_set_str(h, SCR_CINDEX_KEY_CURRENT, current);
   return SCR_SUCCESS;
+}
+
+/* returns the CURRENT name */
+int scr_cache_index_get_current(const kvtree* h, char** current)
+{
+  int kvtree_rc = kvtree_util_get_str(h, SCR_CINDEX_KEY_CURRENT, current);
+  int rc = (kvtree_rc == KVTREE_SUCCESS) ? SCR_SUCCESS : SCR_FAILURE;
+  return rc;
 }
 
 /* sets the dataset hash for the given dataset id */

--- a/src/scr_cache_index.h
+++ b/src/scr_cache_index.h
@@ -49,13 +49,13 @@ Cache index set/get/unset data functions
 =========================================
 */
 
-/* returns the CURRENT name */
-int scr_cache_index_get_current(const kvtree* h, char** current);
-
 /* set the CURRENT name, used to rememeber if we already proccessed
  * a SCR_CURRENT name a user may have provided to set the current value,
  * we ignore that request in later runs and use this marker to remember */
 int scr_cache_index_set_current(const kvtree* h, const char* current);
+
+/* returns the CURRENT name */
+int scr_cache_index_get_current(const kvtree* h, char** current);
 
 /* sets the dataset hash for the given dataset id */
 int scr_cache_index_set_dataset(scr_cache_index* cindex, int dset, kvtree* hash);

--- a/src/scr_conf.h
+++ b/src/scr_conf.h
@@ -205,6 +205,11 @@
 #define SCR_FLUSH_ASYNC_PERCENT (0.0) /* TODO: the fsync complicates this throttling, disable it for now */
 #endif
 
+/* max number of checkpoints to keep in prefix (0 disables) */
+#ifndef SCR_PREFIX_SIZE
+#define SCR_PREFIX_SIZE (0)
+#endif
+
 /* =========================================================================
  * Default checksum settings.
  * ========================================================================= */

--- a/src/scr_flush.h
+++ b/src/scr_flush.h
@@ -13,7 +13,7 @@
 #define SCR_FLUSH_H
 
 #include "kvtree.h"
-#include "scr_filemap.h"
+#include "scr_cache_index.h"
 
 /* given file list from flush_prepare, allocate and fill in arrays for filo,
  * caller should free arrays with call to filolist_free*/
@@ -31,11 +31,11 @@ char* scr_flush_dataset_metadir(const scr_dataset* dataset);
  * it as incomplete */
 int scr_flush_init_index(scr_dataset* dataset);
 
-/* given a filemap and a dataset id, prepare and return a list of files to be flushed */
-int scr_flush_prepare(const scr_filemap* map, int id, kvtree* file_list);
+/* given a cache index and a dataset id, prepare and return a list of files to be flushed */
+int scr_flush_prepare(const scr_cache_index* cindex, int id, kvtree* file_list);
 
 /* given a dataset id that has been flushed and the list provided by scr_flush_prepare,
  * complete the flush by writing the summary file */
-int scr_flush_complete(int id, kvtree* file_list);
+int scr_flush_complete(const scr_cache_index* cindex, int id, kvtree* file_list);
 
 #endif

--- a/src/scr_flush_async.c
+++ b/src/scr_flush_async.c
@@ -95,7 +95,7 @@ int scr_flush_async_start(scr_cache_index* cindex, int id)
 
   /* this may take a while, so tell user what we're doing */
   if (scr_my_rank_world == 0) {
-    scr_dbg(1, "Initiating flush of dataset %d %s", id, dset_name);
+    scr_dbg(1, "Initiating async flush of dataset %d `%s'", id, dset_name);
   }
 
   /* make sure all processes make it this far before progressing */
@@ -247,7 +247,7 @@ int scr_flush_async_complete(scr_cache_index* cindex, int id)
 
   /* write summary file */
   if (scr_flush_async_flushed == SCR_SUCCESS &&
-      scr_flush_complete(id, scr_flush_async_file_list) != SCR_SUCCESS)
+      scr_flush_complete(cindex, id, scr_flush_async_file_list) != SCR_SUCCESS)
   {
     scr_flush_async_flushed = SCR_FAILURE;
   }
@@ -294,7 +294,7 @@ int scr_flush_async_complete(scr_cache_index* cindex, int id)
     /* log messages about flush */
     if (scr_flush_async_flushed == SCR_SUCCESS) {
       /* the flush worked, print a debug message */
-      scr_dbg(1, "scr_flush_async_complete: Flush of dataset succeeded %d %s", id, dset_name);
+      scr_dbg(1, "scr_flush_async_complete: Flush of dataset succeeded %d `%s'", id, dset_name);
 
       /* log details of flush */
       if (scr_log_enable) {
@@ -302,7 +302,7 @@ int scr_flush_async_complete(scr_cache_index* cindex, int id)
       }
     } else {
       /* the flush failed, this is more serious so print an error message */
-      scr_err("scr_flush_async_complete: Flush of dataset failed %d %s", id, dset_name);
+      scr_err("scr_flush_async_complete: Flush of dataset failed %d `%s'", id, dset_name);
 
       /* log details of flush */
       if (scr_log_enable) {

--- a/src/scr_flush_sync.c
+++ b/src/scr_flush_sync.c
@@ -116,7 +116,7 @@ int scr_flush_sync(scr_cache_index* cindex, int id)
 
   /* this may take a while, so tell user what we're doing */
   if (scr_my_rank_world == 0) {
-    scr_dbg(1, "Initiating flush of dataset %d %s", id, dset_name);
+    scr_dbg(1, "Initiating flush of dataset %d `%s'", id, dset_name);
   }
 
   /* make sure all processes make it this far before progressing */
@@ -169,7 +169,7 @@ int scr_flush_sync(scr_cache_index* cindex, int id)
 
   /* write summary file */
   if (flushed == SCR_SUCCESS &&
-      scr_flush_complete(id, file_list) != SCR_SUCCESS)
+      scr_flush_complete(cindex, id, file_list) != SCR_SUCCESS)
   {
     flushed = SCR_FAILURE;
   }
@@ -207,7 +207,7 @@ int scr_flush_sync(scr_cache_index* cindex, int id)
     /* log messages about flush */
     if (flushed == SCR_SUCCESS) {
       /* the flush worked, print a debug message */
-      scr_dbg(1, "scr_flush_sync: Flush of dataset succeeded %d %s", id, dset_name);
+      scr_dbg(1, "scr_flush_sync: Flush of dataset succeeded %d `%s'", id, dset_name);
 
       /* log details of flush */
       if (scr_log_enable) {
@@ -215,7 +215,7 @@ int scr_flush_sync(scr_cache_index* cindex, int id)
       }
     } else {
       /* the flush failed, this is more serious so print an error message */
-      scr_err("scr_flush_sync: Flush of dataset failed %d %s", id, dset_name);
+      scr_err("scr_flush_sync: Flush of dataset failed %d `%s'", id, dset_name);
 
       /* log details of flush */
       if (scr_log_enable) {

--- a/src/scr_globals.c
+++ b/src/scr_globals.c
@@ -130,6 +130,8 @@ int    scr_flush_async_in_progress = 0;                       /* tracks whether 
 int    scr_flush_async_dataset_id  = -1;                      /* tracks the id of the checkpoint being flushed */
 double scr_flush_async_bytes       = 0.0;                     /* records the total number of bytes to be flushed */
 
+int scr_prefix_size = SCR_PREFIX_SIZE; /* max number of checkpoints to keep in prefix directory */
+
 int scr_crc_on_copy   = SCR_CRC_ON_COPY;   /* whether to enable crc32 checks during scr_swap_files() */
 int scr_crc_on_flush  = SCR_CRC_ON_FLUSH;  /* whether to enable crc32 checks during flush and fetch */
 int scr_crc_on_delete = SCR_CRC_ON_DELETE; /* whether to enable crc32 checks when deleting checkpoints */

--- a/src/scr_globals.h
+++ b/src/scr_globals.h
@@ -97,6 +97,7 @@
 #include "scr_flush_file_mpi.h"
 #include "scr_cache.h"
 #include "scr_cache_rebuild.h"
+#include "scr_prefix.h"
 #include "scr_fetch.h"
 #include "scr_flush.h"
 #include "scr_flush_sync.h"
@@ -179,6 +180,8 @@ extern int   scr_flush;            /* how many checkpoints between flushes */
 extern int   scr_flush_width;      /* specify number of processes to write files simultaneously */
 extern int   scr_flush_on_restart; /* specify whether to flush cache on restart */
 extern int   scr_global_restart;   /* set if code must be restarted from parallel file system */
+
+extern int scr_prefix_size; /* max number of checkpoints to keep in prefix directory */
 
 extern int scr_flush_async;             /* whether to use asynchronous flush */
 extern double scr_flush_async_bw;       /* bandwidth limit imposed during async flush */

--- a/src/scr_index_api.c
+++ b/src/scr_index_api.c
@@ -449,6 +449,26 @@ int scr_index_mark_flushed(kvtree* index, int id, const char* name)
   return SCR_SUCCESS;
 }
 
+/* copy dataset into given dataset object,
+ * returns SCR_FAILURE if not found */
+int scr_index_get_dataset(kvtree* index, int id, const char* name, scr_dataset* dataset)
+{
+  int rc = SCR_FAILURE;
+
+  /* get pointer to dataset hash */
+  kvtree* dset_hash = kvtree_get_kv_int(index, SCR_INDEX_1_KEY_DATASET, id);
+
+  /* lookup dataset hash in index */
+  kvtree* dset = kvtree_get(dset_hash, SCR_INDEX_1_KEY_DATASET);
+  if (dset != NULL) {
+    /* found it, copy contents of dataset hash */
+    kvtree_merge(dataset, dset);
+    rc = SCR_SUCCESS;
+  }
+
+  return rc;
+}
+
 /* get completeness code for given dataset id and name in given hash,
  * sets complete=0 and returns SCR_FAILURE if key is not set */
 int scr_index_get_complete(kvtree* index, int id, const char* name, int* complete)
@@ -512,7 +532,7 @@ int scr_index_get_most_recent_complete(const kvtree* index, int earlier_than, in
 
     /* if we have a limit and the current id is beyond that limit,
      * skip it */
-    if (earlier_than != -1 && current_id > earlier_than) {
+    if (earlier_than != -1 && current_id >= earlier_than) {
       continue;
     }
 
@@ -559,13 +579,13 @@ int scr_index_get_most_recent_complete(const kvtree* index, int earlier_than, in
     }
 
     /* get the name of the dataset */
-    char* name;
-    scr_dataset_get_name(dataset_hash, &name);
+    char* current_name;
+    scr_dataset_get_name(dataset_hash, &current_name);
 
     /* if we found one, copy the dataset id and name, and update our max */
     if (found_one) {
       *id = current_id;
-      strcpy(name, name);
+      strcpy(name, current_name);
 
       /* update our max */
       max_id = current_id;

--- a/src/scr_index_api.h
+++ b/src/scr_index_api.h
@@ -59,6 +59,10 @@ int scr_index_clear_failed(kvtree* index, int id, const char* name);
 /* record flush time for given dataset id and name in given hash */
 int scr_index_mark_flushed(kvtree* index, int id, const char* name);
 
+/* copy dataset into given dataset object,
+ * returns SCR_FAILURE if key is not set */
+int scr_index_get_dataset(kvtree* index, int id, const char* name, scr_dataset* dataset);
+
 /* get completeness code for given dataset id and name in given hash,
  * sets complete=0 and returns SCR_FAILURE if key is not set */
 int scr_index_get_complete(kvtree* index, int id, const char* name, int* complete);

--- a/src/scr_prefix.c
+++ b/src/scr_prefix.c
@@ -1,0 +1,423 @@
+/*
+ * Copyright (c) 2009, Lawrence Livermore National Security, LLC.
+ * Produced at the Lawrence Livermore National Laboratory.
+ * Written by Adam Moody <moody20@llnl.gov>.
+ * LLNL-CODE-411039.
+ * All rights reserved.
+ * This file is part of The Scalable Checkpoint / Restart (SCR) library.
+ * For details, see https://sourceforge.net/projects/scalablecr/
+ * Please also read this file: LICENSE.TXT.
+*/
+
+#include "scr_globals.h"
+#include "scr_cache_index.h"
+#include "scr_storedesc.h"
+
+#include "spath.h"
+#include "kvtree.h"
+#include "dtcmp.h"
+
+#include <sys/types.h>
+#include <dirent.h>
+
+/* delete named dataset from index file in prefix directory */
+static int scr_prefix_remove_index(const char* name)
+{
+  /* delete from index file */
+  if (scr_my_rank_world == 0) {
+      /* read the index file */
+      kvtree* index_hash = kvtree_new();
+      if (scr_index_read(scr_prefix_path, index_hash) == SCR_SUCCESS) {
+        /* if there is an entry for this dataset, remove it */
+        int id;
+        if (scr_index_get_id_by_name(index_hash, name, &id) == SCR_SUCCESS) {
+          /* found an entry, remove it and update the index file */
+          scr_index_remove(index_hash, name);
+          scr_index_write(scr_prefix_path, index_hash);
+        }
+      }
+      kvtree_delete(&index_hash);
+  }
+
+  /* hold everyone until delete is complete */
+  MPI_Barrier(scr_comm_world);
+
+  return SCR_SUCCESS;
+}
+
+/* open dirname, scan entries, and delete them */
+static int scr_prefix_rmscan(const char* dirname)
+{
+  int rc = SCR_SUCCESS;
+
+  /* scan over all items in the directory and delete them */
+  DIR* dirp = opendir(dirname);
+  if (dirp != NULL) {
+    /* opened the directory, now scan over each item */
+    struct dirent* de;
+    while (de = readdir(dirp)) {
+      /* get name of the current item */
+      char* name = de->d_name;
+
+      /* skip "." and ".." */
+      if (strcmp(name, ".")  == 0 ||
+          strcmp(name, "..") == 0)
+      {
+        continue;
+      }
+
+      /* got an item, build full path to it */
+      spath* path = spath_from_str(dirname);
+      spath_append_str(path, name);
+      char* item = spath_strdup(path);
+      spath_delete(&path);
+
+      /* delete the item */
+      scr_file_unlink(item);
+
+      scr_free(&item);
+    }
+
+    /* done deleting stuff from this directory */
+    closedir(dirp);
+  }
+
+  /* delete scr dataset directory itself */
+  scr_rmdir(dirname);
+
+  return rc;
+}
+
+/* deletes user data files from prefix directory for named dataset */
+static int scr_prefix_delete_data(int id)
+{
+  int rc = SCR_SUCCESS;
+
+  /* build path to dataset directory under prefix */
+  spath* dataset_path = spath_from_str(scr_prefix_scr);
+  spath_append_strf(dataset_path, "scr.dataset.%d", id);
+
+  /* TODO: this is stepping on Filo internals */
+  /* build path to rank2file */
+  spath* rank2file_path = spath_dup(dataset_path);
+  spath_append_str(rank2file_path, "rank2file");
+  const char* rank2file = spath_strdup(rank2file_path);
+  spath_delete(&rank2file_path);
+  spath_delete(&dataset_path);
+
+  /* get the list of files to read */
+  kvtree* filelist = kvtree_new();
+  if (kvtree_read_scatter(rank2file, filelist, scr_comm_world) != KVTREE_SUCCESS) {
+    /* failed to read list of files in this dataset */
+    scr_free(&rank2file);  
+    kvtree_delete(&filelist);
+    return SCR_FAILURE;
+  }
+
+  /* done with rank2file */
+  scr_free(&rank2file);  
+
+  /* allocate list of file names */
+  kvtree* files = kvtree_get(filelist, "FILE");
+  int num_files = kvtree_size(files);
+
+  /* delete files and count up number of directories */
+  int num_dirs = 0;
+  int min_depth = -1;
+  int max_depth = -1;
+  kvtree_elem* elem;
+  for (elem = kvtree_elem_first(files);
+       elem != NULL;
+       elem = kvtree_elem_next(elem))
+  {
+    /* get the file name */
+    char* file = kvtree_elem_key(elem);
+
+    /* build full path to the file under the prefix directory */
+    spath* file_path = spath_dup(scr_prefix_path);
+    spath_append_str(file_path, file);
+    spath_reduce(file_path);
+    char* src_file = spath_strdup(file_path);
+
+    /* delete the file */
+    scr_file_unlink(src_file);
+
+    /* free file path string */
+    scr_free(&src_file);
+
+    /* now get the directory portion */
+    spath_dirname(file_path);
+    if (spath_is_child(scr_prefix_path, file_path)) {
+      int parent_components = spath_components(scr_prefix_path);
+      int target_components = spath_components(file_path);
+      num_dirs += target_components - parent_components;
+
+      if (min_depth == -1 || parent_components < min_depth) {
+        min_depth = parent_components;
+      }
+      if (max_depth == -1 || target_components > max_depth) {
+        max_depth = target_components;
+      }
+    }
+    spath_delete(&file_path);
+  }
+
+  /* identify minimum rank with a valid value */
+  int source;
+  int source_rank = scr_ranks_world;
+  if (min_depth != -1) {
+    source_rank = scr_my_rank_world;
+  }
+  MPI_Allreduce(&source_rank, &source, 1, MPI_INT, MPI_MIN, scr_comm_world);
+
+  /* delete directories for user dataset files if any rank found them */
+  if (source < scr_ranks_world) {
+    /* some rank has defined min/max values,
+     * get min_depth from that rank */
+    int min_source = min_depth;
+    MPI_Bcast(&min_source, 1, MPI_INT, source, scr_comm_world);
+
+    /* initialize our own min/max if needed */
+    if (min_depth == -1) {
+      min_depth = min_source;
+    }
+    if (max_depth == -1) {
+      max_depth = min_source;
+    }
+
+    /* get global min and max values across all procs */
+    int min_global, max_global;
+    MPI_Allreduce(&min_depth, &min_global, 1, MPI_INT, MPI_MIN, scr_comm_world);
+    MPI_Allreduce(&max_depth, &max_global, 1, MPI_INT, MPI_MAX, scr_comm_world);
+
+    /* allocate memory to hold list of each of our directories */
+    char** dirs = (char**) SCR_MALLOC(num_dirs * sizeof(char*));
+    int* depths = (int*)   SCR_MALLOC(num_dirs * sizeof(int));
+
+    /* get list of directories */
+    int i = 0;
+    for (elem = kvtree_elem_first(files);
+         elem != NULL;
+         elem = kvtree_elem_next(elem))
+    {
+      /* get the file name */
+      char* file = kvtree_elem_key(elem);
+
+      /* build full path to the file under the prefix directory */
+      spath* file_path = spath_dup(scr_prefix_path);
+      spath_append_str(file_path, file);
+      spath_reduce(file_path);
+
+      /* now get the directory portion */
+      spath_dirname(file_path);
+      if (spath_is_child(scr_prefix_path, file_path)) {
+        /* work back for each directory component from the file
+         * to the prefix directory */
+        int parent_components = spath_components(scr_prefix_path);
+        int target_components = spath_components(file_path);
+        while (target_components > parent_components) {
+          /* get a copy of this directory string and its depth */
+          char* dir = spath_strdup(file_path);
+          dirs[i]   = dir;
+          depths[i] = target_components;
+          i++;
+
+          /* chop off another component and try again */
+          spath_dirname(file_path);
+          target_components--;
+        }
+      }
+
+      /* release the path object for this file */
+      spath_delete(&file_path);
+    }
+
+    /* compute union of directories to identify leaders */
+    uint64_t groups;
+    uint64_t* group_id    = (uint64_t*) SCR_MALLOC(sizeof(uint64_t) * num_dirs);
+    uint64_t* group_ranks = (uint64_t*) SCR_MALLOC(sizeof(uint64_t) * num_dirs);
+    uint64_t* group_rank  = (uint64_t*) SCR_MALLOC(sizeof(uint64_t) * num_dirs);
+    int dtcmp_rc = DTCMP_Rankv_strings(
+      num_dirs, dirs, &groups, group_id, group_ranks, group_rank,
+      DTCMP_FLAG_NONE, scr_comm_world
+    );
+    if (dtcmp_rc != DTCMP_SUCCESS) {
+      rc = SCR_FAILURE;
+    }
+
+    /* delete directories from bottom level to top */
+    int depth;
+    for (depth = max_global; depth >= min_global; depth--) {
+      /* iterate over each directory we have,
+       * delete it if it's at the right level and
+       * if we are the designated leader */
+      for (i = 0; i < num_dirs; i++) {
+        if (depths[i] == depth &&
+            group_rank[i] == 0)
+        {
+          /* will naturally fail to delete non-empty directories */
+          scr_rmdir(dirs[i]);
+        }
+      }
+
+      /* execute barrier to ensure everyone is done with this level
+       * before we move a level up */
+      MPI_Barrier(scr_comm_world);
+    }
+
+    /* free dtcmp buffers */
+    scr_free(&group_id);
+    scr_free(&group_ranks);
+    scr_free(&group_rank);
+
+    /* free memory allocated for directory list */
+    for (i = 0; i < num_dirs; i++) {
+      /* free directory name strings */
+      scr_free(&dirs[i]);
+    }
+    scr_free(&dirs);
+    scr_free(&depths);
+  }
+
+  /* done with the list of files */
+  kvtree_delete(&filelist);
+
+  return rc;
+}
+
+/* delete named dataset from the prefix directory */
+int scr_prefix_delete(int id, const char* name)
+{
+  int rc = SCR_SUCCESS;
+
+  /* print a debug messages */
+  if (scr_my_rank_world == 0) {
+    scr_dbg(1, "Deleting dataset %d `%s' from `%s'", id, name, scr_prefix);
+  }
+  
+  /* first, delete user data files from prefix directory */
+  scr_prefix_delete_data(id);
+
+  /* delete files within scr.dataset.id directory,
+   * this is most likely just the summary and rank2file files,
+   * but we do this by scanning and deleting items
+   * in case we happened to execute a scavenge in which case
+   * we'll also have lots of redundancy and filemap files */
+  if (scr_my_rank_world == 0) {
+    /* build path to dataset directory under prefix */
+    spath* dataset_path = spath_from_str(scr_prefix_scr);
+    spath_append_strf(dataset_path, "scr.dataset.%d", id);
+    char* dataset_dir = spath_strdup(dataset_path);
+    spath_delete(&dataset_path);
+
+    /* scan over all items in the directory and delete them */
+    scr_prefix_rmscan(dataset_dir);
+
+    /* free dataset directory name */
+    scr_free(&dataset_dir);
+  }
+
+  /* drop the entry from the index file */
+  scr_prefix_remove_index(name);
+
+  /* hold everyone until delete is complete */
+  MPI_Barrier(scr_comm_world);
+
+  return rc;
+}
+
+/* keep a sliding window of checkpoints in the prefix directory,
+ * delete any pure checkpoints that fall outside of the window
+ * defined by the given dataset id and the window width,
+ * excludes checkpoints that are marked as output */
+int scr_prefix_delete_sliding(int id, int window)
+{
+  /* rank 0 reads the index file */
+  kvtree* index_hash = NULL;
+  int read_index_file = 0;
+  if (scr_my_rank_world == 0) {
+    /* create an empty hash to store our index */
+    index_hash = kvtree_new();
+
+    /* read the index file */
+    if (scr_index_read(scr_prefix_path, index_hash) == SCR_SUCCESS) {
+      read_index_file = 1;
+    }
+  }
+
+  /* don't enter while loop below if rank 0 failed to read index file */
+  int continue_deleting = 1;
+  MPI_Bcast(&read_index_file, 1, MPI_INT, 0, scr_comm_world);
+  if (! read_index_file) {
+    continue_deleting = 0;
+  }
+
+  /* we count the current checkpoint as a member of the window */
+  window--;
+
+  /* iterate over all checkpoints in the prefix directory,
+   * deleting any pure checkpoints that fall outside of the window */
+  int target_id = id;
+  while (continue_deleting) {
+    /* rank 0 determines the directory to fetch from */
+    char target[SCR_MAX_FILENAME];
+    if (scr_my_rank_world == 0) {
+      /* TODO: delete checkpoint if not valid, even if in window? */
+
+      /* get the most recent complete checkpoint older than the target id */
+      int next_id = -1;
+      scr_index_get_most_recent_complete(index_hash, target_id, &next_id, target);
+      target_id = next_id;
+
+      /* found the next most recent checkpoint,
+       * consider whether we should keep it */
+      if (target_id >= 0) {
+        /* keep this checkpoint if we're still in the window */
+        if (window > 0) {
+          /* saved by the window, look for something older */
+          window--;
+          continue;
+        }
+
+        /* not in window, but we also keep any checkpoints
+         * that are marked as output */
+        scr_dataset* dataset = scr_dataset_new();
+        if (scr_index_get_dataset(index_hash, target_id, target, dataset) == SCR_SUCCESS) {
+          /* get output flag for this dataset */
+          int is_output = scr_dataset_is_output(dataset);
+          if (is_output) {
+            /* this checkpoint is also marked as output, so don't delete it */
+            scr_dataset_delete(&dataset);
+            continue;
+          }
+        }
+        scr_dataset_delete(&dataset);
+      }
+    }
+
+    /* broadcast target id from rank 0 */
+    MPI_Bcast(&target_id, 1, MPI_INT, 0, scr_comm_world);
+
+    /* if we got an id, delete it, otherwise we're done */
+    if (target_id >= 0) {
+      /* get name from rank 0 */
+      scr_strn_bcast(target, sizeof(target), 0, scr_comm_world);
+
+      /* delete this dataset from the prefix directory */
+      scr_prefix_delete(target_id, target);
+    } else {
+      /* ran out of checkpoints to consider */
+      continue_deleting = 0;
+    }
+  }
+
+  /* delete the index hash */
+  if (scr_my_rank_world == 0) {
+    kvtree_delete(&index_hash);
+  }
+
+  /* hold everyone until delete is complete */
+  MPI_Barrier(scr_comm_world);
+
+  return SCR_SUCCESS;
+}

--- a/src/scr_prefix.h
+++ b/src/scr_prefix.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2009, Lawrence Livermore National Security, LLC.
+ * Produced at the Lawrence Livermore National Laboratory.
+ * Written by Adam Moody <moody20@llnl.gov>.
+ * LLNL-CODE-411039.
+ * All rights reserved.
+ * This file is part of The Scalable Checkpoint / Restart (SCR) library.
+ * For details, see https://sourceforge.net/projects/scalablecr/
+ * Please also read this file: LICENSE.TXT.
+*/
+
+#ifndef SCR_PREFIX_H
+#define SCR_PREFIX_H
+
+/* delete named dataset from the prefix directory */
+int scr_prefix_delete(int id, const char* name);
+
+/* keep a sliding window of checkpoints in the prefix directory,
+ * delete any pure checkpoints that fall outside of the window
+ * defined by the given dataset id and the window width,
+ * excludes checkpoints that are marked as output */
+int scr_prefix_delete_sliding(int id, int window);
+
+#endif /* SCR_PREFIX_H */


### PR DESCRIPTION
This adds support for deleting datasets from the prefix directory.

This enables SCR to maintain a sliding window of checkpoints on the file system in the prefix directory by deleting old checkpoints as new ones are flushed.  After each successful flush, any checkpoint that falls outside of the window is deleted.  Checkpoints that are also marked as output are not considered for deletion, only pure checkpoints.  One must enable this by specifying the window size with a new ```SCR_PREFIX_SIZE``` parameter.  Setting this to 0 disables SCR from deleting checkpoints in the prefix directory.

The scavenge operation does not currently delete checkpoints, even if the sliding window is enabled.

It adds a new ```SCR_Delete(const char* name)``` API that lets the application ask SCR to delete a dataset.  This deletes user files and child directories (up to prefix directory) as well as SCR metadata associated with the dataset, including the ```.scr/scr.dataset.id``` directory and the entry from the index file.

It adds a new ```SCR_Drop(const char* name)``` API that the application can use to instruct SCR to drop an entry from the index file for a dataset while leaving its files in place.  This is equivalent to running the ```scr_index --remove name``` command.

Resolves https://github.com/LLNL/scr/issues/195
Resolves https://github.com/LLNL/scr/issues/196