### PR TITLE
Makedist2

### DIFF
--- a/dist/CMakeLists.txt
+++ b/dist/CMakeLists.txt
@@ -456,8 +456,10 @@ ADD_LIBRARY(scr_o OBJECT
 # Install header files
 LIST(APPEND libscr_install_headers
     scr/src/scr.h
-    scr/src/scrf.h
 )
+IF(ENABLE_FORTRAN)
+    LIST(APPEND libscr_install_headers scr/src/scrf.h)
+ENDIF(ENABLE_FORTRAN)
 INSTALL(FILES ${libscr_install_headers} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 IF(BUILD_SHARED_LIBS)

--- a/doc/rst/users/build.rst
+++ b/doc/rst/users/build.rst
@@ -12,27 +12,19 @@ corresponding SCR functionality is disabled.
 
 Required:
 
+* C and C++ compilers
 * CMake, Version 2.8+
-* Compilers (C, C++, and Fortran)
 * MPI 3.0+
-* pdsh (https://github.com/chaos/pdsh)
-* DTCMP (https://github.com/llnl/dtcmp)
-* LWGRP (https://github.com/llnl/lwgrp)
-* AXL (https://github.com/ECP-VeloC/AXL)
-* er (https://github.com/ECP-VeloC/er)
-* KVTree (https://github.com/ECP-VeloC/KVTree)
-* rankstr (https://github.com/ECP-VeloC/rankstr)
-* redset (https://github.com/ECP-VeloC/redset)
-* shuffile (https://github.com/ECP-VeloC/shuffile)
-* spath (https://github.com/ECP-VeloC/spath)
 
 Optional:
 
+* Fortran compiler (for Fortran bindings)
+* pdsh (for scalable restart and scavenge) (https://github.com/chaos/pdsh)
 * libyogrt (for time remaining in a job allocation) (https://github.com/llnl/libyogrt)
 * MySQL (for logging SCR activities)
 
 To simplify the install process,
-one can use the SCR :code:`bootstrap.sh` script with CMake or use Spack.
+one can use CMake to build a release tarball or use Spack.
 
 The CMake and Spack sections below assume that one is installing SCR on a system with
 existing compilers, a resource manager (like SLURM or LSF), and an MPI environment.

--- a/doc/rst/users/config.rst
+++ b/doc/rst/users/config.rst
@@ -360,7 +360,7 @@ The table in this section specifies the full set of SCR configuration parameters
      - Set to 1 to enable asynchronous flush methods (if supported).
    * - :code:`SCR_FLUSH_TYPE`
      - :code:`SYNC`
-     - Specify the AXL transfer method.  Set to one of: :code:`SYNC`, :code:`PTHREAD`, :code:`BBAPI`, or :code:`DATAWARP`.
+     - Specify the flush transfer method.  Set to one of: :code:`SYNC`, :code:`PTHREAD`, :code:`BBAPI`, or :code:`DATAWARP`.
    * - :code:`SCR_FLUSH_WIDTH`
      - 256
      - Specify the number of processes that may write simultaneously to the parallel file system.

--- a/doc/rst/users/quick.rst
+++ b/doc/rst/users/quick.rst
@@ -16,7 +16,7 @@ Building SCR
 
 SCR has a number of dependencies.
 To simplify the install process,
-one can use our :code:`bootstrap.sh` script with CMake or use Spack.
+one can use a release tarball with CMake or use Spack.
 For full details on building SCR,
 please see Section :ref:`sec-library`.
 
@@ -70,21 +70,24 @@ Building the SCR :code:`test_api` Example
 
 In this quick start guide, we use the :code:`test_api.c` program.
 
-If you installed SCR with CMake,
-:code:`test_api.c` was already compiled as part of the make install step above.
-You just need to change into the :code:`examples` subdirectory
-within the current CMake :code:`build` directory:
+If you install SCR with CMake,
+:code:`test_api.c` is compiled as part of the make install step.
+You can find it in the :code:`examples` subdirectory
+within the CMake :code:`build` directory:
 
 .. code-block:: bash
 
   cd examples
 
-Then skip to the next section to run :code:`test_api.c`.
+If you still have this direcotry,
+then skip ahead to the next section to run :code:`test_api.c`.
 
-If you installed SCR with Spack,
-you will find example programs in the :code:`<install>/share/scr/examples` directory,
+Alternatively, you will find source files for example programs
+in the :code:`<install>/share/scr/examples` directory,
 where :code:`<install>` is the path in which SCR was installed.
-You can find Spack's SCR install directory using the following command:
+
+If you install SCR with Spack,
+you can identify the SCR install directory with the following command:
 
 .. code-block:: bash
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,8 +8,10 @@ INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR} ${PROJECT_BINARY_DIR})
 # Install header files
 LIST(APPEND libscr_install_headers
 	scr.h
-	scrf.h
 )
+IF(ENABLE_FORTRAN)
+    LIST(APPEND libscr_install_headers scrf.h)
+ENDIF(ENABLE_FORTRAN)
 INSTALL(FILES ${libscr_install_headers} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 ## CLI should build without MPI dependence


### PR DESCRIPTION
Hide mention of components in docs.
Don't install scrf.h when Fortran disabled.