### PR TITLE
add code of conduct and contributing guide

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,43 @@
+# SCR Community Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the SCR project or its community. Examples of representing the project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of the project may be further defined and clarified by SCR maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the SCR PI at `kathryn@llnl.gov`. The SCR team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The SCR team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/) ([version 1.4](http://contributor-covenant.org/version/1/4)).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 SCR is an open source project. We welcome contributions via pull requests as well as questions, feature requests, or bug reports via issues. Contact our team through GitHub issues or via the [mailing lists](https://computing.llnl.gov/projects/scalable-checkpoint-restart-for-mpi/contact). Please also refer to our [code of conduct](CODE_OF_CONDUCT.md).
 
-If you aren't an SCR developer at LLNL, you won't have permission to push new branches to the repository. First, you should create a fork. This will create your copy of the SCR repository and ensure you can push your changes up to GitHub and create PRs. SCR uses Travis for continuous integration tests. Our tests are automatically run against every new PR, and passing all tests is a requirement for merging your PR.
+If you aren't an SCR developer at LLNL, you won't have permission to push new branches to the repository. First, you should create a fork. This will create your copy of the SCR repository and ensure you can push your changes up to GitHub and create PRs. SCR uses LLNL internal resources via gitlab runners to test code changes. Please include details on how we can test your contribution.
 
 * Create your branches off the `develop` branch.
 * Clearly name your branches, commits, and PRs as this will help us manage queued work in a timely manner.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,13 @@
+# SCR Contributing Guidelines
+
+SCR is an open source project. We welcome contributions via pull requests as well as questions, feature requests, or bug reports via issues. Contact our team through GitHub issues or via the [mailing lists](https://computing.llnl.gov/projects/scalable-checkpoint-restart-for-mpi/contact). Please also refer to our [code of conduct](CODE_OF_CONDUCT.md).
+
+If you aren't an SCR developer at LLNL, you won't have permission to push new branches to the repository. First, you should create a fork. This will create your copy of the SCR repository and ensure you can push your changes up to GitHub and create PRs. SCR uses Travis for continuous integration tests. Our tests are automatically run against every new PR, and passing all tests is a requirement for merging your PR.
+
+* Create your branches off the `develop` branch.
+* Clearly name your branches, commits, and PRs as this will help us manage queued work in a timely manner.
+* Articulate your commit messages in the imperative (e.g., `Adds new privacy policy link to README`).
+* Commit your work in logically organized commits, and group commits together logically in a PR.
+* Title each PR clearly and give it an unambiguous description.
+* Review existing issues before opening a new one. Your issue might already be under development or discussed by others. Feel free to add to any outstanding issue/bug.
+* Be explicit when opening issues and reporting bugs. What behavior are you expecting? What is your justification or use case for the new feature/enhancement? How can the bug be recreated? What are any environment variables to consider?


### PR DESCRIPTION
Ping @kathrynmohror @adammoody 

Adding code of conduct and contributing guide for SCR. Something similar will go into the components. 

@kathrynmohror, I put your email down as the Code of conduct contact person (and project PI), since I didn't feel that those emails should go to the mailing list. Is this okay? I could also leave out that portion.