### PR TITLE
fix: allow scr_config queries after init

### DIFF
--- a/doc/rst/users/api.rst
+++ b/doc/rst/users/api.rst
@@ -103,13 +103,18 @@ SCR_Config
     INTEGER IERROR
 
 Configure the SCR library.
-Most of the SCR configuration parameters listed in :ref:`sec-config` can be set at run time using :code:`SCR_Config`.
-The syntax to set parameters matches the syntax used in SCR configuration files.
-The application can make multiple calls to :code:`SCR_Config`.
-All calls to :code:`SCR_Config` must come before the application calls :code:`SCR_Init`.
+Most of the SCR configuration parameters listed in :ref:`sec-config` can be set, queried,
+and unset at run time using :code:`SCR_Config`.
+The application can make multiple calls to :code:`SCR_Config`, including for the same SCR configuration parameter.
+All calls to :code:`SCR_Config` to set or unset parameter values must occur before the application calls :code:`SCR_Init`.
+One may call :code:`SCR_Config` to query parameter values before and after :code:`SCR_Init` has been called.
 This function is collective, and all processes must provide identical values for :code:`config`.
 
-To set a parameter,
+There are two forms of SCR configuration parameters:
+a simple form that consists of a single key/value pair
+and a multi-item form that consists of a parent key/value pair and set of child key/value pairs.
+
+To set a simple parameter,
 one specifies a parameter name and its value in the form of a :code:`key=value` string as the :code:`config` argument.
 For example, passing the string :code:`SCR_FLUSH=10` sets :code:`SCR_FLUSH` to the value of 10.
 If one sets the same parameter with multiple calls to :code:`SCR_Config`,
@@ -117,7 +122,7 @@ SCR applies the most recent value.
 When setting a parameter, for C applications, :code:`SCR_Config` always returns :code:`NULL`.
 For Fortran applications, :code:`IERROR` is always set to :code:`SCR_SUCCESS`.
 
-To query a value, one specifies just the parameter name as the string in :code:`config`.
+To query the value of a simple parameter, one specifies just the parameter name as the string in :code:`config`.
 For example, one can specify the string :code:`SCR_FLUSH` to query its current value.
 When querying a value, for C applications,
 the call allocates and returns a pointer to a string holding the value of the parameter.
@@ -125,22 +130,22 @@ The caller is responsible for calling :code:`free` to release the returned strin
 If the parameter has not been set, :code:`NULL` is returned.
 For Fortran applications, the value is returned as a string in the :code:`VAL` argument.
 
-To unset a value, one specifies the parameter name with an empty value
+To unset the value of a simple parameter, one specifies the parameter name with an empty value
 in the form of a :code:`key=` string as the :code:`config` argument.
 For example, to unset the value assigned to :code:`SCR_FLUSH`, specify the string :code:`SCR_FLUSH=`.
 Unsetting a parameter removes any value that was assigned by a prior call to :code:`SCR_Config`,
-but it does not unset the parameter value that may have been set through other means,
+but it does not unset the parameter value that has been set through other means,
 like an environment variable or in a configuration file (see :ref:`sec-config`).
 When unsetting a value, for C applications, :code:`SCR_Config` always returns :code:`NULL`.
 For Fortran applications, :code:`IERROR` is always set to :code:`SCR_SUCCESS`.
 
-Multi-item SCR configuration parameters like :code:`CKPT` can be set using a
+Multi-item parameters like :code:`CKPT` can be set using a
 sequence of :code:`key=value` pairs that are separated by spaces.
 For example, to define a :code:`CKPT` redundancy descriptor,
 one can pass a string such as :code:`CKPT=0 TYPE=XOR SET_SIZE=16`.
 
-To query a subvalue, one must specify the top level :code:`key=value` pair followed
-by the name of the key being queried.
+To query a subvalue of a multi-item parameter, one must specify the parent level :code:`key=value` pair followed
+by the name of the child key being queried.
 For instance, to get the type of the redundancy scheme of redundancy descriptor :code:`0`,
 one can specify the string :code:`CKPT=0 TYPE`.
 

--- a/src/scr.c
+++ b/src/scr.c
@@ -2486,11 +2486,6 @@ int SCR_Finalize()
 /* sets or gets a configuration option */
 const char* SCR_Config(const char* config_string)
 {
-  /* manage state transition */
-  if (scr_state != SCR_STATE_UNINIT) {
-    scr_state_transition_error(scr_state, "SCR_Config()", __FILE__, __LINE__);
-  }
-
   /* if not enabled, bail with an error */
   if (! scr_enabled) {
     return NULL;
@@ -2776,7 +2771,13 @@ const char* SCR_Config(const char* config_string)
       kvtree_delete(&toplevel_hash);
     }
   } else {
-    /* user wants to set or unset a parameter */
+    /* user wants to set or unset a parameter,
+     * only allow changing parameters before SCR_Init */
+    if (scr_state != SCR_STATE_UNINIT) {
+      scr_state_transition_error(scr_state, "SCR_Config()", __FILE__, __LINE__);
+    }
+
+    /* determine whether we have a simple key/value pair or a two-level param */
     if (value_hash == NULL) {
       /* dealing with a simple key/value parameter pair */
       if (toplevel_value) {
@@ -2827,11 +2828,6 @@ const char* SCR_Config(const char* config_string)
 
 const char* SCR_Configf(const char* format, ...)
 {
-  /* manage state transition */
-  if (scr_state != SCR_STATE_UNINIT) {
-    scr_state_transition_error(scr_state, "SCR_Configf()", __FILE__, __LINE__);
-  }
-
   /* if not enabled, bail with an error */
   if (! scr_enabled) {
     return NULL;


### PR DESCRIPTION
Permit users to call SCR_Config after SCR_Init to query a parameter.  Continue to throw an error if users try to change/unset a parameter after SCR_Init.