### PR TITLE
Spack and CMake review of build docs

### DIFF
--- a/doc/rst/users/integration.rst
+++ b/doc/rst/users/integration.rst
@@ -506,7 +506,7 @@ to the installation directory for SCR.
 ========================== ============================================================================
 Compile Flags              :code:`-I$(SCR_INSTALL_DIR)/include`
 C Dynamic Link Flags       :code:`-L$(SCR_INSTALL_DIR)/lib64 -lscr -Wl,-rpath,$(SCR_INSTALL_DIR)/lib64`
-C Static Link Flags        :code:`-L$(SCR_INSTALL_DIR)/lib64 -lscr -lz`
+C Static Link Flags        :code:`-L$(SCR_INSTALL_DIR)/lib64 -lscr`
 Fortran Dynamic Link Flags :code:`-L$(SCR_INSTALL_DIR)/lib64 -lscrf -Wl,-rpath,$(SCR_INSTALL_DIR)/lib64`
-Fortran Static Link Flags  :code:`-L$(SCR_INSTALL_DIR)/lib64 -lscrf -lz`
+Fortran Static Link Flags  :code:`-L$(SCR_INSTALL_DIR)/lib64 -lscrf`
 ========================== ============================================================================

--- a/doc/rst/users/integration.rst
+++ b/doc/rst/users/integration.rst
@@ -513,3 +513,9 @@ Fortran Static Link Flags  :code:`-L$(SCR_INSTALL_DIR)/lib64 -lscrf`
 
 .. note::
    On some platforms the default library installation path will be :code:`/lib` instead of :code:`/lib64`.
+
+If Spack was used to build SCR, the :code:`SCR_INSTALL_DIR` can be found with:
+
+.. code-block:: bash
+
+  spack location -i scr

--- a/doc/rst/users/integration.rst
+++ b/doc/rst/users/integration.rst
@@ -510,3 +510,6 @@ C Static Link Flags        :code:`-L$(SCR_INSTALL_DIR)/lib64 -lscr`
 Fortran Dynamic Link Flags :code:`-L$(SCR_INSTALL_DIR)/lib64 -lscrf -Wl,-rpath,$(SCR_INSTALL_DIR)/lib64`
 Fortran Static Link Flags  :code:`-L$(SCR_INSTALL_DIR)/lib64 -lscrf`
 ========================== ============================================================================
+
+.. note::
+   On some platforms the default library installation path will be :code:`/lib` instead of :code:`/lib64`.

--- a/doc/rst/users/quick.rst
+++ b/doc/rst/users/quick.rst
@@ -94,8 +94,8 @@ SCR works and to ensure that your build of SCR is working.
 Running the SCR :code:`test_api` Example
 ------------------------------------------
 
-A quick test of your SCR installation can be done by setting a few
-environment variables and running :code:`test_api` in an interactive job allocation.
+A quick test of your SCR installation can be done by
+running :code:`test_api` in an interactive job allocation.
 The following assumes you are running on a SLURM-based system.
 If you are not using SLURM, then modify the node allocation and
 run commands as appropriate for your resource manager.
@@ -112,7 +112,7 @@ Here we execute a 4-process run on 4 nodes:
 
 .. code-block:: bash
 
-  srun -n4 -N4 ./test_api
+  srun -n 4 -N 4 ./test_api
 
 This example program writes 6 checkpoints using SCR.
 Assuming all goes well, you should see output similar to the following
@@ -132,7 +132,7 @@ Assuming all goes well, you should see output similar to the following
   FileIO: Min   52.38 MB/s        Max   52.39 MB/s        Avg   52.39 MB/s       Agg  209.55 MB/s
 
 If you do not see output similar to this,
-there is likely a problem with your environment set up or build of SCR.
+there may be a problem with your environment or your build of SCR.
 Please see the detailed sections of this user guide for more help
 or email us (see :ref:`sec-contact`.)
 
@@ -163,7 +163,7 @@ into an application to write checkpoints.
     /* Call SCR_Init after MPI_Init */
     SCR_Init();
 
-    for(int t = 0; t < TIMESTEPS; t++) {
+    for (int t = 0; t < TIMESTEPS; t++) {
       /* ... Do work ... */
 
       /* Ask SCR if a checkpoint should be saved (optional) */

--- a/doc/rst/users/quick.rst
+++ b/doc/rst/users/quick.rst
@@ -87,10 +87,6 @@ Build it by executing:
   cd <install>/share/scr/examples
   make test_api
 
-**TODO: Spack: Need to verify.**
-
-**TODO: CMake: This may not work as written.**
-
 Upon a successful build, you will have a :code:`test_api` executable.
 You can use this test program to get a feel for how
 SCR works and to ensure that your build of SCR is working.
@@ -111,20 +107,7 @@ Here we allocate 4 nodes:
 
   salloc -N 4
 
-Once you have the compute nodes,
-then set a few environment variables.
-We use bash syntax in this example.:
-
-.. code-block:: bash
-
-  # make sure the SCR library is in your library path
-  export LD_LIBRARY_PATH=${SCR_INSTALL}/lib
-
-**TODO: Spack: Need to verify.**
-
-**TODO: CMake: Need to verify.**
-
-Now run :code:`test_api`.
+Once you have the compute nodes you can run :code:`test_api`.
 Here we execute a 4-process run on 4 nodes:
 
 .. code-block:: bash


### PR DESCRIPTION
I've fixed up the build and link documentation for both CMake and Spack paths.

Closes #301. Closes #302. Closes #303. Closes #304.