### PR TITLE
fix: clear cache index object in cache purge

### DIFF
--- a/src/scr_cache.c
+++ b/src/scr_cache.c
@@ -492,17 +492,16 @@ int scr_cache_purge(scr_cache_index* cindex)
     }
   } while (current_id != -1);
 
-  /* now delete the cache index itself */
+  /* free our list of dataset ids */
+  scr_free(&dsets);
+
+  /* delete the cache index file itself */
   char* file = spath_strdup(scr_cindex_file);
   scr_file_unlink(file);
   scr_free(&file);
 
-  /* TODO: want to clear the map object here? */
-
-  /* TODO: want to delete the cache index file? */
-
-  /* free our list of dataset ids */
-  scr_free(&dsets);
+  /* clear the cache index object */
+  scr_cache_index_clear(cindex);
 
   return 1;
 }


### PR DESCRIPTION
The cache purge function would delete the cache index file, but it did not clear the object.  If a run then later rewrote the cache index file, any settings in the object (which might now be stale) would be written back to the file so that a subsequent run would pick up those inconsistent settings.