### PR TITLE
set SCR_END_TIME for SLURM to be used when YOGRT is not present

### DIFF
--- a/scripts/TLCC/scr_run.in
+++ b/scripts/TLCC/scr_run.in
@@ -133,6 +133,8 @@ if [ "$SCR_FLUSH_ASYNC" == "1" ] ; then
   daemon_pid=$!
 fi
 
+export SCR_END_TIME=$(date -d $(scontrol --oneliner show job $SLURM_JOBID | perl -n -e 'm/EndTime=(\S*)/ and print $1') +%s)
+
 # enter the run loop
 down_nodes=""
 attempts=0


### PR DESCRIPTION
scr can use use libyogrt to find out how much time is left in a job. However libyogrt is an optional dependency and scr can be built without it. 

For many scheduling systems scr_run sets an env variable `SCR_END_TIME` which is used as a fallback to compute the remaining time.

This pull request sets this variable based on information obtained from `scrontrol`.

Tested to work on SLURM on my workstation.