### PR TITLE
dist: drop doc and test directories from tarball

### DIFF
--- a/dist/builddist
+++ b/dist/builddist
@@ -94,6 +94,13 @@ for (( i=0; i<${len}; i=$(($i + 3)) )); do
         if [ "$component" == "lwgrp" ] ; then
             sed -i 's@#include "../config/config.h"@@g' lwgrp/src/lwgrp_internal.h
         fi
+
+        # remove doc and test directories for a smaller tarball
+        rm -rf ${component}/doc
+        rm -rf ${component}/doc-dev
+        if [ "$component" != "scr" ] ; then
+          rm -rf ${component}/test
+        fi
     cd ..
 done
 


### PR DESCRIPTION
The doc directories from SCR and the components include image files that are not actually installed.  Meanwhile, the documentation can be viewed in rendered form online.  Dropping those directories reduces the dist tarball size from 2MB to about 600KB.