### PR TITLE
add scr_configf for formatted config calls

### DIFF
--- a/src/scr.c
+++ b/src/scr.c
@@ -2675,6 +2675,39 @@ const char* SCR_Config(const char* config_string)
   return retval;
 }
 
+const char* SCR_Configf(const char* format, ...)
+{
+  /* manage state transition */
+  if (scr_state != SCR_STATE_UNINIT) {
+    scr_state_transition_error(scr_state, "SCR_Configf()", __FILE__, __LINE__);
+  }
+
+  /* if not enabled, bail with an error */
+  if (! scr_enabled) {
+    return NULL;
+  }
+
+  /* compute the size of the string we need to allocate */
+  va_list args;
+  va_start(args, format);
+  int size = vsnprintf(NULL, 0, format, args) + 1;
+  va_end(args);
+
+  /* allocate and print the string */
+  char* str = (char*) SCR_MALLOC(size);
+  va_start(args, format);
+  vsnprintf(str, size, format, args);
+  va_end(args);
+
+  /* delegate work to SCR_Config and get result */
+  char* ret = SCR_Config(str);
+
+  /* free the temporary string */
+  scr_free(&str);
+
+  return ret;
+}
+
 /* sets flag to 1 if a checkpoint should be taken, flag is set to 0 otherwise */
 int SCR_Need_checkpoint(int* flag)
 {

--- a/src/scr.h
+++ b/src/scr.h
@@ -58,6 +58,9 @@ int SCR_Finalize(void);
  */
 const char* SCR_Config(const char* config);
 
+/* Formatted version of SCR_Config, for printf-like formatting */
+const char* SCR_Configf(const char* format, ...);
+
 /*****************
  * File registration
  ****************/


### PR DESCRIPTION
SCR_Config is working well in the apps so far, but it does lead to a lot of patterns like the following:
```
char config[1024];
snprintf(config, sizeof(config), "SCR_FLUSH=%d", checkpoint_freq);
SCR_Config(config);
```
This adds a formatted option, so the above simplifies to:
```
SCR_Configf("SCR_FLUSH=%d", checkpoint_freq);
```
This should help with C/C++ users.  Don't know if there is something similar for Fortran or not.