### PR TITLE
doc: update text about setting SCR_CNTL_BASE

### DIFF
--- a/doc/rst/users/build.rst
+++ b/doc/rst/users/build.rst
@@ -68,11 +68,3 @@ Some useful CMake command line options are:
 * :code:`-DSCR_CNTL_BASE=[path]` : Path to SCR Control directory, defaults to :code:`/dev/shm`
 * :code:`-DSCR_CACHE_BASE=[path]` : Path to SCR Cache directory, defaults to :code:`/dev/shm`
 * :code:`-DSCR_CONFIG_FILE=[path]` : Path to SCR system configuration file, defaults to :code:`/etc/scr/scr.conf`
-
-To change the SCR control directory, one must either set :code:`-DSCR_CNTL_BASE` at build time
-or one must specify :code:`SCR_CNTL_BASE` in the SCR system configuration file.
-These paths are hardcoded into the SCR library and scripts during the build process.
-It is not possible to specify the control directory through environment variables or the user configuration file.
-
-Unlike the control directory, the SCR cache directory can be specified at run time
-through either environment variables or the user configuration file.

--- a/doc/rst/users/config.rst
+++ b/doc/rst/users/config.rst
@@ -19,11 +19,6 @@ taking the first value it finds.
 * System configuration file,
 * Compile-time constants.
 
-Some parameters, such as the location of the control directory,
-cannot be specified by the user.
-Such parameters must be either set in the system configuration file
-or hard-coded into SCR as compile-time constants.
-
 To find a user configuration file,
 SCR looks for a file named :code:`.scrconf` in the prefix directory (note the leading dot).
 Alternatively, one may specify the name and location of the user configuration file
@@ -271,6 +266,9 @@ The table in this section specifies the full set of SCR configuration parameters
    * - :code:`SCR_CHECKPOINT_OVERHEAD`
      - 0.0
      - Set to positive floating-point value to specify maximum percent overhead allowed for checkpointing operations as guided by :code:`SCR_Need_checkpoint`.
+   * - :code:`SCR_CNTL_BASE`
+     - :code:`/dev/shm`
+     - Specify the default base directory SCR should use to store its runtime control metadata.  The control directory should be in fast, node-local storage like RAM disk.
    * - :code:`SCR_HALT_EXIT`
      - 0
      - Whether SCR should call :code:`exit()` when it detects an active halt condition.

--- a/doc/rst/users/overview.rst
+++ b/doc/rst/users/overview.rst
@@ -103,8 +103,8 @@ SCR incorporates a control base directory name along with
 the user name and allocation id associated with the resource allocation.
 This enables multiple users, or multiple jobs by the same user,
 to run at the same time without conflicting for the same control directory.
-The control base directory is hard-coded into the SCR library at configure time,
-but this value may be overridden via a system configuration file.
+A default control base directory is hard-coded into the SCR library at configure time,
+but this value may be overridden at runtime.
 
 SCR can direct the application to write dataset files to subdirectories
 within a *cache directory*.
@@ -119,11 +119,9 @@ Cache directories should ideally be located on scalable storage.
 To construct the full path of a cache directory,
 SCR incorporates a cache base directory name with
 the user name and the allocation id associated with the resource allocation.
-A set of valid cache base directories is hard-coded into the SCR library at configure time,
-but this set can be overridden in a system configuration file.
-Out of this set, one may select a subset of cache base
-directories to use during a run.
 It is valid for a cache directory to use the same base path as the control directory.
+A default cache base directory is hard-coded into the SCR library at configure time,
+but this value may be overridden at runtime.
 
 The user must configure the maximum number of datasets
 that SCR should keep in each cache directory.


### PR DESCRIPTION
Update documentation to remove restriction on the user setting SCR_CNTL_BASE at run time.