### PR TITLE
Apibreak

### DIFF
--- a/examples/test_api.c
+++ b/examples/test_api.c
@@ -231,7 +231,7 @@ double getbw(char* name, char* buf, size_t size, int times)
         /* using scr, start our output */
         scr_retval = SCR_Start_output(label, flags);
         if (scr_retval != SCR_SUCCESS) {
-          printf("%d: failed calling SCR_Start_checkpoint(): %d: @%s:%d\n",
+          printf("%d: failed calling SCR_Start_output(): %d: @%s:%d\n",
                  rank, scr_retval, __FILE__, __LINE__
           );
         }
@@ -301,7 +301,8 @@ double getbw(char* name, char* buf, size_t size, int times)
 
       /* mark this checkpoint as complete */
       if (use_scr) {
-        scr_retval = SCR_Complete_output(valid);
+        int allvalid;
+        scr_retval = SCR_Complete_output(valid, &allvalid);
         if (scr_retval != SCR_SUCCESS) {
           printf("%d: failed calling SCR_Complete_output: %d: @%s:%d\n",
                  rank, scr_retval, __FILE__, __LINE__
@@ -510,12 +511,8 @@ int main (int argc, char* argv[])
         }
 
         /* indicate to library that we're done with restart, tell it whether we read our data ok */
-        scr_retval = SCR_Complete_restart(found_checkpoint);
-        if (scr_retval == SCR_SUCCESS) {
-          /* all procs succeeded in reading their checkpoint file,
-           * we've successfully restarted */
-          restarted = 1;
-        } else {
+        scr_retval = SCR_Complete_restart(found_checkpoint, &restarted);
+        if (scr_retval != SCR_SUCCESS) {
           printf("%d: failed calling SCR_Complete_restart: %d: @%s:%d\n",
                  rank, scr_retval, __FILE__, __LINE__
           );

--- a/examples/test_api_file.c
+++ b/examples/test_api_file.c
@@ -54,9 +54,9 @@ double getbw(char* name, char* buf, size_t size, int times)
 */
 
       /* instruct SCR we are starting the next checkpoint */
-      scr_retval = SCR_Start_checkpoint();
+      scr_retval = SCR_Start_output(NULL, SCR_FLAG_CHECKPOINT);
       if (scr_retval != SCR_SUCCESS) {
-        printf("%d: failed calling SCR_Start_checkpoint(): %d: @%s:%d\n",
+        printf("%d: failed calling SCR_Start_output(): %d: @%s:%d\n",
                rank, scr_retval, __FILE__, __LINE__
         );
       }
@@ -107,9 +107,10 @@ double getbw(char* name, char* buf, size_t size, int times)
       */
 
       /* mark this checkpoint as complete */
-      scr_retval = SCR_Complete_checkpoint(valid);
+      int allvalid;
+      scr_retval = SCR_Complete_output(valid, &allvalid);
       if (scr_retval != SCR_SUCCESS) {
-        printf("%d: failed calling SCR_Complete_checkpoint: %d: @%s:%d\n",
+        printf("%d: failed calling SCR_Complete_output: %d: @%s:%d\n",
                rank, scr_retval, __FILE__, __LINE__
         );
       }

--- a/examples/test_api_multiple_file.c
+++ b/examples/test_api_multiple_file.c
@@ -170,15 +170,14 @@ int main (int argc, char* argv[])
   int t;
   for(t=0; t < 1; t++) {
     int rc;
-    int all_valid = 1;
-    scr_retval = SCR_Start_checkpoint();
+    int valid = 1;
+    scr_retval = SCR_Start_output(NULL, SCR_FLAG_CHECKPOINT);
     if (scr_retval != SCR_SUCCESS) {
-      printf("%d: failed calling SCR_Start_checkpoint(): %d: @%s:%d\n",
+      printf("%d: failed calling SCR_Start_output(): %d: @%s:%d\n",
              rank, scr_retval, __FILE__, __LINE__
       );
     }
   for (i=0; i < num_files; i++) {
-    int valid = 0;
     char file[2094];
     scr_retval = SCR_Route_file(files[i], file);
     if (scr_retval != SCR_SUCCESS) {
@@ -188,8 +187,6 @@ int main (int argc, char* argv[])
     }
     int fd_me = open(file, O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR);
     if (fd_me > 0) {
-      valid = 1;
-
       // write the checkpoint
       rc = write_checkpoint(fd_me, timestep, bufs[i], filesizes[i]);
       if (rc < 0) { valid = 0; }
@@ -200,12 +197,14 @@ int main (int argc, char* argv[])
       // make sure the close is without error
       rc = close(fd_me);
       if (rc < 0) { valid = 0; }
+    } else {
+      valid = 0;
     }
-    if (!valid) { all_valid = 0; }
   }
-  scr_retval = SCR_Complete_checkpoint(all_valid);
+  int allvalid;
+  scr_retval = SCR_Complete_output(valid, &allvalid);
   if (scr_retval != SCR_SUCCESS) {
-    printf("%d: failed calling SCR_Complete_checkpoint(): %d: @%s:%d\n",
+    printf("%d: failed calling SCR_Complete_output(): %d: @%s:%d\n",
            rank, scr_retval, __FILE__, __LINE__
     );
   }
@@ -220,15 +219,14 @@ int main (int argc, char* argv[])
     double time_start = MPI_Wtime();
     for(t=0; t < times; t++) {
       int rc;
-      int all_valid = 1;
-      scr_retval = SCR_Start_checkpoint();
+      int valid = 1;
+      scr_retval = SCR_Start_output(NULL, SCR_FLAG_CHECKPOINT);
       if (scr_retval != SCR_SUCCESS) {
-        printf("%d: failed calling SCR_Start_checkpoint(): %d: @%s:%d\n",
+        printf("%d: failed calling SCR_Start_output(): %d: @%s:%d\n",
                rank, scr_retval, __FILE__, __LINE__
         );
       }
       for (i=0; i < num_files; i++) {
-        int valid = 0;
         char file[2094];
         scr_retval = SCR_Route_file(files[i], file);
         if (scr_retval != SCR_SUCCESS) {
@@ -239,7 +237,6 @@ int main (int argc, char* argv[])
         int fd_me = open(file, O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR);
         if (fd_me > 0) {
           count++;
-          valid = 1;
           
           // write the checkpoint
           rc = write_checkpoint(fd_me, timestep, bufs[i], filesizes[i]);
@@ -251,12 +248,14 @@ int main (int argc, char* argv[])
           // make sure the close is without error
           rc = close(fd_me);
           if (rc < 0) { valid = 0; }
+        } else {
+          valid = 0;
         }
-        if (!valid) { all_valid = 0; }
       }
-      scr_retval = SCR_Complete_checkpoint(all_valid);
+      int allvalid;
+      scr_retval = SCR_Complete_output(valid, &allvalid);
       if (scr_retval != SCR_SUCCESS) {
-        printf("%d: failed calling SCR_Complete_checkpoint(): %d: @%s:%d\n",
+        printf("%d: failed calling SCR_Complete_output(): %d: @%s:%d\n",
                rank, scr_retval, __FILE__, __LINE__
         );
       }

--- a/examples/test_ckpt.F
+++ b/examples/test_ckpt.F
@@ -55,7 +55,7 @@
         read(readunit,iostat=ios) R1
         close(readunit)
 
-        call SCR_COMPLETE_RESTART(valid, ierr)
+        call SCR_COMPLETE_RESTART(valid, flag, ierr)
       endif
 
       if (mynod == 0) then
@@ -71,26 +71,6 @@
 
         forall(i=1:ni,j=1:nj,k=1:nk) W1(i,j,k) = 
      +      nodeoff*mynod+i+ni*(j-1+nj*(k-1))
-
-!       test checkpoint interface
-        call SCR_START_CHECKPOINT(ierr)
-
-        write(file_suffix, '(i5.5)') loop
-        ckptname = "ckpt_" // trim(file_suffix)
-
-        writeunit = mynod
-        write(file_suffix, '(i5.5)') writeunit
-        fname = trim(ckptname) // "/" //
-     +      trim(basefname) // trim(file_suffix) // ".ckpt"
-        call SCR_ROUTE_FILE(fname, fname_scr, ierr)
-
-        valid = 1
-        open(unit=writeunit,file=fname_scr,form='unformatted',
-     +      action='write')
-        write(writeunit,iostat=ios) W1
-        close(writeunit)
-
-        call SCR_COMPLETE_CHECKPOINT(valid, ierr)
 
 !       test output interface
         write(file_suffix, '(i5.5)') loop
@@ -110,7 +90,7 @@
         write(writeunit,iostat=ios) W1
         close(writeunit)
 
-        call SCR_COMPLETE_OUTPUT(valid, ierr)
+        call SCR_COMPLETE_OUTPUT(valid, flag, ierr)
 
         call MPI_BARRIER(MPI_COMM_WORLD, ierr)
 

--- a/examples/test_ckpt.cpp
+++ b/examples/test_ckpt.cpp
@@ -34,7 +34,7 @@ int checkpoint(int size_mb)
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 
     /* Inform SCR that we are starting a new checkpoint */
-    SCR_Start_checkpoint();
+    SCR_Start_output(NULL, SCR_FLAG_CHECKPOINT);
 
     /* Build the filename for our checkpoint file */
     sprintf(tmp, "rank_%d", rank);
@@ -50,7 +50,8 @@ int checkpoint(int size_mb)
     cout << "Out: " << file << "\n";
 
     /* Tell SCR whether this process wrote its checkpoint files successfully */
-    SCR_Complete_checkpoint(1);
+    int allvalid;
+    SCR_Complete_output(1, &allvalid);
 
     return 0;
 }

--- a/src/scr.c
+++ b/src/scr.c
@@ -1337,7 +1337,7 @@ static int scr_assign_ownership(scr_filemap* map, int bypass)
 }
 
 /* end phase for current output dataset */
-static int scr_complete_output(int valid)
+static int scr_complete_output(int valid, int* allvalid)
 {
   /* bail out if there is no active call to Start_output */
   if (! scr_in_output) {
@@ -1595,6 +1595,9 @@ static int scr_complete_output(int valid)
       scr_log_event("COMPUTE_START", NULL, NULL, NULL, NULL, NULL);
     }
   }
+
+  /* set flag based on return value for now */
+  *allvalid = (rc == SCR_SUCCESS);
 
   return rc;
 }
@@ -2407,32 +2410,6 @@ int SCR_Start_output(const char* name, int flags)
   return scr_start_output(name, flags);
 }
 
-/* informs SCR that a fresh checkpoint set is about to start */
-int SCR_Start_checkpoint()
-{
-  /* manage state transition */
-  if (scr_state != SCR_STATE_IDLE) {
-    scr_state_transition_error(scr_state, "SCR_Start_checkpoint()", __FILE__, __LINE__);
-  }
-  scr_state = SCR_STATE_CHECKPOINT;
-
-  /* if not enabled, bail with an error */
-  if (! scr_enabled) {
-    return SCR_FAILURE;
-  }
-
-  /* bail out if not initialized -- will get bad results */
-  if (! scr_initialized) {
-    scr_abort(-1, "SCR has not been initialized @ %s:%d",
-      __FILE__, __LINE__
-    );
-    return SCR_FAILURE;
-  }
-
-  /* delegate the rest to start_output */
-  return scr_start_output(NULL, SCR_FLAG_CHECKPOINT);
-}
-
 /* given a filename, return the full path to the file which the user should write to */
 int SCR_Route_file(const char* file, char* newfile)
 {
@@ -2656,7 +2633,7 @@ int SCR_Route_file(const char* file, char* newfile)
 }
 
 /* inform library that the current dataset is complete */
-int SCR_Complete_output(int valid)
+int SCR_Complete_output(int valid, int* allvalid)
 {
   /* manage state transition */
   if (scr_state != SCR_STATE_OUTPUT) {
@@ -2679,34 +2656,7 @@ int SCR_Complete_output(int valid)
     return SCR_FAILURE;
   }
 
-  return scr_complete_output(valid);
-}
-
-/* completes the checkpoint set and marks it as valid or not */
-int SCR_Complete_checkpoint(int valid)
-{
-  /* manage state transition */
-  if (scr_state != SCR_STATE_CHECKPOINT) {
-    scr_abort(-1, "Must call SCR_Start_checkpoint() before SCR_Complete_checkpoint() @ %s:%d",
-      __FILE__, __LINE__
-    );
-  }
-  scr_state = SCR_STATE_IDLE;
-
-  /* if not enabled, bail with an error */
-  if (! scr_enabled) {
-    return SCR_FAILURE;
-  }
-
-  /* bail out if not initialized -- will get bad results */
-  if (! scr_initialized) {
-    scr_abort(-1, "SCR has not been initialized @ %s:%d",
-      __FILE__, __LINE__
-    );
-    return SCR_FAILURE;
-  }
-
-  return scr_complete_output(valid);
+  return scr_complete_output(valid, allvalid);
 }
 
 /* determine whether SCR has a restart available to read,
@@ -2813,7 +2763,7 @@ int SCR_Start_restart(char* name)
 }
 
 /* inform library that the current restart is complete */
-int SCR_Complete_restart(int valid)
+int SCR_Complete_restart(int valid, int* allvalid)
 {
   /* manage state transition */
   if (scr_state != SCR_STATE_RESTART) {
@@ -2839,10 +2789,11 @@ int SCR_Complete_restart(int valid)
   /* turn off our restart flag */
   scr_have_restart = 0;
 
-  /* since we have no output flag to return to user whether all procs
-   * passed in valid=1, we'll overload the return code for that purpose,
-   * this should eventually be changed to use an output flag instead */
+  /* assume we succeeded */
   int rc = SCR_SUCCESS;
+
+  /* assume restart was valid */
+  *allvalid = 1;
 
   /* check that all procs read valid data */
   if (! scr_alltrue(valid, scr_comm_world)) {
@@ -2852,9 +2803,8 @@ int SCR_Complete_restart(int valid)
      * we should also record this current checkpoint as failed in the
      * index file so that we don't fetch it again*/
 
-    /* use the return code to indicate that some process failed to
-     * read its checkpoint file */
-    rc = SCR_FAILURE;
+    /* indicate that some process failed to read its checkpoint file */
+    *allvalid = 0;
 
     /* mark current checkpoint as bad in our index file so that
      * we don't attempt to fetch it again */

--- a/src/scr.h
+++ b/src/scr.h
@@ -63,30 +63,20 @@ int SCR_Have_restart(int* flag, char* name);
 int SCR_Start_restart(char* name);
 
 /* inform library that the current restart is complete */
-int SCR_Complete_restart(int valid);
-
-/*****************
- * Checkpoint routines (backwards compatibility)
- ****************/
-
-/* determine whether a checkpoint should be taken at the current time */
-int SCR_Need_checkpoint(int* flag);
-
-/* inform library that a new checkpoint is starting */
-int SCR_Start_checkpoint(void);
-
-/* inform library that the current checkpoint is complete */
-int SCR_Complete_checkpoint(int valid);
+int SCR_Complete_restart(int valid, int* allvalid);
 
 /*****************
  * Output routines
  ****************/
 
+/* determine whether a checkpoint should be taken at the current time */
+int SCR_Need_checkpoint(int* flag);
+
 /* inform library that a new output dataset is starting */
 int SCR_Start_output(const char* name, int flags);
 
 /* inform library that the current dataset is complete */
-int SCR_Complete_output(int valid);
+int SCR_Complete_output(int valid, int* allvalid);
 
 /*****************
  * Environment and configuration routines

--- a/src/scr_interpose.c
+++ b/src/scr_interpose.c
@@ -163,7 +163,7 @@ static int scri_start_checkpoint()
 
     /* start the checkpoint */
     scri_interpose_enabled = 0;
-    SCR_Start_checkpoint();
+    SCR_Start_output(NULL, SCR_FLAG_CHECKPOINT);
     scri_interpose_enabled = 1;
 
     /* mark us inside a checkpoint */
@@ -196,7 +196,8 @@ static int scri_complete_checkpoint(int index)
     if (!still_open) {
       /* disable the interposer since SCR_Complete_checkpoint calls open/close */
       scri_interpose_enabled = 0;
-      SCR_Complete_checkpoint(1);
+      int allvalid;
+      SCR_Complete_output(1, &allvalid);
       scri_interpose_enabled = 1;
 
       /* mark us out of the checkpoint */

--- a/src/scrf.c
+++ b/src/scrf.c
@@ -183,15 +183,15 @@ FORTRAN_API void FORT_CALL scr_start_restart_(char* name FORT_MIXED_LEN(name_len
   return;
 }
 
-FORTRAN_API void FORT_CALL scr_complete_restart_(int* valid, int* ierror)
+FORTRAN_API void FORT_CALL scr_complete_restart_(int* valid, int* allvalid, int* ierror)
 {
   int valid_tmp = *valid;
-  *ierror = SCR_Complete_restart(valid_tmp);
+  *ierror = SCR_Complete_restart(valid_tmp, allvalid);
   return;
 }
 
 /*================================================
- * Checkpoint functions
+ * Output functions
  *================================================*/
 
 FORTRAN_API void FORT_CALL scr_need_checkpoint_(int* flag, int* ierror)
@@ -199,23 +199,6 @@ FORTRAN_API void FORT_CALL scr_need_checkpoint_(int* flag, int* ierror)
   *ierror = SCR_Need_checkpoint(flag);
   return;
 }
-
-FORTRAN_API void FORT_CALL scr_start_checkpoint_(int* ierror)
-{
-  *ierror = SCR_Start_checkpoint();
-  return;
-}
-
-FORTRAN_API void FORT_CALL scr_complete_checkpoint_(int* valid, int* ierror)
-{
-  int valid_tmp = *valid;
-  *ierror = SCR_Complete_checkpoint(valid_tmp);
-  return;
-}
-
-/*================================================
- * Output functions
- *================================================*/
 
 FORTRAN_API void FORT_CALL scr_start_output_(char* name FORT_MIXED_LEN(name_len), int* flags, int* ierror FORT_END_LEN(name_len))
 {
@@ -232,10 +215,10 @@ FORTRAN_API void FORT_CALL scr_start_output_(char* name FORT_MIXED_LEN(name_len)
   return;
 }
 
-FORTRAN_API void FORT_CALL scr_complete_output_(int* valid, int* ierror)
+FORTRAN_API void FORT_CALL scr_complete_output_(int* valid, int* allvalid, int* ierror)
 {
   int valid_tmp = *valid;
-  *ierror = SCR_Complete_output(valid_tmp);
+  *ierror = SCR_Complete_output(valid_tmp, allvalid);
   return;
 }
 


### PR DESCRIPTION
Drops ```SCR_Start_checkpoint``` and ```SCR_Complete_checkpoint```.

Adds an output flag to complete functions to return status to caller rather than using the return code.
```
SCR_Complete_restart(int valid, int* allvalid)
SCR_Complete_output(int valid, int* allvalid)
```
Update examples to better illustrate purpose of ```valid``` flag.