### PR TITLE
check mode bits, uid, and gid instead of ctime for file changes

### DIFF
--- a/src/scr_cache.c
+++ b/src/scr_cache.c
@@ -291,6 +291,8 @@ int scr_cache_delete(scr_cache_index* cindex, int id)
       scr_filemap_get_meta(map, file, meta);
 
       int file_changed = 0;
+
+      /* check that file contents have not been modified */
       if (scr_meta_check_mtime(meta, &statbuf) != SCR_SUCCESS) {
         file_changed = 1;
         scr_warn("Detected mtime change in file `%s' since it was completed @ %s:%d",
@@ -298,11 +300,10 @@ int scr_cache_delete(scr_cache_index* cindex, int id)
         );
       }
 
-      /* TODO: this check triggers when deleting a checkpoint that was rebuilt on restart,
-       * perhaps we can skip this check on rebuilt datasets? */
-      if (scr_meta_check_ctime(meta, &statbuf) != SCR_SUCCESS) {
+      /* check that permission bits, uid, and gid have not changed */
+      if (scr_meta_check_metadata(meta, &statbuf) != SCR_SUCCESS) {
         file_changed = 1;
-        scr_warn("Detected ctime change in file `%s' since it was completed @ %s:%d",
+        scr_warn("Detected change in mode bits, uid, or gid on file `%s' since it was completed @ %s:%d",
           file, __FILE__, __LINE__
         );
       }

--- a/src/scr_meta.c
+++ b/src/scr_meta.c
@@ -402,6 +402,39 @@ int scr_meta_check_ctime(const scr_meta* meta, struct stat* sb)
   return SCR_FAILURE;
 }
 
+int scr_meta_check_metadata(const scr_meta* meta, struct stat* sb)
+{
+  /* check that the mode bits (permissions) have not changed */
+  unsigned long mode;
+  if (kvtree_util_get_unsigned_long(meta, SCR_META_KEY_MODE, &mode) != KVTREE_SUCCESS) {
+    return SCR_FAILURE;
+  }
+  if (mode != (unsigned long)sb->st_mode) {
+    return SCR_FAILURE;
+  }
+
+  /* check that the user id for the owner has not changed */
+  unsigned long uid;
+  if (kvtree_util_get_unsigned_long(meta, SCR_META_KEY_UID, &uid) != KVTREE_SUCCESS) {
+    return SCR_FAILURE;
+  }
+  if (uid != (unsigned long)sb->st_uid) {
+    return SCR_FAILURE;
+  }
+
+  /* check that the group id has not changed */
+  unsigned long gid;
+  if (kvtree_util_get_unsigned_long(meta, SCR_META_KEY_GID, &gid) != KVTREE_SUCCESS) {
+    return SCR_FAILURE;
+  }
+  if (gid != (unsigned long)sb->st_gid) {
+    return SCR_FAILURE;
+  }
+
+  /* everything checks out */
+  return SCR_SUCCESS;
+}
+
 int scr_meta_apply_stat(const scr_meta* meta, const char* file)
 {
   int rc = SCR_SUCCESS;

--- a/src/scr_meta.h
+++ b/src/scr_meta.h
@@ -157,6 +157,9 @@ int scr_meta_check_mtime(const scr_meta* meta, struct stat* statbuf);
 /* returns SCR_SUCCESS if ctime is set and if it matches values in statbuf */
 int scr_meta_check_ctime(const scr_meta* meta, struct stat* statbuf);
 
+/* returns SCR_SUCCESS if mode bits, uid, and gid match values in statbuf */
+int scr_meta_check_metadata(const scr_meta* meta, struct stat* statbuf);
+
 /* apply stat metadata recorded in meta to given file path */
 int scr_meta_apply_stat(const scr_meta* meta, const char* file);
 


### PR DESCRIPTION
When looking for changes to a file before deleting it from cache, this replaces the ctime check with checks against mode bits, uid, and gid instead.  The ctime check was intended as a quick way to look for changes to those fields.  However, a rebuild of a file would change ctime, which led to false positives.