### PR TITLE
change default behavior to not exit on active halt condition

### DIFF
--- a/doc/rst/users/api.rst
+++ b/doc/rst/users/api.rst
@@ -173,10 +173,8 @@ It is recommended to call this function after each checkpoint.
 
 It is critical for a job to stop early enough to leave time to copy datasets
 from cache to the parallel file system before the allocation expires.
-By default, the SCR library automatically calls :code:`exit` at certain points.
-This works especially well in conjunction with the :code:`SCR_HALT_SECONDS` parameter.
-However, this default behavior does not provide the application a chance to exit cleanly.
-SCR can be configured to avoid an automatic exit using the :code:`SCR_HALT_ENABLED` parameter.
+One can configure how early the job should exit within its allocation
+by setting the :code:`SCR_HALT_SECONDS` parameter.
 
 This call also enables a running application to react to external commands.
 For instance, if the application has been instructed to halt using the :code:`scr_halt` command,
@@ -381,11 +379,7 @@ that started with the preceding call to :code:`SCR_Start_output`.
 
 In the current implementation,
 SCR applies the redundancy scheme during :code:`SCR_Complete_output`.
-Before returning from the function,
-MPI rank 0 determines whether the job should be halted
-and signals this condition to all other ranks (see :ref:`sec-halt`).
-If the job should be halted, rank 0 records a reason in the halt file,
-and then all tasks call :code:`exit`, unless the auto exit feature is disabled.
+The dataset is then flushed to the prefix directory if needed.
 
 Restart API
 -----------

--- a/doc/rst/users/halt.rst
+++ b/doc/rst/users/halt.rst
@@ -19,11 +19,13 @@ A number of different halt conditions can be specified.
 In most cases, the :code:`scr_halt` command communicates these conditions to the running
 application via the :code:`halt.scr` file,
 which is stored in the hidden :code:`.scr` directory within the prefix directory.
-The SCR library reads the halt file when the application calls :code:`SCR_Init`
-and each time the application completes a checkpoint.
+The application can determine when to exit by calling :code:`SCR_Should_exit`.
+
+Additionally, one can set :code:`SCR_HALT_EXIT=1` to configure SCR to exit the job
+if it detects an active halt condition.
+In that case, the SCR library reads the halt file when the application calls :code:`SCR_Init`
+and during :code:`SCR_Complete_output` after each complete checkpoint.
 If a halt condition is satisfied, all tasks in the application call :code:`exit`.
-One can disable this behavior by setting the :code:`SCR_HALT_ENABLED` parameter to 0.
-In this case, the application can determine when to exit by calling :code:`SCR_Should_exit`.
 
 Halt after next checkpoint
 --------------------------

--- a/src/scr_conf.h
+++ b/src/scr_conf.h
@@ -77,9 +77,9 @@
 #define SCR_HALT_SECONDS (0)
 #endif
 
-/* whether SCR will shut down and call exit if halt condition is detected */
-#ifndef SCR_HALT_ENABLED
-#define SCR_HALT_ENABLED (1)
+/* whether SCR will call exit if halt condition is detected */
+#ifndef SCR_HALT_EXIT
+#define SCR_HALT_EXIT (0)
 #endif
 
 /* =========================================================================
@@ -99,12 +99,12 @@
 
 /* base control directory */
 #ifndef SCR_CNTL_BASE
-#define SCR_CNTL_BASE "/tmp"
+#define SCR_CNTL_BASE "/dev/shm"
 #endif
 
 /* default base cache directory */
 #ifndef SCR_CACHE_BASE
-#define SCR_CACHE_BASE "/tmp"
+#define SCR_CACHE_BASE "/dev/shm"
 #endif
 
 /* default cache size (max number of checkpoints to keep in cache) */
@@ -191,7 +191,7 @@
 #define SCR_FLUSH_ON_RESTART (0)
 #endif
 
-/* when set, SCR will flush on restart and disable fetch for codes that must restart from the PFS */
+/* when set, SCR will flush on restart and set fetch to bypass mode for codes that must restart from the PFS */
 #ifndef SCR_GLOBAL_RESTART
 #define SCR_GLOBAL_RESTART (0)
 #endif

--- a/src/scr_globals.c
+++ b/src/scr_globals.c
@@ -112,7 +112,7 @@ size_t scr_mpi_buf_size  = SCR_MPI_BUF_SIZE;  /* set MPI buffer size to chunk fi
 size_t scr_file_buf_size = SCR_FILE_BUF_SIZE; /* set buffer size to chunk file copies to/from parallel file system */
 
 int scr_halt_seconds     = SCR_HALT_SECONDS; /* secs remaining in allocation before job should be halted */
-int scr_halt_enabled     = SCR_HALT_ENABLED; /* whether SCR will exit job if halt condition is detected */
+int scr_halt_exit        = SCR_HALT_EXIT;    /* whether SCR will call exit if halt condition is detected */
 
 int   scr_purge            = 0;                    /* whether to delete all datasets from cache during SCR_Init */
 int   scr_distribute       = SCR_DISTRIBUTE;       /* whether to call scr_distribute_files during SCR_Init */

--- a/src/scr_globals.h
+++ b/src/scr_globals.h
@@ -170,7 +170,7 @@ extern size_t scr_mpi_buf_size;  /* set MPI buffer size to chunk file transfer *
 extern size_t scr_file_buf_size; /* set buffer size to chunk file copies to/from parallel file system */
 
 extern int scr_halt_seconds; /* secs remaining in allocation before job should be halted */
-extern int scr_halt_enabled; /* whether SCR will exit job if halt condition is detected */
+extern int scr_halt_exit;    /* whether SCR will call exit if halt condition is detected */
 
 extern int   scr_purge;            /* delete all datasets from cache on restart for debugging */
 extern int   scr_distribute;       /* whether to call scr_distribute_files during SCR_Init */


### PR DESCRIPTION
By default, SCR calls ``exit(0)`` when it detects an active halt condition.

https://github.com/LLNL/scr/blob/073d0352b06bbaf3034f411f2b882902cd74f80e/src/scr.c#L369

This check executes during ``SCR_Init`` and during ``SCR_Complete_output`` after completing a successful checkpoint.  This behavior is useful for some apps, but others will likely find this behavior to be disruptive.

Since the docs have been updated to suggest that apps make calls to ``SCR_Should_exit``, this switches the default SCR behavior to *not* exit.

Users can restore the old behavior by setting ``SCR_HALT_EXIT=1``.

Changed documentation in places to match this new default behavior:
- https://scr.readthedocs.io/en/v2.0.0/users/api.html#scr-complete-checkpoint
- https://scr.readthedocs.io/en/v2.0.0/users/api.html#scr-should-exit
- https://scr.readthedocs.io/en/v2.0.0/users/config.html#scr-parameters
- https://scr.readthedocs.io/en/v2.0.0/users/halt.html#scr-halt-and-the-halt-file

Changed this parameter name from ``SCR_HALT_ENABLED`` to ``SCR_HALT_EXIT``, since halt logic is always enabled.  The difference is whether SCR calls exit or not.