### PR TITLE
clean up of examples makefile

### DIFF
--- a/examples/makefile.examples.in
+++ b/examples/makefile.examples.in
@@ -2,8 +2,8 @@ MPICC     ?= mpicc
 MPICXX    ?= mpicxx
 MPIF90    ?= mpif90
 OPT       ?= -g -O3
-LIBDIR     = -L@X_LIBDIR@ -Wl,-rpath,@X_LIBDIR@ -lscr @SCR_LINK_LINE@
-INCLUDES   = -I@X_INCLUDEDIR@ -I/usr/include -I.
+LIBDIR     = -L@X_LIBDIR@ -Wl,-rpath,@X_LIBDIR@ -lscr
+INCLUDES   = -I@X_INCLUDEDIR@
 
 all: test_api test_api_multiple test_interpose test_interpose_multiple test_ckpt test_ckpt_F
 


### PR DESCRIPTION
This works in my testing.

The examples and this functional makefile is installed to `install-path/scr/share/examples/`. Users can run `make` there to successfully build all the examples.

The only thing to note is that if ENABLE_FORTRAN is turned of at the SCR project level, the examples will still include the fortran examples. If fortran is disabled because it’s not installed (such as mpif90 does not exist) then there may be an error.