### PR TITLE
bootstrap.sh build errors and --clean option

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -17,18 +17,18 @@ build_debug=0 # whether to build optimized (0) or debug "-g -O0" (1)
 build_dev=0   # whether to checkout fixed version tags (0) or use latest (1)
 
 while [ $# -ge 1 ]; do
-    case "$1" in
-      "--ssh" )
-        clone_ssh=1 ;;
-      "--debug" )
-        build_debug=1 ;;
-      "--dev" )
-        build_dev=1 ;;
-      *)
-        echo "USAGE ERROR: unknown option $1"
-        exit 1 ;;
-    esac
-    shift
+  case "$1" in
+    "--ssh" )
+      clone_ssh=1 ;;
+    "--debug" )
+      build_debug=1 ;;
+    "--dev" )
+      build_dev=1 ;;
+    *)
+      echo "USAGE ERROR: unknown option $1"
+      exit 1 ;;
+  esac
+  shift
 done
 
 ROOT="$(pwd)"
@@ -61,22 +61,22 @@ else
   url_prefix="git@github.com:"
 fi
 repos=(${url_prefix}ECP-VeloC/KVTree.git
-    ${url_prefix}ECP-VeloC/AXL.git
-    ${url_prefix}ECP-VeloC/spath.git
-    ${url_prefix}ECP-VeloC/rankstr.git
-    ${url_prefix}ECP-VeloC/redset.git
-    ${url_prefix}ECP-VeloC/shuffile.git
-    ${url_prefix}ECP-VeloC/er.git
+  ${url_prefix}ECP-VeloC/AXL.git
+  ${url_prefix}ECP-VeloC/spath.git
+  ${url_prefix}ECP-VeloC/rankstr.git
+  ${url_prefix}ECP-VeloC/redset.git
+  ${url_prefix}ECP-VeloC/shuffile.git
+  ${url_prefix}ECP-VeloC/er.git
 )
 
 for i in "${repos[@]}" ; do
-	# Get just the name of the project (like "KVTree")
-	name=$(basename $i | sed 's/\.git//g')
-	if [ -d $name ] ; then
-		echo "$name already exists, skipping it"
-	else
-		git clone $i
-	fi
+  # Get just the name of the project (like "KVTree")
+  name=$(basename $i | sed 's/\.git//g')
+  if [ -d $name ] ; then
+    echo "$name already exists, skipping it"
+  else
+    git clone $i
+  fi
 done
 
 # whether to build optimized or "-g -O0" debug
@@ -124,77 +124,145 @@ pushd ${pdsh}
   fi
 popd
 
-cd KVTree
+pushd KVTree
   if [ $build_dev -eq 0 ] ; then
     git checkout v1.1.1
   fi
-  mkdir -p build && cd build
-  cmake -DCMAKE_BUILD_TYPE=$buildtype -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR -DMPI=ON ..
-  make -j `nproc`
-  make install
-cd ../..
+  mkdir -p build
+  pushd build
+    cmake \
+      -DCMAKE_BUILD_TYPE=$buildtype \
+      -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR \
+      -DMPI=ON \
+      .. && \
+    make -j `nproc` && \
+    make install
+    if [ $? -ne 0 ]; then
+      echo "failed to configure, build, or install kvtree"
+      exit 1
+    fi
+  popd
+popd
 
-cd AXL
+pushd AXL
   if [ $build_dev -eq 0 ] ; then
     git checkout v0.4.0
   fi
-  mkdir -p build && cd build
-  cmake -DCMAKE_BUILD_TYPE=$buildtype -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR ..
-  make -j `nproc`
-  make install
-cd ../..
+  mkdir -p build
+  pushd build
+    cmake \
+      -DCMAKE_BUILD_TYPE=$buildtype \
+      -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR \
+      .. && \
+    make -j `nproc` && \
+    make install
+    if [ $? -ne 0 ]; then
+      echo "failed to configure, build, or install axl"
+      exit 1
+    fi
+  popd
+popd
 
-cd spath
+pushd spath
   if [ $build_dev -eq 0 ] ; then
     git checkout v0.0.2
   fi
-  mkdir -p build && cd build
-  cmake -DCMAKE_BUILD_TYPE=$buildtype -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR -DMPI=ON ..
-  make -j `nproc`
-  make install
-  #make test
-cd ../..
+  mkdir -p build
+  pushd build
+    cmake \
+      -DCMAKE_BUILD_TYPE=$buildtype \
+      -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR \
+      -DMPI=ON \
+      .. && \
+    make -j `nproc` && \
+    make install
+    if [ $? -ne 0 ]; then
+      echo "failed to configure, build, or install spath"
+      exit 1
+    fi
+  popd
+popd
 
-cd rankstr
+pushd rankstr
   if [ $build_dev -eq 0 ] ; then
     git checkout v0.0.3
   fi
-  mkdir -p build && cd build
-  cmake -DCMAKE_BUILD_TYPE=$buildtype -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR ..
-  make -j `nproc`
-  make install
-  #make test
-cd ../..
+  mkdir -p build
+  pushd build
+    cmake \
+      -DCMAKE_BUILD_TYPE=$buildtype \
+      -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR \
+      .. && \
+    make -j `nproc` && \
+    make install
+    if [ $? -ne 0 ]; then
+      echo "failed to configure, build, or install rankstr"
+      exit 1
+    fi
+  popd
+popd
 
-cd redset
+pushd redset
   if [ $build_dev -eq 0 ] ; then
     git checkout v0.0.5
   fi
-  mkdir -p build && cd build
-  cmake -DCMAKE_BUILD_TYPE=$buildtype -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR -DWITH_KVTREE_PREFIX=$INSTALL_DIR ..
-  make -j `nproc`
-  make install
-cd ../..
+  mkdir -p build
+  pushd build
+    cmake \
+      -DCMAKE_BUILD_TYPE=$buildtype \
+      -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR \
+      -DWITH_KVTREE_PREFIX=$INSTALL_DIR \
+      .. && \
+    make -j `nproc` && \
+    make install
+    if [ $? -ne 0 ]; then
+      echo "failed to configure, build, or install redset"
+      exit 1
+    fi
+  popd
+popd
 
-cd shuffile
+pushd shuffile
   if [ $build_dev -eq 0 ] ; then
     git checkout v0.0.4
   fi
-  mkdir -p build && cd build
-  cmake -DCMAKE_BUILD_TYPE=$buildtype -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR -DWITH_KVTREE_PREFIX=$INSTALL_DIR ..
-  make -j `nproc`
-  make install
-cd ../..
+  mkdir -p build
+  pushd build
+    cmake \
+      -DCMAKE_BUILD_TYPE=$buildtype \
+      -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR \
+      -DWITH_KVTREE_PREFIX=$INSTALL_DIR \
+      .. && \
+    make -j `nproc` && \
+    make install
+    if [ $? -ne 0 ]; then
+      echo "failed to configure, build, or install shuffile"
+      exit 1
+    fi
+  popd
+popd
 
-cd er
+pushd er
   if [ $build_dev -eq 0 ] ; then
     git checkout v0.0.4
   fi
-  mkdir -p build && cd build
-  cmake -DCMAKE_BUILD_TYPE=$buildtype -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR -DWITH_KVTREE_PREFIX=$INSTALL_DIR -DWITH_REDSET_PREFIX=$INSTALL_DIR -DWITH_SHUFFILE_PREFIX=$INSTALL_DIR ..
-  make -j `nproc`
-  make install
-cd ../..
+  mkdir -p build
+  pushd build
+    cmake \
+      -DCMAKE_BUILD_TYPE=$buildtype \
+      -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR \
+      -DWITH_KVTREE_PREFIX=$INSTALL_DIR \
+      -DWITH_REDSET_PREFIX=$INSTALL_DIR \
+      -DWITH_SHUFFILE_PREFIX=$INSTALL_DIR \
+      .. && \
+    make -j `nproc` && \
+    make install
+    if [ $? -ne 0 ]; then
+      echo "failed to configure, build, or install er"
+      exit 1
+    fi
+  popd
+popd
 
 set +x
 cd "$ROOT"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -15,6 +15,7 @@ set -x
 clone_ssh=0   # whether to clone with https (0) or ssh (1)
 build_debug=0 # whether to build optimized (0) or debug "-g -O0" (1)
 build_dev=0   # whether to checkout fixed version tags (0) or use latest (1)
+build_clean=0 # whether to keep deps directory (0) or delete and recreate (1)
 
 while [ $# -ge 1 ]; do
   case "$1" in
@@ -24,6 +25,8 @@ while [ $# -ge 1 ]; do
       build_debug=1 ;;
     "--dev" )
       build_dev=1 ;;
+    "--clean" )
+      build_clean=1 ;;
     *)
       echo "USAGE ERROR: unknown option $1"
       exit 1 ;;
@@ -32,10 +35,15 @@ while [ $# -ge 1 ]; do
 done
 
 ROOT="$(pwd)"
+INSTALL_DIR=$ROOT/install
+
+if [ $build_clean -eq 1 ] ; then
+  rm -rf deps
+  rm -rf install
+fi
 
 mkdir -p deps
 mkdir -p install
-INSTALL_DIR=$ROOT/install
 
 cd deps
 


### PR DESCRIPTION
To help ensure someone gets a correct build, this checks for and report builds errors.  A new ``--clean`` option is added to delete deps and install dirs before building to force a fresh clone and build of everything.