### PR TITLE
allow for multiple outstanding flush operations

### DIFF
--- a/src/scr.c
+++ b/src/scr.c
@@ -134,6 +134,105 @@ static scr_reddesc* scr_get_reddesc(const scr_dataset* dataset, int ndescs, scr_
   return d;
 }
 
+/* returns 1 if dataset id can be finalized in poststage, 0 otherwise */
+static int scr_flush_can_poststage(int id)
+{
+  int poststage = 0;
+
+  /* currently only BBAPI can support poststage */
+  const scr_storedesc* storedesc = scr_cache_get_storedesc(scr_cindex, id);
+  const char* type = storedesc->xfer;
+  if (strcmp(type, "BBAPI") == 0) {
+    poststage = 1;
+  }
+
+  return poststage;
+}
+
+static int scr_flush_finalize(void)
+{
+  /* When using poststage, we can finalize flushes
+   * after the job completes rather than waiting on them here. */
+  int poststage = scr_flush_poststage;
+
+  /* check each outstanding async flush, if any */
+  if (poststage && scr_flush_async_in_progress()) {
+    /* Got at least one outstanding async flush.
+     * Check whether all async flushes can be handled in poststage.
+     * Iterate over all dataset ids still being flushed.
+     * If any can not be completed in poststage, disable all poststage. */
+
+    /* get ordered list of ids being flushed */
+    int flush_num = 0;
+    int* flush_ids = NULL;
+    scr_flush_async_get_list(scr_cindex, &flush_num, &flush_ids);
+
+    /* check that all flushes are using something we can complete in poststage */
+    int i;
+    for (i = 0; i < flush_num; i++) {
+      int id = flush_ids[i];
+      if (! scr_flush_can_poststage(id)) {
+        poststage = 0;
+      }
+    }
+
+    /* free list of flush ids */
+    scr_free(&flush_ids);
+  }
+
+  /* check latest checkpoint if it still needs to be flushed */
+  if (poststage && scr_flush > 0 && scr_flush_file_need_flush(scr_ckpt_dset_id)) {
+    /* latest checkpoint needs to be flushed,
+     * check whether we can also handle this checkpoint with poststage */
+    if (scr_flush_can_poststage(scr_ckpt_dset_id)) {
+      /* can finalize this flush in poststage */
+      if (! scr_flush_file_is_flushing(scr_ckpt_dset_id)) {
+        /* Initiate the flush now, but finish in the poststage.
+         * Start as an async flush, even if we're otherwise using sync flush. */
+        int flush_rc = scr_flush_async_start(scr_cindex, scr_ckpt_dset_id);
+        if (flush_rc != SCR_SUCCESS) {
+          scr_err("Flush of dataset %d failed @ %s:%d",
+            scr_ckpt_dset_id, __FILE__, __LINE__
+          );
+        }
+      }
+    } else {
+      /* cannot use poststage, so disable */
+      poststage = 0;
+    }
+  }
+
+  /* if we're not using postage, wait on all flushes now */
+  if (! poststage) {
+    /* wait on all async flushes to complete */
+    if (scr_flush_async_in_progress()) {
+      /* if any flush cannot use poststage, wait on them all to finish now */
+      int flush_rc = scr_flush_async_waitall(scr_cindex);
+      if (flush_rc != SCR_SUCCESS) {
+        scr_err("Flush of datasets failed @ %s:%d",
+          __FILE__, __LINE__
+        );
+      }
+    }
+
+    /* Flush checkpoint synchronously (wait for it to finish now). */
+    if (scr_flush > 0 && scr_flush_file_need_flush(scr_ckpt_dset_id)) {
+      int flush_rc = scr_flush_sync(scr_cindex, scr_ckpt_dset_id);
+      if (flush_rc != SCR_SUCCESS) {
+        scr_err("Flush of dataset %d failed @ %s:%d",
+          scr_ckpt_dset_id, __FILE__, __LINE__
+        );
+      }
+    }
+  }
+
+  if (scr_flush_async) {
+    scr_flush_async_finalize();
+  }
+
+  return SCR_SUCCESS;
+}
+
 /*
 =========================================
 Halt logic
@@ -281,57 +380,8 @@ static int scr_bool_check_halt_and_decrement(int halt_cond, int decrement)
 
   /* halt job if we need to, and flush latest checkpoint if needed */
   if (need_to_halt && halt_exit) {
-    /* handle any async flush */
-    if (scr_flush_async_in_progress) {
-      /* there's an async flush ongoing, see which dataset is being flushed */
-      int flush_rc;
-      if (scr_flush_async_dataset_id == scr_dataset_id) {
-#ifdef HAVE_LIBCPPR
-        /* if we have CPPR, async flush is faster than sync flush, so let it finish */
-        flush_rc = scr_flush_async_wait(scr_cindex);
-#else
-        /* we're going to sync flush this same checkpoint below, so kill it if it's from POSIX */
-        /* else wait */
-        /* get the TYPE of the store for checkpoint */
-        /* neither strdup nor free */
-        const scr_storedesc* storedesc = scr_cache_get_storedesc(scr_cindex, scr_dataset_id);
-        const char* type = storedesc->xfer;
-        if (strcmp(type, "DATAWARP") == 0) {
-          /* wait for datawarp flushes to finish */
-          flush_rc = scr_flush_async_wait(scr_cindex);
-        } else {
-          /* kill the async flush, we'll get this with a sync flush instead */
-          scr_flush_async_stop();
-        }
-#endif
-      } else {
-        /* the async flush is flushing a different dataset, so wait for it */
-        flush_rc = scr_flush_async_wait(scr_cindex);
-      }
-      if (flush_rc != SCR_SUCCESS) {
-        scr_abort(-1, "Flush of dataset %d failed @ %s:%d",
-          scr_flush_async_dataset_id, __FILE__, __LINE__
-        );
-      }
-    }
-
-    /* flush files if needed */
-    if (scr_flush > 0 && scr_flush_file_need_flush(scr_ckpt_dset_id)) {
-      if (scr_my_rank_world == 0) {
-        scr_dbg(2, "sync flush due to need to halt @ %s:%d", __FILE__, __LINE__);
-      }
-      int flush_rc = scr_flush_sync(scr_cindex, scr_ckpt_dset_id);
-      if (flush_rc != SCR_SUCCESS) {
-        scr_abort(-1, "Flush of dataset %d failed @ %s:%d",
-          scr_ckpt_dset_id, __FILE__, __LINE__
-        );
-      }
-    }
-
-    /* give our async flush method a chance to shut down */
-    if (scr_flush_async) {
-      scr_flush_async_finalize();
-    }
+    /* flush any pending datasets and shut down flush methods */
+    scr_flush_finalize();
 
     /* sync up tasks before exiting (don't want tasks to exit so early that
      * runtime kills others after timeout) */
@@ -413,29 +463,10 @@ static int scr_check_flush(scr_cache_index* map)
   if (need_flush) {
     /* need to flush, determine whether to use async or sync flush */
     if (scr_flush_async) {
-      if (scr_my_rank_world == 0) {
-        scr_dbg(2, "async flush attempt @ %s:%d", __FILE__, __LINE__);
-      }
-
-      /* check that we don't start an async flush if one is already in progress */
-      if (scr_flush_async_in_progress) {
-        /* we need to flush the current dataset, however, another flush is ongoing,
-         * so wait for this other flush to complete before starting the next one */
-        int flush_rc = scr_flush_async_wait(scr_cindex);
-        if (flush_rc != SCR_SUCCESS) {
-          scr_abort(-1, "Flush of dataset %d failed @ %s:%d",
-            scr_flush_async_dataset_id, __FILE__, __LINE__
-          );
-        }
-      }
-
       /* start an async flush on the current dataset id */
       scr_flush_async_start(scr_cindex, scr_dataset_id);
     } else {
       /* synchronously flush the current dataset */
-      if (scr_my_rank_world == 0) {
-        scr_dbg(2, "sync flush attempt @ %s:%d", __FILE__, __LINE__);
-      }
       int flush_rc = scr_flush_sync(scr_cindex, scr_dataset_id);
       if (flush_rc != SCR_SUCCESS) {
         scr_abort(-1, "Flush of dataset %d failed @ %s:%d",
@@ -1276,18 +1307,38 @@ static int scr_start_output(const char* name, int flags)
     }
   }
 
-  /* if we still don't have room and we're flushing, the dataset we need to delete
-   * must be flushing, so wait for it to finish */
+  /* if we still don't have room and we're flushing,
+   * the dataset we need to delete must be flushing, so wait for it to finish */
   if (nckpts_base >= size && flushing != -1) {
-    /* TODO: we could increase the transfer bandwidth to reduce our wait time */
+    /* in case there are ongoing flush operations from other cache
+     * base locations, finalize datasets in order up to our target id
+     * so that we don't mess up our current pointer */
 
-    /* wait for this dataset to complete its flush */
-    int flush_rc = scr_flush_async_wait(scr_cindex);
-    if (flush_rc != SCR_SUCCESS) {
-      scr_abort(-1, "Flush of dataset %d failed @ %s:%d",
-        scr_flush_async_dataset_id, __FILE__, __LINE__
-      );
+    /* get full list of ids for ongoing flushes */
+    int flush_num = 0;
+    int* flush_ids = NULL;
+    scr_flush_async_get_list(scr_cindex, &flush_num, &flush_ids);
+
+    /* wait for each dataset up to and including the one we need
+     * to complete */
+    for (i = 0; i < flush_num; i++) {
+      /* wait for this dataset to complete its flush */
+      int id = flush_ids[i];
+      int flush_rc = scr_flush_async_wait(scr_cindex, id);
+      if (flush_rc != SCR_SUCCESS) {
+        scr_abort(-1, "Flush of dataset %d failed @ %s:%d",
+          id, __FILE__, __LINE__
+        );
+      }
+
+      /* can break once the target id is done */
+      if (id == flushing) {
+        break;
+      }
     }
+
+    /* free list of flush ids */
+    scr_free(&flush_ids);
 
     /* now dataset is no longer flushing, we can delete it and continue on */
     scr_cache_delete(scr_cindex, flushing);
@@ -1673,22 +1724,9 @@ static int scr_complete_output(int valid)
   }
 
   /* if we have an async flush ongoing, take this chance to check whether it's completed */
-  if (scr_flush_async_in_progress) {
+  if (scr_flush_async_in_progress()) {
     /* got an outstanding async flush, let's check it */
-    if (scr_flush_async_test(scr_cindex, scr_flush_async_dataset_id) == SCR_SUCCESS) {
-      /* async flush has finished, go ahead and complete it */
-      int flush_rc = scr_flush_async_complete(scr_cindex, scr_flush_async_dataset_id);
-      if (flush_rc != SCR_SUCCESS) {
-        scr_abort(-1, "Flush of dataset %d failed @ %s:%d",
-          scr_flush_async_dataset_id, __FILE__, __LINE__
-        );
-      }
-    } else {
-      /* not done yet, just print a progress message to the screen */
-      if (scr_my_rank_world == 0) {
-        scr_dbg(1, "Flush of dataset %d is ongoing", scr_flush_async_dataset_id);
-      }
-    }
+    scr_flush_async_progall(scr_cindex);
   }
 
   /* done with dataset */
@@ -2337,86 +2375,8 @@ int SCR_Finalize()
     scr_halt(SCR_FINALIZE_CALLED);
   }
 
-  /* When using poststage, we may finalize flushes after the job completes
-   * rather than waiting on it here.  In that case, we'll set this flag to 1 */
-  int poststage = 0;
-
-  /* handle any async flush */
-  if (scr_flush_async_in_progress) {
-    /* there's an async flush ongoing, see which dataset is being flushed */
-    int flush_rc;
-    if (scr_flush_async_dataset_id == scr_dataset_id) {
-#ifdef HAVE_LIBCPPR
-      /* if we have CPPR, async flush is faster than sync flush, so let it finish */
-      flush_rc = scr_flush_async_wait(scr_cindex);
-#else
-      /* we're going to sync flush this same checkpoint below, so kill it if it's from POSIX */
-      /* else wait */
-      /* get the TYPE of the store for checkpoint */
-      /* neither strdup nor free */
-      const scr_storedesc* storedesc = scr_cache_get_storedesc(scr_cindex, scr_dataset_id);
-      const char* type = storedesc->xfer;
-      if (strcmp(type, "DATAWARP") == 0) {
-        /* wait for datawarp flushes to finish */
-        flush_rc = scr_flush_async_wait(scr_cindex);
-      } else if (strcmp(type, "BBAPI") == 0 && scr_flush_poststage) {
-        /* Special case: We're using BBAPI poststage, meaning we will finalize
-         * the flush after the job ends using the scr_poststage script.
-         *
-         * So don't wait for the flush to finish here - it's going to continue
-         * transferring "in the background" and will be dealt with using the
-         * scr_poststage script later on. */
-        poststage = 1; /* skip finalizing this dataset */
-        flush_rc = SCR_SUCCESS;
-      } else {
-        /* kill the async flush, we'll get this with a sync flush instead */
-        scr_flush_async_stop();
-      }
-#endif
-    } else {
-      /* the async flush is flushing a different checkpoint, so wait for it */
-      flush_rc = scr_flush_async_wait(scr_cindex);
-    }
-    if (flush_rc != SCR_SUCCESS) {
-      scr_abort(-1, "Flush of dataset %d failed @ %s:%d",
-        scr_flush_async_dataset_id, __FILE__, __LINE__
-      );
-    }
-  }
-
-  /* flush checkpoint set if we need to */
-  if (scr_flush > 0 && scr_flush_file_need_flush(scr_ckpt_dset_id)) {
-    /* have a checkpoint dataset that needs to be flushed */
-    if (scr_my_rank_world == 0) {
-      scr_dbg(2, "Begin flushing checkpoints that haven't started @ %s:%d", __FILE__, __LINE__);
-    }
-
-    int flush_rc;
-    if (poststage) {
-      /* we'll finalize this flush in poststage */
-      if (scr_flush_file_is_flushing(scr_ckpt_dset_id)) {
-        /* checkpoint is already flushing, so nothing else to do */
-        flush_rc = SCR_SUCCESS;
-      } else {
-        /* Initiate the flush now, but finish in the poststage.
-         * Start as an async flush, even if we're otherwise using sync flush. */
-        flush_rc = scr_flush_async_start(scr_cindex, scr_ckpt_dset_id);
-      }
-    } else {
-      /* Flush checkpoint synchronously (wait for it to finish now). */
-      flush_rc = scr_flush_sync(scr_cindex, scr_ckpt_dset_id);
-    }
-
-    if (flush_rc != SCR_SUCCESS) {
-      scr_abort(-1, "Flush of dataset %d failed @ %s:%d",
-          scr_ckpt_dset_id, __FILE__, __LINE__
-          );
-    }
-  }
-
-  if(scr_flush_async){
-    scr_flush_async_finalize();
-  }
+  /* flush any pending datasets and shut down flush methods */
+  scr_flush_finalize();
 
   /* free off the memory allocated for our descriptors */
   scr_reddescs_free();

--- a/src/scr.c
+++ b/src/scr.c
@@ -1842,87 +1842,85 @@ int SCR_Init()
   }
 
   /* coonfigure used libraries */
+  kvtree* axl_config = kvtree_new();
+  if (kvtree_util_set_bytecount(axl_config,
+      AXL_KEY_CONFIG_FILE_BUF_SIZE, scr_file_buf_size) != KVTREE_SUCCESS)
   {
-    kvtree* axl_config = kvtree_new();
-    assert(axl_config);
-
-    if (kvtree_util_set_bytecount(axl_config, AXL_KEY_CONFIG_FILE_BUF_SIZE,
-                                  scr_file_buf_size) != KVTREE_SUCCESS) {
-      scr_abort(-1, "Failed to set AXL config option %s @ %s:%d",
-        AXL_KEY_CONFIG_FILE_BUF_SIZE, __FILE__, __LINE__
-      );
-    }
-    if (kvtree_util_set_int(axl_config, AXL_KEY_CONFIG_DEBUG,
-                            scr_debug) != KVTREE_SUCCESS) {
-      scr_abort(-1, "Failed to set AXL config option %s @ %s:%d",
-        AXL_KEY_CONFIG_DEBUG, __FILE__, __LINE__
-      );
-    }
-    if (kvtree_util_set_int(axl_config, AXL_KEY_CONFIG_MKDIR,
-                            scr_axl_mkdir) != KVTREE_SUCCESS) {
-      scr_abort(-1, "Failed to set AXL config option %s @ %s:%d",
-        AXL_KEY_CONFIG_MKDIR, __FILE__, __LINE__
-      );
-    }
-    if (kvtree_util_set_int(axl_config, AXL_KEY_CONFIG_COPY_METADATA,
-                            scr_copy_metadata) != KVTREE_SUCCESS) {
-      scr_abort(-1, "Failed to set AXL config option %s @ %s:%d",
-        AXL_KEY_CONFIG_COPY_METADATA, __FILE__, __LINE__
-      );
-    }
-    if (kvtree_util_set_int(axl_config, AXL_KEY_CONFIG_RANK,
-                            scr_my_rank_world) != KVTREE_SUCCESS) {
-      scr_abort(-1, "Failed to set AXL config option %s @ %s:%d",
-        AXL_KEY_CONFIG_RANK, __FILE__, __LINE__
-      );
-    }
-
-    if (AXL_Config(axl_config) == NULL) {
-      scr_abort(-1, "Failed to configure AXL @ %s:%d",
-        __FILE__, __LINE__
-      );
-    }
-
-    kvtree_delete(&axl_config);
+    scr_abort(-1, "Failed to set AXL config option %s @ %s:%d",
+      AXL_KEY_CONFIG_FILE_BUF_SIZE, __FILE__, __LINE__
+    );
   }
+  if (kvtree_util_set_int(axl_config,
+      AXL_KEY_CONFIG_DEBUG, scr_debug) != KVTREE_SUCCESS)
   {
-    kvtree* er_config = kvtree_new();
-    assert(er_config);
-
-    if (kvtree_util_set_int(er_config, ER_KEY_CONFIG_DEBUG,
-                            scr_debug) != KVTREE_SUCCESS) {
-      scr_abort(-1, "Failed to set ER config option %s @ %s:%d",
-        ER_KEY_CONFIG_DEBUG, __FILE__, __LINE__
-      );
-    }
-    if (kvtree_util_set_int(er_config, ER_KEY_CONFIG_SET_SIZE, scr_set_size) !=
-        KVTREE_SUCCESS) {
-      scr_abort(-1, "Failed to set ER config option %s @ %s:%d",
-        ER_KEY_CONFIG_SET_SIZE, __FILE__, __LINE__
-      );
-    }
-    if (kvtree_util_set_int(er_config, ER_KEY_CONFIG_MPI_BUF_SIZE,
-                            scr_mpi_buf_size) != KVTREE_SUCCESS) {
-      scr_abort(-1, "Failed to set ER config option %s @ %s:%d",
-        ER_KEY_CONFIG_MPI_BUF_SIZE, __FILE__, __LINE__
-      );
-    }
-    if (kvtree_util_set_int(er_config, ER_KEY_CONFIG_CRC_ON_COPY,
-                            scr_crc_on_copy) != KVTREE_SUCCESS) {
-      scr_abort(-1, "Failed to set ER config option %s @ %s:%d",
-        ER_KEY_CONFIG_CRC_ON_COPY, __FILE__, __LINE__
-      );
-    }
-
-    if (ER_Config(er_config) == NULL)
-    {
-      scr_abort(-1, "Failed to configure ER @ %s:%d",
-        __FILE__, __LINE__
-      );
-    }
-
-    kvtree_delete(&er_config);
+    scr_abort(-1, "Failed to set AXL config option %s @ %s:%d",
+      AXL_KEY_CONFIG_DEBUG, __FILE__, __LINE__
+    );
   }
+  if (kvtree_util_set_int(axl_config,
+      AXL_KEY_CONFIG_MKDIR, scr_axl_mkdir) != KVTREE_SUCCESS)
+  {
+    scr_abort(-1, "Failed to set AXL config option %s @ %s:%d",
+      AXL_KEY_CONFIG_MKDIR, __FILE__, __LINE__
+    );
+  }
+  if (kvtree_util_set_int(axl_config,
+      AXL_KEY_CONFIG_COPY_METADATA, scr_copy_metadata) != KVTREE_SUCCESS)
+  {
+    scr_abort(-1, "Failed to set AXL config option %s @ %s:%d",
+      AXL_KEY_CONFIG_COPY_METADATA, __FILE__, __LINE__
+    );
+  }
+  if (kvtree_util_set_int(axl_config,
+      AXL_KEY_CONFIG_RANK, scr_my_rank_world) != KVTREE_SUCCESS)
+  {
+    scr_abort(-1, "Failed to set AXL config option %s @ %s:%d",
+      AXL_KEY_CONFIG_RANK, __FILE__, __LINE__
+    );
+  }
+  if (AXL_Config(axl_config) == NULL) {
+    scr_abort(-1, "Failed to configure AXL @ %s:%d",
+      __FILE__, __LINE__
+    );
+  }
+  kvtree_delete(&axl_config);
+
+  kvtree* er_config = kvtree_new();
+  if (kvtree_util_set_int(er_config,
+      ER_KEY_CONFIG_DEBUG, scr_debug) != KVTREE_SUCCESS)
+  {
+    scr_abort(-1, "Failed to set ER config option %s @ %s:%d",
+      ER_KEY_CONFIG_DEBUG, __FILE__, __LINE__
+    );
+  }
+  if (kvtree_util_set_int(er_config,
+      ER_KEY_CONFIG_SET_SIZE, scr_set_size) != KVTREE_SUCCESS)
+  {
+    scr_abort(-1, "Failed to set ER config option %s @ %s:%d",
+      ER_KEY_CONFIG_SET_SIZE, __FILE__, __LINE__
+    );
+  }
+  if (kvtree_util_set_int(er_config,
+      ER_KEY_CONFIG_MPI_BUF_SIZE, scr_mpi_buf_size) != KVTREE_SUCCESS)
+  {
+    scr_abort(-1, "Failed to set ER config option %s @ %s:%d",
+      ER_KEY_CONFIG_MPI_BUF_SIZE, __FILE__, __LINE__
+    );
+  }
+  if (kvtree_util_set_int(er_config,
+      ER_KEY_CONFIG_CRC_ON_COPY, scr_crc_on_copy) != KVTREE_SUCCESS)
+  {
+    scr_abort(-1, "Failed to set ER config option %s @ %s:%d",
+      ER_KEY_CONFIG_CRC_ON_COPY, __FILE__, __LINE__
+    );
+  }
+  if (ER_Config(er_config) == NULL)
+  {
+    scr_abort(-1, "Failed to configure ER @ %s:%d",
+      __FILE__, __LINE__
+    );
+  }
+  kvtree_delete(&er_config);
 
   /* check that some required parameters are set */
   if (scr_username == NULL || scr_jobid == NULL) {

--- a/src/scr_flush_async.c
+++ b/src/scr_flush_async.c
@@ -16,27 +16,15 @@
 #include "kvtree_util.h"
 #include "axl_mpi.h"
 
-#define ASYNC_KEY_OUT_NAME "NAME"
-#define ASYNC_KEY_OUT_AXL  "AXL"
+#define ASYNC_KEY_OUT_DSET   "DSET"   /* list items by dataset id */
+#define ASYNC_KEY_OUT_STATUS "STATUS" /* tracks whether flush has failed in any stage */
+#define ASYNC_KEY_OUT_FILES  "FILES"  /* list of files to be transferred */
+#define ASYNC_KEY_OUT_AXL    "AXL"    /* tracks AXL id for outstanding transfer */
+#define ASYNC_KEY_OUT_TIME   "TIME"   /* start time of transfer from time */
+#define ASYNC_KEY_OUT_WTIME  "WTIME"  /* start time of transfer from Wtime */
 
-/* records the time the async flush started */
-static time_t scr_flush_async_timestamp_start;
-
-/* records the time the async flush started from MPI_Wtime */
-static double scr_flush_async_time_start;
-
-/* tracks list of files written with flush */
-static kvtree* scr_flush_async_file_list = NULL;
-
-/* tracks AXL id for outstanding transfer */
-static kvtree* scr_flush_async_axl_list = NULL;
-
-/* path to rankfile for ongoing flush */
-static char* scr_flush_async_rankfile = NULL;
-
-/* flag indicating whether we have detected failure
- * at any point in process of async flush */
-static int scr_flush_async_flushed = SCR_FAILURE;
+/* tracks info for all outstanding transfers */
+static kvtree* scr_flush_async_list = NULL;
 
 /*
 =========================================
@@ -45,7 +33,8 @@ Asynchronous flush functions
 */
 
 static int scr_axl_start(
-  const char* name,
+  int dset_id,
+  const char* dset_name,
   const char* state_file,
   int num_files,
   const char** src_filelist,
@@ -56,8 +45,8 @@ static int scr_axl_start(
   int rc = SCR_SUCCESS;
 
   /* define a transfer handle */
-  int id = AXL_Create_comm(xfer_type, name, state_file, comm);
-  if (id < 0) {
+  int axl_id = AXL_Create_comm(xfer_type, dset_name, state_file, comm);
+  if (axl_id < 0) {
     scr_err("Failed to create AXL transfer handle @ %s:%d",
       __FILE__, __LINE__
     );
@@ -65,17 +54,17 @@ static int scr_axl_start(
   }
 
   /* create record for this transfer in outstanding list, and record AXL id */
-  kvtree* name_hash = kvtree_set_kv(scr_flush_async_axl_list, ASYNC_KEY_OUT_NAME, name);
-  kvtree_util_set_int(name_hash, ASYNC_KEY_OUT_AXL, id);
+  kvtree* dset_hash = kvtree_set_kv_int(scr_flush_async_list, ASYNC_KEY_OUT_DSET, dset_id);
+  kvtree_util_set_int(dset_hash, ASYNC_KEY_OUT_AXL, axl_id);
 
   /* add files to transfer list */
   int i;
   for (i = 0; i < num_files; i++) {
     const char* src_file = src_filelist[i];
     const char* dst_file = dst_filelist[i];
-    if (AXL_Add(id, src_file, dst_file) != AXL_SUCCESS) {
+    if (AXL_Add(axl_id, src_file, dst_file) != AXL_SUCCESS) {
       scr_err("Failed to add file to AXL transfer handle %d: %s --> %s @ %s:%d",
-        id, src_file, dst_file, __FILE__, __LINE__
+        axl_id, src_file, dst_file, __FILE__, __LINE__
       );
       rc = SCR_FAILURE;
     }
@@ -83,13 +72,11 @@ static int scr_axl_start(
 
   /* verify that all rank added all of their files successfully */
   if (! scr_alltrue(rc == SCR_SUCCESS, comm)) {
-    /* some process failed to add its files, delete entry from the list */
-    kvtree_unset_kv(scr_flush_async_axl_list, ASYNC_KEY_OUT_NAME, name);
-
-    /* release the handle */
-    if (AXL_Free_comm(id, comm) != AXL_SUCCESS) {
+    /* some process failed to add its files,
+     * release the handle */
+    if (AXL_Free_comm(axl_id, comm) != AXL_SUCCESS) {
       scr_err("Failed to free AXL transfer handle %d @ %s:%d",
-        id, __FILE__, __LINE__
+        axl_id, __FILE__, __LINE__
       );
     }
 
@@ -98,9 +85,9 @@ static int scr_axl_start(
   }
 
   /* kick off the transfer */
-  if (AXL_Dispatch_comm(id, comm) != AXL_SUCCESS) {
+  if (AXL_Dispatch_comm(axl_id, comm) != AXL_SUCCESS) {
     scr_err("Failed to dispatch AXL transfer handle %d @ %s:%d",
-      id, __FILE__, __LINE__
+      axl_id, __FILE__, __LINE__
     );
     rc = SCR_FAILURE;
   }
@@ -112,16 +99,16 @@ static int scr_axl_start(
   return rc;
 }
 
-static int scr_axl_test(const char* name, MPI_Comm comm)
+static int scr_axl_test(int dset_id, MPI_Comm comm)
 {
   int rc = SCR_FAILURE;
 
   /* lookup AXL id in outstanding list */
-  int id;
-  kvtree* name_hash = kvtree_get_kv(scr_flush_async_axl_list, ASYNC_KEY_OUT_NAME, name);
-  if (kvtree_util_get_int(name_hash, ASYNC_KEY_OUT_AXL, &id) == KVTREE_SUCCESS) {
+  int axl_id;
+  kvtree* dset_hash = kvtree_get_kv_int(scr_flush_async_list, ASYNC_KEY_OUT_DSET, dset_id);
+  if (kvtree_util_get_int(dset_hash, ASYNC_KEY_OUT_AXL, &axl_id) == KVTREE_SUCCESS) {
     /* test whether transfer is still active */
-    if (AXL_Test_comm(id, comm) == AXL_SUCCESS) {
+    if (AXL_Test_comm(axl_id, comm) == AXL_SUCCESS) {
       rc = SCR_SUCCESS;
     }
   }
@@ -129,32 +116,29 @@ static int scr_axl_test(const char* name, MPI_Comm comm)
   return rc;
 }
 
-static int scr_axl_wait(const char* name, MPI_Comm comm)
+static int scr_axl_wait(int dset_id, MPI_Comm comm)
 {
   int rc = SCR_SUCCESS;
 
   /* lookup AXL id in outstanding list */
-  int id;
-  kvtree* name_hash = kvtree_get_kv(scr_flush_async_axl_list, ASYNC_KEY_OUT_NAME, name);
-  if (kvtree_util_get_int(name_hash, ASYNC_KEY_OUT_AXL, &id) == KVTREE_SUCCESS) {
+  int axl_id;
+  kvtree* dset_hash = kvtree_get_kv_int(scr_flush_async_list, ASYNC_KEY_OUT_DSET, dset_id);
+  if (kvtree_util_get_int(dset_hash, ASYNC_KEY_OUT_AXL, &axl_id) == KVTREE_SUCCESS) {
     /* test whether transfer is still active */
-    if (AXL_Wait_comm(id, comm) != AXL_SUCCESS) {
+    if (AXL_Wait_comm(axl_id, comm) != AXL_SUCCESS) {
       scr_err("Failed to wait on AXL transfer handle %d @ %s:%d",
-        id, __FILE__, __LINE__
+        axl_id, __FILE__, __LINE__
       );
       rc = SCR_FAILURE;
     }
 
     /* release the handle */
-    if (AXL_Free_comm(id, comm) != AXL_SUCCESS) {
+    if (AXL_Free_comm(axl_id, comm) != AXL_SUCCESS) {
       scr_err("Failed to free AXL transfer handle %d @ %s:%d",
-        id, __FILE__, __LINE__
+        axl_id, __FILE__, __LINE__
       );
       rc = SCR_FAILURE;
     }
-
-    /* delete entry for this transfer from AXL list */
-    kvtree_unset_kv(scr_flush_async_axl_list, ASYNC_KEY_OUT_NAME, name);
   } else {
     /* failed to lookup id */
     rc = SCR_FAILURE;
@@ -168,7 +152,7 @@ int scr_flush_async_stop()
 {
   /* this may take a while, so tell user what we're doing */
   if (scr_my_rank_world == 0) {
-    scr_dbg(1, "scr_flush_async_stop_all: Stopping flush");
+    scr_dbg(1, "Stopping all async flush operations");
   }
 
   /* stop all ongoing transfers */
@@ -177,18 +161,29 @@ int scr_flush_async_stop()
   }
 
   /* remove FLUSHING state from flush file */
-  scr_flush_async_in_progress = 0;
   /*
   scr_flush_file_location_unset(id, SCR_FLUSH_KEY_LOCATION_FLUSHING);
   */
 
-  /* clear internal flush_async variables to indicate there is no flush */
-  kvtree_delete(&scr_flush_async_file_list);
-  scr_free(&scr_flush_async_rankfile);
+  /* TODO: clear async_list */
 
   /* make sure all processes have made it this far before we leave */
   MPI_Barrier(scr_comm_world);
   return SCR_SUCCESS;
+}
+
+/* returns 1 if any async flush is ongoing, 0 otherwise */
+int scr_flush_async_in_progress(void)
+{
+  int size = kvtree_size(scr_flush_async_list);
+  return (size > 0);
+}
+
+/* returns 1 if any id is in async list, 0 otherwise */
+int scr_flush_async_in_list(int id)
+{
+  kvtree* dset_hash = kvtree_get_kv_int(scr_flush_async_list, ASYNC_KEY_OUT_DSET, id);
+  return (dset_hash != NULL);
 }
 
 /* start an asynchronous flush from cache to parallel file
@@ -216,43 +211,48 @@ int scr_flush_async_start(scr_cache_index* cindex, int id)
   /* make sure all processes make it this far before progressing */
   MPI_Barrier(scr_comm_world);
 
+  /* create record for this transfer in outstanding list */
+  kvtree* dset_hash = kvtree_set_kv_int(scr_flush_async_list, ASYNC_KEY_OUT_DSET, id);
+
+  /* flag to indicate whether flush has failed at any stage */
+  kvtree_util_set_int(dset_hash, ASYNC_KEY_OUT_STATUS, SCR_SUCCESS);
+
   /* start timer */
   if (scr_my_rank_world == 0) {
-    scr_flush_async_timestamp_start = scr_log_seconds();
-    scr_flush_async_time_start = MPI_Wtime();
+    time_t timestamp_start = scr_log_seconds();
+    double time_start = MPI_Wtime();
+    kvtree_util_set_unsigned_long(dset_hash, ASYNC_KEY_OUT_TIME, (unsigned long)timestamp_start);
+    kvtree_util_set_double(dset_hash, ASYNC_KEY_OUT_WTIME, time_start);
 
     /* log the start of the flush */
     if (scr_log_enable) {
       scr_log_event("ASYNC_FLUSH_START", NULL, &id, dset_name,
-                    &scr_flush_async_timestamp_start, NULL);
+                    &timestamp_start, NULL);
     }
   }
 
   /* mark that we've started a flush */
-  scr_flush_async_in_progress = 1;
-  scr_flush_async_dataset_id = id;
   scr_flush_file_location_set(id, SCR_FLUSH_KEY_LOCATION_FLUSHING);
 
-  /* this flag will remember whether any stage fails */
-  scr_flush_async_flushed = SCR_SUCCESS;
-
   /* get list of files to flush */
-  scr_flush_async_file_list = kvtree_new();
-  if (scr_flush_prepare(cindex, id, scr_flush_async_file_list) != SCR_SUCCESS) {
+  kvtree* file_list = kvtree_new();
+  if (scr_flush_prepare(cindex, id, file_list) != SCR_SUCCESS) {
     if (scr_my_rank_world == 0) {
       scr_err("scr_flush_async_start: Failed to prepare flush @ %s:%d",
         __FILE__, __LINE__
       );
       if (scr_log_enable) {
+        double time_start;
+        kvtree_util_get_double(dset_hash, ASYNC_KEY_OUT_WTIME, &time_start);
         double time_end = MPI_Wtime();
-        double time_diff = time_end - scr_flush_async_time_start;
+        double time_diff = time_end - time_start;
         scr_log_event("ASYNC_FLUSH_FAIL", "Failed to prepare flush",
                       &id, dset_name, NULL, &time_diff);
       }
     }
+    kvtree_util_set_int(dset_hash, ASYNC_KEY_OUT_STATUS, SCR_FAILURE);
     scr_dataset_delete(&dataset);
-    kvtree_delete(&scr_flush_async_file_list);
-    scr_flush_async_flushed = SCR_FAILURE;
+    kvtree_delete(&file_list);
     return SCR_FAILURE;
   }
 
@@ -260,7 +260,10 @@ int scr_flush_async_start(scr_cache_index* cindex, int id)
   int numfiles;
   char** src_filelist;
   char** dst_filelist;
-  scr_flush_list_alloc(scr_flush_async_file_list, &numfiles, &src_filelist, &dst_filelist);
+  scr_flush_list_alloc(file_list, &numfiles, &src_filelist, &dst_filelist);
+
+  /* attach file list for this transfer to outstanding list */
+  kvtree_set(dset_hash, ASYNC_KEY_OUT_FILES, file_list);
 
   /* create entry in index file to indicate that dataset may exist,
    * but is not yet complete */
@@ -287,7 +290,7 @@ int scr_flush_async_start(scr_cache_index* cindex, int id)
 
   /* define path for rank2file map */
   spath_append_str(dataset_path, "rank2file");
-  scr_flush_async_rankfile = spath_strdup(dataset_path);
+  char* rankfile = spath_strdup(dataset_path);
   spath_delete(&dataset_path);
 
   /* build a list of files for this rank */
@@ -312,8 +315,9 @@ int scr_flush_async_start(scr_cache_index* cindex, int id)
   }
 
   /* save our file list to disk */
-  kvtree_write_gather(scr_flush_async_rankfile, filelist, scr_comm_world);
+  kvtree_write_gather(rankfile, filelist, scr_comm_world);
   kvtree_delete(&filelist);
+  scr_free(&rankfile);
 
   /* create directories */
   scr_flush_create_dirs(scr_prefix, numfiles, (const char**) dst_filelist, scr_comm_world);
@@ -336,13 +340,13 @@ int scr_flush_async_start(scr_cache_index* cindex, int id)
 
   /* start writing files via AXL */
   int rc = SCR_SUCCESS;
-  if (scr_axl_start(dset_name, state_file, numfiles, (const char**) src_filelist, (const char**) dst_filelist,
+  if (scr_axl_start(id, dset_name, state_file, numfiles, (const char**) src_filelist, (const char**) dst_filelist,
     xfer_type, scr_comm_world) != SCR_SUCCESS)
   {
     /* failed to initiate AXL transfer */
     /* TODO: auto delete files? */
+    kvtree_util_set_int(dset_hash, ASYNC_KEY_OUT_STATUS, SCR_FAILURE);
     rc = SCR_FAILURE;
-    scr_flush_async_flushed = SCR_FAILURE;
   }
 
   /* free the path to the state file */
@@ -363,7 +367,10 @@ int scr_flush_async_start(scr_cache_index* cindex, int id)
 int scr_flush_async_test(scr_cache_index* cindex, int id)
 {
   /* if the transfer failed, indicate that transfer has completed */
-  if (scr_flush_async_flushed != SCR_SUCCESS) {
+  int status = SCR_FAILURE;
+  kvtree* dset_hash = kvtree_get_kv_int(scr_flush_async_list, ASYNC_KEY_OUT_DSET, id);
+  kvtree_util_get_int(dset_hash, ASYNC_KEY_OUT_STATUS, &status);
+  if (status != SCR_SUCCESS) {
     return SCR_SUCCESS;
   }
 
@@ -375,9 +382,13 @@ int scr_flush_async_test(scr_cache_index* cindex, int id)
   char* dset_name = NULL;
   scr_dataset_get_name(dataset, &dset_name);
 
+  if (scr_my_rank_world == 0) {
+    scr_dbg(1, "Testing async flush of dataset %d `%s'", id, dset_name);
+  }
+
   /* test whether transfer is done */
   int rc = SCR_SUCCESS;
-  if (scr_axl_test(dset_name, scr_comm_world) != SCR_SUCCESS) {
+  if (scr_axl_test(id, scr_comm_world) != SCR_SUCCESS) {
     rc = SCR_FAILURE;
   }
 
@@ -399,29 +410,40 @@ int scr_flush_async_complete(scr_cache_index* cindex, int id)
   scr_dataset_get_name(dataset, &dset_name);
 
   if (scr_my_rank_world == 0) {
-    scr_dbg(1, "Completing flush of dataset %d %s @ %s:%d", id, dset_name, __FILE__, __LINE__);
+    scr_dbg(1, "Completing async flush of dataset %d `%s' @ %s:%d", id, dset_name, __FILE__, __LINE__);
   }
 
-  /* TODO: wait on Filo if we failed to start? */
+  /* free the dataset */
+  scr_dataset_delete(&dataset);
+
+  /* lookup record for thie dataset */
+  kvtree* dset_hash = kvtree_get_kv_int(scr_flush_async_list, ASYNC_KEY_OUT_DSET, id);
+
   /* wait for transfer to complete */
-  if (scr_axl_wait(dset_name, scr_comm_world) != SCR_SUCCESS) {
-    scr_flush_async_flushed = SCR_FAILURE;
+  if (scr_axl_wait(id, scr_comm_world) != SCR_SUCCESS) {
+    kvtree_util_set_int(dset_hash, ASYNC_KEY_OUT_STATUS, SCR_FAILURE);
   }
+
+  /* lookup status of transfer */
+  int status = SCR_FAILURE;
+  kvtree_util_get_int(dset_hash, ASYNC_KEY_OUT_STATUS, &status);
+
+  /* get list of files for this transfer */
+  kvtree* file_list = kvtree_get(dset_hash, ASYNC_KEY_OUT_FILES);
 
   /* write summary file */
-  if (scr_flush_async_flushed == SCR_SUCCESS &&
-      scr_flush_complete(cindex, id, scr_flush_async_file_list) != SCR_SUCCESS)
+  if (status == SCR_SUCCESS &&
+      scr_flush_complete(cindex, id, file_list) != SCR_SUCCESS)
   {
-    scr_flush_async_flushed = SCR_FAILURE;
+    kvtree_util_set_int(dset_hash, ASYNC_KEY_OUT_STATUS, SCR_FAILURE);
   }
 
-  /* mark that we've stopped the flush */
-  scr_flush_async_in_progress = 0;
-  scr_flush_file_location_unset(id, SCR_FLUSH_KEY_LOCATION_FLUSHING);
+  /* lookup final status of transfer */
+  status = SCR_FAILURE;
+  kvtree_util_get_int(dset_hash, ASYNC_KEY_OUT_STATUS, &status);
 
-  /* free the file list for this checkpoint */
-  kvtree_delete(&scr_flush_async_file_list);
-  scr_free(&scr_flush_async_rankfile);
+  /* mark that we've stopped the flush */
+  scr_flush_file_location_unset(id, SCR_FLUSH_KEY_LOCATION_FLUSHING);
 
   /* stop timer, compute bandwidth, and report performance */
   if (scr_my_rank_world == 0) {
@@ -440,24 +462,27 @@ int scr_flush_async_complete(scr_cache_index* cindex, int id)
     int total_files = 0.0;
     scr_dataset_get_files(dataset, &total_files);
 
-    /* delete the dataset object */
-    scr_dataset_delete(&dataset);
+    /* lookup dataset name */
+    char* dset_name = NULL;
+    scr_dataset_get_name(dataset, &dset_name);
 
     /* stop timer and compute bandwidth */
+    double time_start;
+    kvtree_util_get_double(dset_hash, ASYNC_KEY_OUT_WTIME, &time_start);
     double time_end = MPI_Wtime();
-    double time_diff = time_end - scr_flush_async_time_start;
+    double time_diff = time_end - time_start;
     double bw = 0.0;
     if (time_diff > 0.0) {
-      bw = scr_flush_async_bytes / (1024.0 * 1024.0 * time_diff);
+      bw = total_bytes / (1024.0 * 1024.0 * time_diff);
     }
     scr_dbg(1, "scr_flush_async_complete: %f secs, %e bytes, %f MB/s, %f MB/s per proc",
-      time_diff, scr_flush_async_bytes, bw, bw/scr_ranks_world
+      time_diff, total_bytes, bw, bw/scr_ranks_world
     );
 
     /* log messages about flush */
-    if (scr_flush_async_flushed == SCR_SUCCESS) {
+    if (status == SCR_SUCCESS) {
       /* the flush worked, print a debug message */
-      scr_dbg(1, "scr_flush_async_complete: Flush of dataset succeeded %d `%s'", id, dset_name);
+      scr_dbg(1, "Flush succeeded for dataset %d `%s'", id, dset_name);
 
       /* log details of flush */
       if (scr_log_enable) {
@@ -465,7 +490,7 @@ int scr_flush_async_complete(scr_cache_index* cindex, int id)
       }
     } else {
       /* the flush failed, this is more serious so print an error message */
-      scr_err("scr_flush_async_complete: Flush of dataset failed %d `%s'", id, dset_name);
+      scr_err("Flush failed for dataset %d `%s'", id, dset_name);
 
       /* log details of flush */
       if (scr_log_enable) {
@@ -475,29 +500,53 @@ int scr_flush_async_complete(scr_cache_index* cindex, int id)
 
     /* log transfer stats */
     if (scr_log_enable) {
+      unsigned long starttime;
+      kvtree_util_get_unsigned_long(dset_hash, ASYNC_KEY_OUT_TIME, &starttime);
+      time_t timestamp_start = (time_t) starttime;
+
       char* dir = NULL;
       scr_cache_index_get_dir(cindex, id, &dir);
+
       scr_log_transfer("FLUSH_ASYNC", dir, scr_prefix, &id, dset_name,
-        &scr_flush_async_timestamp_start, &time_diff, &total_bytes, &total_files
+        &timestamp_start, &time_diff, &total_bytes, &total_files
       );
     }
+
+    /* delete the dataset object */
+    scr_dataset_delete(&dataset);
   }
 
-  /* free the dataset */
-  scr_dataset_delete(&dataset);
+  /* remove dset from async_list */
+  kvtree_unset_kv_int(scr_flush_async_list, ASYNC_KEY_OUT_DSET, id);
 
-  return scr_flush_async_flushed;
+  return status;
 }
 
 /* wait until the checkpoint currently being flushed completes */
-int scr_flush_async_wait(scr_cache_index* cindex)
+int scr_flush_async_wait(scr_cache_index* cindex, int id)
 {
-  if (scr_flush_async_in_progress) {
-    while (scr_flush_file_is_flushing(scr_flush_async_dataset_id)) {
+  if (scr_flush_async_in_progress()) {
+    /* get the dataset corresponding to this id */
+    scr_dataset* dataset = scr_dataset_new();
+    scr_cache_index_get_dataset(cindex, id, dataset);
+
+    /* lookup dataset name */
+    char* dset_name = NULL;
+    scr_dataset_get_name(dataset, &dset_name);
+
+    /* this may take a while, so tell user what we're doing */
+    if (scr_my_rank_world == 0) {
+      scr_dbg(1, "Waiting on async flush of dataset %d `%s'", id, dset_name);
+    }
+
+    /* delete the dataset object */
+    scr_dataset_delete(&dataset);
+
+    while (scr_flush_file_is_flushing(id)) {
       /* test whether the flush has completed, and if so complete the flush */
-      if (scr_flush_async_test(cindex, scr_flush_async_dataset_id) == SCR_SUCCESS) {
+      if (scr_flush_async_test(cindex, id) == SCR_SUCCESS) {
         /* complete the flush */
-        scr_flush_async_complete(cindex, scr_flush_async_dataset_id);
+        scr_flush_async_complete(cindex, id);
       } else {
         /* otherwise, sleep to get out of the way */
         usleep(10*1000*1000);
@@ -507,10 +556,90 @@ int scr_flush_async_wait(scr_cache_index* cindex)
   return SCR_SUCCESS;
 }
 
+/* wait until the checkpoint currently being flushed completes */
+int scr_flush_async_waitall(scr_cache_index* cindex)
+{
+  if (scr_flush_async_in_progress()) {
+    kvtree* dsets = kvtree_get(scr_flush_async_list, ASYNC_KEY_OUT_DSET);
+
+    /* get ordered list of dataset ids */
+    int num;
+    int* ids;
+    kvtree_list_int(dsets, &num, &ids);
+
+    /* iterate over each dataset and wait for it to complete */
+    int i;
+    for (i = 0; i < num; i++) {
+      int id = ids[i];
+      scr_flush_async_wait(cindex, id);
+    }
+
+    /* free memory holding list of dataset ids */
+    scr_free(&ids);
+  }
+
+  return SCR_SUCCESS;
+}
+
+/* progress each dataset in turn until all are complete,
+ * or we find the first that is still going */
+int scr_flush_async_progall(scr_cache_index* cindex)
+{
+  if (scr_flush_async_in_progress()) {
+    kvtree* dsets = kvtree_get(scr_flush_async_list, ASYNC_KEY_OUT_DSET);
+
+    /* get ordered list of dataset ids */
+    int num;
+    int* ids;
+    kvtree_list_int(dsets, &num, &ids);
+
+    /* iterate over each dataset and wait for it to complete */
+    int i;
+    for (i = 0; i < num; i++) {
+      int id = ids[i];
+      if (scr_flush_file_is_flushing(id)) {
+        /* test whether the flush has completed, and if so complete the flush */
+        if (scr_flush_async_test(cindex, id) == SCR_SUCCESS) {
+          /* complete the flush */
+          scr_flush_async_complete(cindex, id);
+        } else {
+          /* TODO: allow flushes to complete out of order */
+
+          /* flush is still going, so that we don't complete datasets
+           * out of order, break the loop and stop here */
+          break;
+        }
+      }
+    }
+
+    /* free memory holding list of dataset ids */
+    scr_free(&ids);
+  }
+
+  return SCR_SUCCESS;
+}
+
+/* get ordered list of ids being flushed,
+ * caller is responsible for freeing ids with scr_free */
+int scr_flush_async_get_list(scr_cache_index* cindex, int* num, int** ids)
+{
+  /* assume we don't have any */
+  *num = 0;
+  *ids = NULL;
+
+  /* get ordered list of dataset ids if we have any */
+  if (scr_flush_async_in_progress()) {
+    kvtree* dsets = kvtree_get(scr_flush_async_list, ASYNC_KEY_OUT_DSET);
+    kvtree_list_int(dsets, num, ids);
+  }
+
+  return SCR_SUCCESS;
+}
+
 /* start any processes for later asynchronous flush operations */
 int scr_flush_async_init()
 {
-  scr_flush_async_axl_list = kvtree_new();
+  scr_flush_async_list = kvtree_new();
 
   return SCR_SUCCESS;
 }
@@ -518,7 +647,7 @@ int scr_flush_async_init()
 /* stop all ongoing asynchronous flush operations */
 int scr_flush_async_finalize()
 {
-  kvtree_delete(&scr_flush_async_axl_list);
+  kvtree_delete(&scr_flush_async_list);
 
   return SCR_SUCCESS;
 }

--- a/src/scr_flush_async.h
+++ b/src/scr_flush_async.h
@@ -17,6 +17,12 @@
 /* stop all ongoing asynchronous flush operations */
 int scr_flush_async_stop(void);
 
+/* returns 1 if any async flush is ongoing, 0 otherwise */
+int scr_flush_async_in_progress(void);
+
+/* returns 1 if any id is in async list, 0 otherwise */
+int scr_flush_async_in_list(int id);
+
 /* start an asynchronous flush from cache to parallel file system under SCR_PREFIX */
 int scr_flush_async_start(scr_cache_index* cindex, int id);
 
@@ -26,12 +32,24 @@ int scr_flush_async_test(scr_cache_index* cindex, int id);
 /* complete the flush from cache to parallel file system */
 int scr_flush_async_complete(scr_cache_index* cindex, int id);
 
-/* wait until the checkpoint currently being flushed completes */
-int scr_flush_async_wait(scr_cache_index* cindex);
+/* wait until the dataset currently being flushed completes */
+int scr_flush_async_wait(scr_cache_index* cindex, int id);
+
+/* wait until all datasets currently being flushed complete */
+int scr_flush_async_waitall(scr_cache_index* cindex);
+
+/* progress each dataset in turn until all are complete,
+ * or we find the first that is still going */
+int scr_flush_async_progall(scr_cache_index* cindex);
+
+/* get ordered list of ids being flushed,
+ * caller is responsible for freeing ids with scr_free */
+int scr_flush_async_get_list(scr_cache_index* cindex, int* num, int** ids);
 
 /* initialize the async transfer processes */
 int scr_flush_async_init(void);
 
 /* finalize the async transfer processes */
 int scr_flush_async_finalize(void);
-#endif
+
+#endif /* SCR_FLUSH_ASYNC_H */

--- a/src/scr_flush_sync.c
+++ b/src/scr_flush_sync.c
@@ -188,9 +188,9 @@ int scr_flush_sync(scr_cache_index* cindex, int id)
     time_start = MPI_Wtime();
   }
 
-  /* if we are flushing something asynchronously, wait on it */
-  if (scr_flush_async_in_progress) {
-    scr_flush_async_wait(cindex);
+  /* if we are flushing anything asynchronously, wait on it */
+  if (scr_flush_async_in_progress()) {
+    scr_flush_async_waitall(cindex);
 
     /* the flush we just waited on could be the requested dataset,
      * so perhaps we're already done */
@@ -265,7 +265,7 @@ int scr_flush_sync(scr_cache_index* cindex, int id)
     /* log messages about flush */
     if (flushed == SCR_SUCCESS) {
       /* the flush worked, print a debug message */
-      scr_dbg(1, "scr_flush_sync: Flush of dataset succeeded %d `%s'", id, dset_name);
+      scr_dbg(1, "scr_flush_sync: Flush succeeded for dataset %d `%s'", id, dset_name);
 
       /* log details of flush */
       if (scr_log_enable) {
@@ -273,7 +273,7 @@ int scr_flush_sync(scr_cache_index* cindex, int id)
       }
     } else {
       /* the flush failed, this is more serious so print an error message */
-      scr_err("scr_flush_sync: Flush of dataset failed %d `%s'", id, dset_name);
+      scr_err("scr_flush_sync: Flush failed for dataset %d `%s'", id, dset_name);
 
       /* log details of flush */
       if (scr_log_enable) {

--- a/src/scr_globals.c
+++ b/src/scr_globals.c
@@ -132,9 +132,6 @@ int   scr_drop_after_current = 0;                  /* whether to drop datasets f
 int    scr_flush_async             = SCR_FLUSH_ASYNC;         /* whether to use asynchronous flush */
 double scr_flush_async_bw          = SCR_FLUSH_ASYNC_BW;      /* bandwidth limit imposed during async flush */
 double scr_flush_async_percent     = SCR_FLUSH_ASYNC_PERCENT; /* runtime limit imposed during async flush */
-int    scr_flush_async_in_progress = 0;                       /* tracks whether an async flush is currently underway */
-int    scr_flush_async_dataset_id  = -1;                      /* tracks the id of the checkpoint being flushed */
-double scr_flush_async_bytes       = 0.0;                     /* records the total number of bytes to be flushed */
 
 int scr_flush_poststage = SCR_FLUSH_POSTSTAGE; /* Use scr_poststage to finalize transfers */
 

--- a/src/scr_globals.h
+++ b/src/scr_globals.h
@@ -190,12 +190,9 @@ extern int   scr_drop_after_current; /* auto-drop datasets from index that come 
 extern int scr_prefix_size;  /* max number of checkpoints to keep in prefix directory */
 extern int scr_prefix_purge; /* whether to delete all datasets listed in index file during SCR_Init */
 
-extern int scr_flush_async;             /* whether to use asynchronous flush */
-extern double scr_flush_async_bw;       /* bandwidth limit imposed during async flush */
-extern double scr_flush_async_percent;  /* runtime limit imposed during async flush */
-extern int scr_flush_async_in_progress; /* tracks whether an async flush is currently underway */
-extern int scr_flush_async_dataset_id;  /* tracks the id of the checkpoint being flushed */
-extern double scr_flush_async_bytes;    /* records the total number of bytes to be flushed */
+extern int scr_flush_async;            /* whether to use asynchronous flush */
+extern double scr_flush_async_bw;      /* bandwidth limit imposed during async flush */
+extern double scr_flush_async_percent; /* runtime limit imposed during async flush */
 
 extern int scr_flush_poststage; /* whether to use scr_poststage.sh to finalize transfers */
 

--- a/src/scr_storedesc.c
+++ b/src/scr_storedesc.c
@@ -309,8 +309,11 @@ int scr_storedescs_index_from_child_path(const char* path)
     return index;
   }
 
-  /* search through the scr_storedescs looking for a match */
+  /* search through the scr_storedescs looking for a match,
+   * match on the longest path we can find, in case we have
+   * a situation like "/dev/shm", and "/dev/shm/dir1" */
   int i;
+  int maxlen = 0;
   for (i = 0; i < scr_nstoredescs; i++) {
     /* get length of path for this descriptor */
     int pathlen = strlen(scr_storedescs[i].name);
@@ -319,9 +322,12 @@ int scr_storedescs_index_from_child_path(const char* path)
     if (scr_storedescs[i].enabled &&
         strncmp(path, scr_storedescs[i].name, pathlen) == 0)
     {
-      /* found a match, record its index, and break */
-      index = i;
-      break;
+      /* found a match, record its index,
+       * keep searching in case we find a longer (better) match */
+      if (maxlen < pathlen) {
+        index = i;
+        maxlen = pathlen;
+      }
     }
   }
 


### PR DESCRIPTION
Currently, SCR only permits a single outstanding async flush at a time.  If the job attempts to start a second, SCR blocks the job and waits on the first to finish.  This extends SCR to support an arbitrary number of simultaneous async flush operations.