### PR TITLE
fix: drop an SCR_Config test reading STORE value

### DIFF
--- a/examples/test_config.c
+++ b/examples/test_config.c
@@ -159,8 +159,11 @@ int main (int argc, char* argv[])
 
   SCR_Config("STORE=/dev/shm GROUP=NODE COUNT=1");
   tests_passed &= test_cfg("STORE=/dev/shm COUNT", "1");
-  tests_passed &= test_cfg("STORE", "/dev/shm");
   tests_passed &= test_cfg("STORE=/dev/shm GROUP", "NODE");
+
+  /* STORE has been set with both /dev/shm/foo and /dev/shm at this point,
+   * so a query should print an error and return NULL */
+  tests_passed &= test_cfg("STORE", NULL);
 
   /* delete values */
   SCR_Config("STORE=");


### PR DESCRIPTION
This addresses our failing test case: https://github.com/LLNL/scr/issues/313.

This happens in a situation like the following:
```
SCR_Config("STORE=/dev/shm     GROUP=NODE COUNT=1")
SCR_Config("STORE=/dev/shm/foo GROUP=NODE COUNT=1")
char* value = SCR_Config("STORE")
```
The return value in the query above is not well defined since STORE has two different settings at this point.

This modifies SCR_Config to print and error and return NULL when querying a key with multiple values.