### PR TITLE
cmake: install python scripts

### DIFF
--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -12,6 +12,7 @@ ENDFUNCTION(SCR_INSTALL_BIN file)
 
 # Common Binaries
 ADD_SUBDIRECTORY(common)
+ADD_SUBDIRECTORY(pyfe)
 
 # Tests
 ADD_SUBDIRECTORY(test)

--- a/scripts/pyfe/CMakeLists.txt
+++ b/scripts/pyfe/CMakeLists.txt
@@ -1,0 +1,1 @@
+ADD_SUBDIRECTORY(pyfe)

--- a/scripts/pyfe/pyfe/CMakeLists.txt
+++ b/scripts/pyfe/pyfe/CMakeLists.txt
@@ -1,0 +1,41 @@
+SET(PYFE
+  __init__.py
+  list_dir.py
+  list_down_nodes.py
+  parsetime.py
+  pdsh_clustershell.py
+  postrun.py
+  scr_check_node.py
+  scr_common.py
+  scr_env.py
+  scr_environment.py
+  scr_get_jobstep_id.py
+  scr_glob_hosts.py
+  scr_halt.py
+  scr_hostlist.py
+  scr_inspect.py
+  scr_jsrun.py
+  scr_kill_jobstep.py
+  scr_list_dir.py
+  scr_list_down_nodes.py
+  scr_lrun.py
+  scr_mpirun.py
+  scr_param.py
+  scr_postrun.py
+  scr_poststage.py
+  scr_prerun.py
+  scr_run.py
+  scr_scavenge.py
+  scr_srun.py
+  scr_test_runtime.py
+  scr_watchdog.py
+)
+INSTALL(FILES ${PYFE} DESTINATION ${CMAKE_INSTALL_BINDIR}/pyfe)
+
+CONFIGURE_FILE(scr_const.py.in scr_const.py @ONLY)
+SET_SOURCE_FILES_PROPERTIES(${CMAKE_CURRENT_SOURCE_DIR}/scr_const.py.in PROPERTIES GENERATED FALSE)
+SET_SOURCE_FILES_PROPERTIES(${CMAKE_CURRENT_BINARY_DIR}/scr_const.py PROPERTIES GENERATED TRUE)
+INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/scr_const.py DESTINATION ${CMAKE_INSTALL_BINDIR}/pyfe)
+
+ADD_SUBDIRECTORY(resmgr)
+ADD_SUBDIRECTORY(joblauncher)

--- a/scripts/pyfe/pyfe/joblauncher/CMakeLists.txt
+++ b/scripts/pyfe/pyfe/joblauncher/CMakeLists.txt
@@ -1,0 +1,11 @@
+SET(JOBLAUNCHERS
+  __init__.py
+  scr_joblauncher.py
+  scr_joblauncher_aprun.py
+  scr_joblauncher_base.py
+  scr_joblauncher_jsrun.py
+  scr_joblauncher_lrun.py
+  scr_joblauncher_mpirun.py
+  scr_joblauncher_srun.py
+)
+INSTALL(FILES ${JOBLAUNCHERS} DESTINATION ${CMAKE_INSTALL_BINDIR}/pyfe/joblauncher)

--- a/scripts/pyfe/pyfe/resmgr/CMakeLists.txt
+++ b/scripts/pyfe/pyfe/resmgr/CMakeLists.txt
@@ -1,0 +1,11 @@
+SET(RESOURCEMANAGERS
+  __init__.py
+  aprun.py
+  auto.py
+  lsf.py
+  nodetests.py
+  pmix.py
+  resourcemanager.py
+  slurm.py
+)
+INSTALL(FILES ${RESOURCEMANAGERS} DESTINATION ${CMAKE_INSTALL_BINDIR}/pyfe/resmgr)


### PR DESCRIPTION
@chaseleif , I've added some cmake files to install the pyfe files.  This install things into ``<install>/bin/pyfe``.  We might move that to a different install location later, but this simplifies things a bit.  After installing SCR, you should then just need to set ``PYTHONPATH``, e.g.,
```
cmake ...
make install

export PYTHONPATH=`pwd`/install/bin
python3 scr_list_down_nodes.py
```