### PR TITLE
fix scr_config when user sets param through environment

### DIFF
--- a/examples/test_config.c
+++ b/examples/test_config.c
@@ -208,6 +208,16 @@ int main (int argc, char* argv[])
   tests_passed &= test_env("$VAR_A ${VAR_B>}", "value a ${VAR_B>}");
   tests_passed &= test_env("$VAR_C", "");
 
+  scr_param_finalize();
+
+  /* test reading in values from app.conf file */
+  /* I cannot use SCR_Config to test for non-existence since it will read in
+   * app.conf */
+  tests_passed &= test_param_get("SCR_COPY_TYPE", NULL);
+  scr_param_init();
+  tests_passed &= test_param_get("SCR_COPY_TYPE", "SINGLE");
+  scr_param_finalize();
+
   /* re-enable debugging */
   SCR_Config("DEBUG=1");
   tests_passed &= test_cfg("DEBUG", "1");
@@ -221,16 +231,6 @@ int main (int argc, char* argv[])
   } else {
     fprintf(stderr, "Failed initializing SCR\n");
   }
-
-  scr_param_finalize();
-
-  /* test reading in values from app.conf file */
-  /* I cannot use SCR_Config to test for non-existence since it will read in
-   * app.conf */
-  tests_passed &= test_param_get("SCR_COPY_TYPE", NULL);
-  scr_param_init();
-  tests_passed &= test_param_get("SCR_COPY_TYPE", "SINGLE");
-  scr_param_finalize();
 
   MPI_Finalize();
 

--- a/examples/test_config.c
+++ b/examples/test_config.c
@@ -141,10 +141,10 @@ int main (int argc, char* argv[])
   tests_passed &= test_cfg("SCR_COPY_TYPE", "SINGLE");
 
   SCR_Config("STORE= /dev/shm/foo GROUP = NODE COUNT  =1");
-  tests_passed &= test_cfg("STORE= /dev/shm/foo GROUP = NODE COUNT", "1");
+  tests_passed &= test_cfg("STORE= /dev/shm/foo COUNT", "1");
 
   SCR_Config("CKPT=0 INTERNAL=1 GROUP=NODE STORE=/dev/shm TYPE=XOR SET_SIZE=16");
-  tests_passed &= test_cfg("CKPT=0 INTERNAL=1 GROUP=NODE STORE=/dev/shm TYPE=XOR SET_SIZE", "16");
+  tests_passed &= test_cfg("CKPT=0 SET_SIZE", "16");
 
   /* check if values are all set */
   tests_passed &= test_cfg("DEBUG", "1");
@@ -158,7 +158,7 @@ int main (int argc, char* argv[])
   tests_passed &= test_cfg("DEBUG", "0");
 
   SCR_Config("STORE=/dev/shm GROUP=NODE COUNT=1");
-  tests_passed &= test_cfg("STORE=/dev/shm GROUP=NODE COUNT", "1");
+  tests_passed &= test_cfg("STORE=/dev/shm COUNT", "1");
   tests_passed &= test_cfg("STORE", "/dev/shm");
   tests_passed &= test_cfg("STORE=/dev/shm GROUP", "NODE");
 

--- a/src/scr.c
+++ b/src/scr.c
@@ -2325,11 +2325,14 @@ const char* SCR_Config(const char* config_string)
 
   /* ensure all ranks specified identical value for config_string */
   char* tmpstr = NULL;
-  if (scr_my_rank_world == 0) {
+  if (scr_my_rank_world == 0 && config_string != NULL) {
     tmpstr = strdup(config_string);
   }
   scr_str_bcast(&tmpstr, 0, scr_comm_world);
-  if (strcmp(config_string, tmpstr) != 0) {
+  if ((config_string == NULL && tmpstr != NULL) ||
+      (config_string != NULL && tmpstr == NULL) ||
+      (config_string != NULL && tmpstr != NULL && strcmp(config_string, tmpstr) != 0))
+  {
     scr_abort(-1, "SCR_Config string must be identical on all processes @ %s:%d",
       __FILE__, __LINE__
     );

--- a/src/scr.c
+++ b/src/scr.c
@@ -2398,6 +2398,10 @@ const char* SCR_Config(const char* config_string)
   kvtree* value_hash   = NULL;
   int is_query         = -1; /* basically tracks if I have seen a '=' but no value yet */
 
+  /* make a copy of the input string, so we can modify it */
+  char* writable_config_string = strdup(config_string);
+  assert(writable_config_string);
+
   /* this is a small state machine to parse name=value pairs of settings,
    * and while I could encode all of this as a table of transitions, it seems
    * that people are usually unhappy with the table form and like an explicit

--- a/src/scr_config.c
+++ b/src/scr_config.c
@@ -40,6 +40,7 @@
 #include <fcntl.h>
 #include <string.h>
 #include <strings.h>
+#include <assert.h>
 
 /* variable length args */
 #include <stdarg.h>
@@ -339,4 +340,93 @@ int scr_config_read_common(const char* file, kvtree* hash)
   fclose(fs);
 
   return SCR_SUCCESS;
+}
+
+int scr_config_write_common(const char* file, const kvtree* hash)
+{
+  int rc = SCR_SUCCESS;
+
+  /* no need to write out a file for a NULL hash,
+   * but let's delete any existing file */
+  if (hash == NULL) {
+    scr_file_unlink(file);
+    return rc;
+  }
+
+  FILE* fh = fopen(file, "w");
+  if (fh != NULL) {
+    int success = 1;
+    kvtree_elem* topkey;
+    for (topkey = kvtree_elem_first(hash);
+         topkey != NULL && success;
+         topkey = kvtree_elem_next(topkey))
+    {
+      kvtree_elem* topval;
+      for (topval = kvtree_elem_first(kvtree_elem_hash(topkey));
+           topval != NULL && success;
+           topval = kvtree_elem_next(topval))
+      {
+        /* NULL values mark deleted entries */
+        if (topval == NULL) {
+          continue;
+        }
+
+        if (fprintf(fh, "%s=%s",
+            kvtree_elem_key(topkey), kvtree_elem_key(topval)) < 0)
+        {
+          success = 0;
+          break;
+        }
+
+        kvtree_elem* key;
+        for (key = kvtree_elem_first(kvtree_elem_hash(topval));
+             key != NULL;
+             key = kvtree_elem_next(key))
+        {
+          kvtree_elem *val = kvtree_elem_first(kvtree_elem_hash(key));
+
+          /* NULL values mark deleted entries */
+          if (val == NULL) {
+            continue;
+          }
+
+          if (fprintf(fh, " %s=%s",
+              kvtree_elem_key(key), kvtree_elem_key(val)) < 0)
+          {
+            success = 0;
+            break;
+          }
+
+          /* assert that app hash is at most a 2-level deep nesting */
+          assert(kvtree_elem_first(kvtree_elem_hash(val)) == NULL);
+        } /* for key */
+
+        if (fputc('\n', fh) == EOF) {
+          success = 0;
+          break;
+        }
+      } /* for topval */
+    } /* for topkey */
+
+    if (! success) {
+      scr_err("Failed to write to config file: '%s' %s @ %s:%d",
+        file, strerror(errno), __FILE__, __LINE__
+      );
+      rc = SCR_FAILURE;
+    }
+
+    if (fclose(fh) != 0) {
+      scr_err("Failed to close config file after writing: '%s' %s @ %s:%d",
+        file, strerror(errno), __FILE__, __LINE__
+      );
+      rc = SCR_FAILURE;
+    }
+  } else {
+    scr_err("Failed to open config file for writing: '%s' %s @ %s:%d",
+      file, strerror(errno), __FILE__, __LINE__
+    );
+    rc = SCR_FAILURE;
+  }
+
+  return rc;
 }

--- a/src/scr_config.h
+++ b/src/scr_config.h
@@ -18,4 +18,9 @@ int scr_config_read_common(const char* file, kvtree* hash);
 
 int scr_config_read(const char* file, kvtree* hash);
 
+int scr_config_write_common(const char* file, const kvtree* hash);
+
+/* write parameters to config file */
+int scr_config_write(const char* file, const kvtree* hash);
+
 #endif

--- a/src/scr_config_mpi.c
+++ b/src/scr_config_mpi.c
@@ -28,22 +28,6 @@ int scr_config_read(const char* file, kvtree* hash)
 {
   int rc = SCR_FAILURE;
 
-  /* scr_config_read is called from scr_app_hash_init which runs before
-   * SCR_Init so MPI may not have been properly set up yet.
-   */
-  /* TODO: this is quite bad, not sure if one could first store all
-   * scr_config settings on all ranks, then in scr_param_init, once MPI is
-   * available, have rank 0 bcast its results. Problem is how ot read in
-   * app.conf before that on only one rank, or find out how to correctly
-   * merge it in afterwards such that subkeys stay deleted. */
-  if (scr_comm_world == MPI_COMM_NULL) {
-    MPI_Comm_dup(MPI_COMM_WORLD,  &scr_comm_world);
-    MPI_Comm_rank(scr_comm_world, &scr_my_rank_world);
-    MPI_Comm_size(scr_comm_world, &scr_ranks_world);
-  }
-  assert(scr_ranks_world > 0);
-  assert(scr_comm_world != MPI_COMM_NULL);
-
   /* only rank 0 reads the file */
   if (scr_my_rank_world == 0) {
     rc = scr_config_read_common(file, hash);

--- a/src/scr_config_mpi.c
+++ b/src/scr_config_mpi.c
@@ -44,3 +44,19 @@ int scr_config_read(const char* file, kvtree* hash)
 
   return rc;
 }
+
+/* write parameters to config file */
+int scr_config_write(const char* file, const kvtree* hash)
+{
+  int rc = SCR_FAILURE;
+
+  /* only rank 0 reads the file */
+  if (scr_my_rank_world == 0) {
+    rc = scr_config_write_common(file, hash);
+  }
+
+  /* broadcast whether rank 0 read the file ok */
+  MPI_Bcast(&rc, 1, MPI_INT, 0, scr_comm_world);
+
+  return rc;
+}

--- a/src/scr_config_serial.c
+++ b/src/scr_config_serial.c
@@ -37,3 +37,10 @@ int scr_config_read(const char* file, kvtree* hash)
   int rc = scr_config_read_common(file, hash);
   return rc;
 }
+
+/* write parameters from hash to config file */
+int scr_config_write(const char* file, const kvtree* hash)
+{
+  int rc = scr_config_write_common(file, hash);
+  return rc;
+}

--- a/src/scr_globals.h
+++ b/src/scr_globals.h
@@ -211,6 +211,8 @@ extern int  scr_my_rank_world;    /* my rank in world */
 
 extern MPI_Comm scr_comm_node; /* communicator of all tasks on the same node */
 
+extern kvtree* scr_app_hash; /* records params set through SCR_Config */
+
 extern kvtree* scr_groupdesc_hash; /* hash defining group descriptors to be used */
 extern kvtree* scr_storedesc_hash; /* hash defining store descriptors to be used */
 extern kvtree* scr_reddesc_hash;   /* hash defining redudancy descriptors to be used */

--- a/src/scr_log.c
+++ b/src/scr_log.c
@@ -100,7 +100,11 @@ static kvtree* scr_db_types = NULL; /* caches type string to type id lookups */
 #endif
 
 /* connects to the SCR log database */
-int scr_mysql_connect(const char* host, const char* user, const char* pass, const char* name)
+int scr_mysql_connect(
+  const char* host,
+  const char* user,
+  const char* pass,
+  const char* name)
 {
 #ifdef HAVE_LIBMYSQLCLIENT
   /* create our type-string-to-id cache */
@@ -421,7 +425,12 @@ int scr_mysql_type_id(const char* type, int* id)
 }
 
 /* records an SCR event in the SCR log database */
-int scr_mysql_log_event(const char* type, const char* note, const int* dset, const time_t* start, const double* secs)
+int scr_mysql_log_event(
+  const char* type,
+  const char* note,
+  const int* dset,
+  const time_t* start,
+  const double* secs)
 {
 #ifdef HAVE_LIBMYSQLCLIENT
   /* lookup the id for the type string */
@@ -492,7 +501,14 @@ int scr_mysql_log_event(const char* type, const char* note, const int* dset, con
 }
 
 /* records an SCR file transfer (copy/fetch/flush/drain) in the SCR log database */
-int scr_mysql_log_transfer(const char* type, const char* from, const char* to, const int* dset, const time_t* start, const double* secs, const double* bytes)
+int scr_mysql_log_transfer(
+  const char* type,
+  const char* from,
+  const char* to,
+  const int* dset,
+  const time_t* start,
+  const double* secs,
+  const double* bytes)
 {
 #ifdef HAVE_LIBMYSQLCLIENT
   /* lookup the id for the type string */
@@ -655,7 +671,11 @@ int scr_mysql_read_job(unsigned long username_id, unsigned long jobname_id, unsi
   return SCR_SUCCESS;
 }
 
-int scr_mysql_register_job(const char* username, const char* jobname, unsigned long start, unsigned long* jobid)
+int scr_mysql_register_job(
+  const char* username,
+  const char* jobname,
+  unsigned long start,
+  unsigned long* jobid)
 {
   int rc = SCR_SUCCESS;
 
@@ -941,7 +961,12 @@ int scr_log_finalize()
 }
 
 /* given a username, a jobname, and a start time, lookup (or create) the id for this job */
-int scr_log_job(const char* username, const char* hostname, const char* jobid, const char* prefix, time_t start)
+int scr_log_job(
+  const char* username,
+  const char* hostname,
+  const char* jobid,
+  const char* prefix,
+  time_t start)
 {
   int rc = SCR_SUCCESS;
 
@@ -1184,10 +1209,6 @@ int scr_log_event(
     rc = scr_mysql_log_event(type, note, dset, &start_val, secs);
   }
 
-  scr_dbg(1, "scr_log_event: type %s, note %s, dset %d, start %s, secs %f",
-    type, note, dset_val, asctime(timeinfo), secs_val
-  );
-
   return rc;
 }
 
@@ -1310,10 +1331,6 @@ int scr_log_transfer(
   if (db_enable) {
     rc = scr_mysql_log_transfer(type, from, to, dset, start, secs, bytes);
   }
-
-  scr_dbg(1, "scr_log_transfer: type %s, src %s, dst %s, dset %d, start %s, secs %f, bytes %f, files%d",
-    type, from, to, dset_val, asctime(timeinfo), secs_val, bytes_val, files_val
-  );
 
   return rc;
 }

--- a/src/scr_param.c
+++ b/src/scr_param.c
@@ -359,38 +359,15 @@ static char* app_config_path()
 {
   char* file = NULL;
 
-  /* look in the prefix directory */
-  char* prefix = NULL;
+  /* get the prefix directory */
   char* value = getenv("SCR_PREFIX");
-  if (value != NULL) {
-    /* user set SCR_PREFIX, strdup that value */
-    prefix = strdup(value);
-  } else {
-    /* if user didn't set with SCR_PREFIX,
-     * pick up the current working directory as a default */
-    char current_dir[SCR_MAX_FILENAME];
-    if (scr_getcwd(current_dir, sizeof(current_dir)) != SCR_SUCCESS) {
-      scr_abort(-1, "Problem reading current working directory @ %s:%d",
-        __FILE__, __LINE__
-      );
-    }
-    prefix = strdup(current_dir);
-  }
-
-  /* couldn't find a prefix directory, so bail */
-  if (prefix == NULL) {
-    return file;
-  }
+  spath* prefix_path = scr_get_prefix(value);
 
   /* tack file name on to directory */
-  spath* path_prefix_scr = spath_from_str(prefix);
-  spath_append_str(path_prefix_scr, ".scr");
-  spath_append_str(path_prefix_scr, SCR_CONFIG_FILE_APP);
-  file = spath_strdup(path_prefix_scr);
-  spath_delete(&path_prefix_scr);
-
-  /* free the prefix dir which we strdup'd */
-  scr_free(&prefix);
+  spath_append_str(prefix_path, ".scr");
+  spath_append_str(prefix_path, SCR_CONFIG_FILE_APP);
+  file = spath_strdup(prefix_path);
+  spath_delete(&prefix_path);
 
   return file;
 }

--- a/src/scr_param.h
+++ b/src/scr_param.h
@@ -50,9 +50,6 @@ int scr_param_init(void);
 /* free contents from config files */
 int scr_param_finalize(void);
 
-/* write application hash to config file $SCR_PREFIX/.scr/app.conf */
-void scr_param_app_hash_write_file(const char *app_config_file);
-
 /* searchs for name and returns a character pointer to its value if set,
  * returns NULL if not found */
 const char* scr_param_get(const char* name);


### PR DESCRIPTION
This updates SCR_Config in a few ways:
- add state transition check that user calls SCR_Config before calling SCR_Init
- add check that user calls SCR_Config with all processes
- add check that input string is the same across all ranks
- call scr_param_init/scr_param_finalize internally so that various hashes are defined (fixes a bug when calling SCR_Config after user has set parameter through environment variable)
- return NULL when setting a value.  This is because we now have to strdup the returned string which then needs to be freed by the caller, and this just adds extra work for most cases when settings values.  Instead, if the caller wants to know the value, they can check the value with a subsequent call to SCR_Config to query the setting.

Updates scr_param_init to create app hash by reading app.conf and updates scr_param_finalize to write out new app.conf.

TODO:
- update scripts to set param to indicate that job is using scripts (throw error if user then tries to set certain params)