### PR TITLE
add SCR_PREFIX_PURGE to delete all datasets listed in index file

### DIFF
--- a/doc/rst/users/config.rst
+++ b/doc/rst/users/config.rst
@@ -322,6 +322,9 @@ The table in this section specifies the full set of SCR configuration parameters
        SCR deletes older checkpoints as new checkpoints are flushed to maintain a sliding window of the specified size.
        Set to 0 to keep all checkpoints.
        Checkpoints marked with :code:`SCR_FLAG_OUTPUT` are not deleted.
+   * - :code:`SCR_PREFIX_PURGE`
+     - 0
+     - Set to 1 to delete all datasets from the prefix directory (both checkpoint and output) during :code:`SCR_Init`.
    * - :code:`SCR_CURRENT`
      - N/A
      - Name of checkpoint to mark as current and attempt to fetch in a new run during :code:`SCR_Init`.

--- a/src/scr.c
+++ b/src/scr.c
@@ -908,6 +908,14 @@ static int scr_get_params()
     scr_prefix_size = atoi(value);
   }
 
+  /* Some applications provide options so their users can wipe out all checkpoints
+   * and start over.  While one could call SCR_Delete for each of those in turn,
+   * we provide this option as a convenience.  If set, SCR will read the index file
+   * and delete *all* datasets, both checkpoint and output. */
+  if ((value = scr_param_get("SCR_PREFIX_PURGE")) != NULL) {
+    scr_prefix_purge = atoi(value);
+  }
+
   /* specify whether to use asynchronous flush */
   if ((value = scr_param_get("SCR_FLUSH_ASYNC")) != NULL) {
     scr_flush_async = atoi(value);
@@ -2053,6 +2061,12 @@ int SCR_Init()
   if (scr_purge) {
     /* clear the cache of all files */
     scr_cache_purge(scr_cindex);
+  }
+
+  /* delete all datasets listed in the index file if
+   * asked to purge the prefix directory */
+  if (scr_prefix_purge) {
+    scr_prefix_delete_all();
   }
 
   /* attempt to distribute files for a restart */

--- a/src/scr_globals.c
+++ b/src/scr_globals.c
@@ -133,7 +133,8 @@ int    scr_flush_async_in_progress = 0;                       /* tracks whether 
 int    scr_flush_async_dataset_id  = -1;                      /* tracks the id of the checkpoint being flushed */
 double scr_flush_async_bytes       = 0.0;                     /* records the total number of bytes to be flushed */
 
-int scr_prefix_size = SCR_PREFIX_SIZE; /* max number of checkpoints to keep in prefix directory */
+int scr_prefix_size  = SCR_PREFIX_SIZE; /* max number of checkpoints to keep in prefix directory */
+int scr_prefix_purge = 0;               /* whether to delete all datasets listed in index file during SCR_Init */
 
 int scr_crc_on_copy   = SCR_CRC_ON_COPY;   /* whether to enable crc32 checks during scr_swap_files() */
 int scr_crc_on_flush  = SCR_CRC_ON_FLUSH;  /* whether to enable crc32 checks during flush and fetch */

--- a/src/scr_globals.h
+++ b/src/scr_globals.h
@@ -184,7 +184,8 @@ extern int   scr_flush_on_restart; /* specify whether to flush cache on restart 
 extern int   scr_global_restart;   /* set if code must be restarted from parallel file system */
 extern int   scr_drop_after_current; /* auto-drop datasets from index that come after named checkpoint when calling SCR_Current */
 
-extern int scr_prefix_size; /* max number of checkpoints to keep in prefix directory */
+extern int scr_prefix_size;  /* max number of checkpoints to keep in prefix directory */
+extern int scr_prefix_purge; /* whether to delete all datasets listed in index file during SCR_Init */
 
 extern int scr_flush_async;             /* whether to use asynchronous flush */
 extern double scr_flush_async_bw;       /* bandwidth limit imposed during async flush */

--- a/src/scr_index_api.h
+++ b/src/scr_index_api.h
@@ -75,6 +75,10 @@ int scr_index_get_id_by_name(const kvtree* index, const char* name, int* id);
  * setting earlier_than = -1 disables this filter */
 int scr_index_get_most_recent_complete(const kvtree* index, int earlier_than, int* id, char* name);
 
+/* lookup the dataset having the lowest id, return its id and name,
+ * sets id to -1 to indicate no dataset is left */
+int scr_index_get_oldest(const kvtree* index, int* id, char* name);
+
 /* remove checkpoints from index that are later than given dataset id */
 int scr_index_remove_later(kvtree* index, int id);
 

--- a/src/scr_prefix.h
+++ b/src/scr_prefix.h
@@ -21,4 +21,8 @@ int scr_prefix_delete(int id, const char* name);
  * excludes checkpoints that are marked as output */
 int scr_prefix_delete_sliding(int id, int window);
 
+/* delete all datasets listed in the index file,
+ * both checkpoint and output */
+int scr_prefix_delete_all(void);
+
 #endif /* SCR_PREFIX_H */


### PR DESCRIPTION
Some applications provide an option to let their users restart the run from scratch.  This parameter tells SCR to delete all datasets from the prefix directory during SCR_Init.  It deletes all datasets (both checkpoint and output) listed in the index file.