### PR TITLE
add scr_current api

### DIFF
--- a/src/scr.c
+++ b/src/scr.c
@@ -3279,6 +3279,7 @@ int SCR_Current(const char* name)
           scr_index_set_current(index_hash, name);
 
           /* TODO: optionally drop checkpoints that follow this one */
+          scr_index_remove_later(index_hash, id);
 
           /* update the index file */
           scr_index_write(scr_prefix_path, index_hash);

--- a/src/scr.c
+++ b/src/scr.c
@@ -3312,6 +3312,30 @@ int SCR_Current(const char* name)
     scr_ckpt_dset_id  = dset_id;
 
     /* TODO: optionally delete any checkpoints that follow this one? */
+    /* get list of datasets in cache */
+    int ndsets;
+    int* dsets;
+    scr_cache_index_list_datasets(scr_cindex, &ndsets, &dsets);
+
+    /* delete any dataset from cache that follows dset_id */
+    int i;
+    for (i = 0; i < ndsets; i++) {
+      int id = dsets[i];
+      if (id > dset_id) {
+        if (! scr_flush_file_is_flushing(id)) {
+          /* this dataset is after the current dataset,
+           * delete it from cache */
+          scr_cache_delete(scr_cindex, id);
+        } else {
+          scr_warn("Skipping delete of dataset %d from cache because it is flushing @ %s:%d",
+            id, __FILE__, __LINE__
+          );
+        }
+      }
+    }
+
+    /* free list of dataset ids */
+    scr_free(&dsets);
 
     /* we don't want to support a restart from this since it is not
      * loaded, we just allow the user to initialize the counters */

--- a/src/scr.h
+++ b/src/scr.h
@@ -107,6 +107,11 @@ int SCR_Complete_output(int valid);
  * Dataset management routines
  ****************/
 
+/* set named dataset as current in index,
+ * and initialize SCR internal counters to assume job
+ * has restarted from this checkpoint */
+int SCR_Current(const char* name);
+
 /* drop named dataset from index */
 int SCR_Drop(const char* name);
 

--- a/src/scr_dataset.h
+++ b/src/scr_dataset.h
@@ -148,10 +148,4 @@ int scr_dataset_is_ckpt(const scr_dataset* dataset);
 /* returns 1 if dataset is a checkpoint, 0 otherwise */
 int scr_dataset_is_output(const scr_dataset* dataset);
 
-/* returns 1 if dataset is a checkpoint, 0 otherwise */
-int scr_dataset_is_ckpt(const scr_dataset* dataset);
-
-/* returns 1 if dataset is output, 0 otherwise */
-int scr_dataset_is_output(const scr_dataset* dataset);
-
 #endif

--- a/src/scr_index_api.h
+++ b/src/scr_index_api.h
@@ -75,4 +75,7 @@ int scr_index_get_id_by_name(const kvtree* index, const char* name, int* id);
  * setting earlier_than = -1 disables this filter */
 int scr_index_get_most_recent_complete(const kvtree* index, int earlier_than, int* id, char* name);
 
+/* remove checkpoints from index that are later than given dataset id */
+int scr_index_remove_later(kvtree* index, int id);
+
 #endif

--- a/src/scrf.c
+++ b/src/scrf.c
@@ -311,6 +311,20 @@ FORTRAN_API void FORT_CALL scr_route_file_(char* name FORT_MIXED_LEN(name_len),
  * Dataset management
  *================================================*/
 
+FORTRAN_API void FORT_CALL scr_current_(char* name FORT_MIXED_LEN(name_len), int* ierror FORT_END_LEN(name_len))
+{
+  /* convert name from a Fortran string to C string */
+  char name_tmp[SCR_MAX_FILENAME];
+  if (scr_fstr2cstr(name, name_len, name_tmp, sizeof(name_tmp)) != 0) {
+    *ierror = !SCR_SUCCESS;
+    return;
+  }
+
+  *ierror = SCR_Current(name_tmp);
+
+  return;
+}
+
 FORTRAN_API void FORT_CALL scr_drop_(char* name FORT_MIXED_LEN(name_len), int* ierror FORT_END_LEN(name_len))
 {
   /* convert name from a Fortran string to C string */


### PR DESCRIPTION
This defines a new ```SCR_Current(const char* name)``` API that an application can use to specify the current checkpoint in the index file.  This also updates the internal SCR counters to match the id values for that checkpoint.  This latter functionality is needed so that SCR can set its counters appropriately in the event that the application has restarted without using the SCR restart API.  In that case, this gives the application a way to inform SCR about which checkpoint it loaded.  It might make sense to split this functionality into two separate API calls, but that is left for future work.

The call to ```SCR_Current``` does the following, assuming that the named dataset actually exists in the index file:
- update the index file to set the named dataset to be current
- change SCR's internal counters to match those for the named dataset
- drop any datasets from the index file that come after the named dataset
- remove any datasets from cache that come after the named dataset, unless the dataset to be removed is being flushed, in which case that dataset is left in cache an warning is printed

The ```scr_index --remove <name>``` option is renamed to ```--drop```.  As before, this option drops the named dataset from the index file.

A new ```scr_index --drop-after <name>``` option is defined to drop all datasets *after* the named dataset.