### PR TITLE
define parameter to purge cache on restart

### DIFF
--- a/src/scr.c
+++ b/src/scr.c
@@ -831,6 +831,12 @@ static int scr_get_params()
     }
   }
 
+  /* whether to delete all datasets from cache on restart,
+   * primarily used for debugging */
+  if ((value = scr_param_get("SCR_CACHE_PURGE")) != NULL) {
+    scr_purge = atoi(value);
+  }
+
   /* whether to distribute files in filemap to ranks */
   if ((value = scr_param_get("SCR_DISTRIBUTE")) != NULL) {
     scr_distribute = atoi(value);
@@ -1990,6 +1996,14 @@ int SCR_Init()
    * on the node, we take this step in case the number of ranks on this node
    * has changed since the last run */
   scr_cache_index_read(scr_cindex_file, scr_cindex);
+
+  /* delete all files in cache on restart if asked to purge,
+   * this is useful during development so the user does not
+   * have to manually delete files from all nodes */
+  if (scr_purge) {
+    /* clear the cache of all files */
+    scr_cache_purge(scr_cindex);
+  }
 
   /* attempt to distribute files for a restart */
   int rc = SCR_FAILURE;

--- a/src/scr_globals.c
+++ b/src/scr_globals.c
@@ -113,6 +113,7 @@ size_t scr_file_buf_size = SCR_FILE_BUF_SIZE; /* set buffer size to chunk file c
 int scr_halt_seconds     = SCR_HALT_SECONDS; /* secs remaining in allocation before job should be halted */
 int scr_halt_enabled     = SCR_HALT_ENABLED; /* whether SCR will exit job if halt condition is detected */
 
+int   scr_purge            = 0;                    /* whether to delete all datasets from cache during SCR_Init */
 int   scr_distribute       = SCR_DISTRIBUTE;       /* whether to call scr_distribute_files during SCR_Init */
 int   scr_fetch            = SCR_FETCH;            /* whether to call scr_fetch_files during SCR_Init */
 int   scr_fetch_width      = SCR_FETCH_WIDTH;      /* specify number of processes to read files simultaneously */

--- a/src/scr_globals.h
+++ b/src/scr_globals.h
@@ -171,6 +171,7 @@ extern size_t scr_file_buf_size; /* set buffer size to chunk file copies to/from
 extern int scr_halt_seconds; /* secs remaining in allocation before job should be halted */
 extern int scr_halt_enabled; /* whether SCR will exit job if halt condition is detected */
 
+extern int   scr_purge;            /* delete all datasets from cache on restart for debugging */
 extern int   scr_distribute;       /* whether to call scr_distribute_files during SCR_Init */
 extern int   scr_fetch;            /* whether to call scr_fetch_files during SCR_Init */
 extern int   scr_fetch_width;      /* specify number of processes to read files simultaneously */


### PR DESCRIPTION
This defines a new ```SCR_CACHE_PURGE``` parameter to ask SCR to purge all datasets from cache during ```SCR_Init```.  It does this without flushing those datasets to the file system.

This setting is helpful when developing and testing SCR within an application.  Without this, one has to manually clean the cache between runs within a compute node allocation using commands like:
```
srun -n $nodes -N $nodes rm -rf /dev/shm/${USER}/scr.{$SLURM_JOBID}
srun -n $nodes -N $nodes rm -rf /ssd/${USER}/scr.{$SLURM_JOBID}
```

This setting does not delete the cache directory or other SCR metadata in cache.

Resolves https://github.com/LLNL/scr/issues/219