### PR TITLE
allow user to set SCR_CNTL_BASE at runtime

### DIFF
--- a/scripts/common/scr_param.pm.in
+++ b/scripts/common/scr_param.pm.in
@@ -70,7 +70,6 @@ sub new
   # set our restricted parameters,
   # these can't be set via env vars or user conf file
   $self->{no_user} = {};
-  $self->{no_user}{"SCR_CNTL_BASE"} = {};
 
   # NOTE: At this point we could scan the environment and user config file
   # for restricted parameters to print a warning.  However, in this case

--- a/src/scr_param.c
+++ b/src/scr_param.c
@@ -422,7 +422,6 @@ int scr_param_init()
     /* allocate hash object to hold names we cannot read from the
      * environment */
     scr_no_user_hash = kvtree_new();
-    kvtree_set(scr_no_user_hash, "SCR_CNTL_BASE", kvtree_new());
 
     /* read in app config file which records any parameters set
      * by application through calls to SCR_Config */

--- a/src/scr_reddesc.c
+++ b/src/scr_reddesc.c
@@ -288,6 +288,8 @@ int scr_reddesc_create_from_hash(
   int set_failures = scr_set_failures;
   kvtree_util_get_int(hash, SCR_CONFIG_KEY_SET_FAILURES, &set_failures);
   if (set_failures < 1 || set_failures > set_size) {
+    /* invalid value for number of failures within a set, disable this descriptor */
+    d->enabled = 0;
     if (scr_my_rank_world == 0) {
       scr_warn("Number of redundancy encodings (%d) must be in the range [1,%d] in redundancy descriptor %d, disabling @ %s:%d",
         set_failures, set_size, d->index, __FILE__, __LINE__


### PR DESCRIPTION
Some people would like to run test jobs in which they get an allocation and then run multiple, independent job steps, where each job step is actually a different test/simulation.  Additionally, these tests may run on the same node.  This leads to a problem because SCR uses the same control and cache directory for all of those, e.g., ``/dev/shm/$USER/scr.$SLURM_JOBID``, whereas they each need their own directory.

This is unusual, but a work around would be to let the user specify different ``SCR_CNTL_BASE`` and ``SCR_CACHE_BASE`` directories for each of their tests.  However, SCR restricts someone from setting ``SCR_CNTL_BASE`` at run time.  It is a configure option or it must be set in the "system" config file, which is installed to a path that is hard coded at build time.

This constraint allowed external commands/scripts to query/set properties on a running job with only knowing the nodes it was using.  I'll keep this PR as WIP until I can check whether that is still needed, and if so, perhaps it's an acceptable trade off to give up in order to let the user set the control directory at runtime.