### PR TITLE
allow runproc command to be a string

### DIFF
--- a/scripts/pyfe/pyfe/resmgr/lsf.py
+++ b/scripts/pyfe/pyfe/resmgr/lsf.py
@@ -59,11 +59,11 @@ class LSF(ResourceManager):
     if jobid == -1:
       print('You must specify the job step id to kill.')
       return 1
-    return runproc(argv=['bkill', '-s', 'KILL', str(jobid)])[1]
+    return runproc("bkill -s KILL " + str(jobid))[1]
 
   def get_scr_end_time(self):
     # run bjobs to get time remaining in current allocation
-    bjobs, rc = runproc(argv=['bjobs', '-o', 'time_left'], getstdout=True)
+    bjobs, rc = runproc("bjobs -o time_left", getstdout=True)
     if rc != 0:
       return 0
 

--- a/scripts/pyfe/pyfe/resmgr/pbsalps.py
+++ b/scripts/pyfe/pyfe/resmgr/pbsalps.py
@@ -22,7 +22,7 @@ class PBSALPS(ResourceManager):
     return os.environ.get('PBS_JOBID')
 
   def get_jobstep_id(self,user='',pid=-1):
-    output = runproc(argv=['apstat','-avv'],getstdout=True)[0].split('\n')
+    output = runproc("apstat -avv",getstdout=True)[0].split('\n')
     nid = None
     try:
       with open('/proc/cray_xt/nid','r') as NIDfile:
@@ -54,8 +54,8 @@ class PBSALPS(ResourceManager):
   def get_job_nodes(self):
     val = os.environ.get('PBS_NUM_NODES')
     if val is not None:
-      argv = ['aprun','-n',val,'-N','1','cat','/proc/cray_xt/nid'] # $nidfile
-      out = runproc(argv=argv,getstdout=True)[0]
+      cmd = "aprun -n " + val + " -N 1 cat /proc/cray_xt/nid" # $nidfile
+      out = runproc(cmd,getstdout=True)[0]
       nodearray = out.split('\n')
       if len(nodearray)>0:
         if nodearray[-1]=='\n':
@@ -72,10 +72,8 @@ class PBSALPS(ResourceManager):
     snodes = self.get_job_nodes()
     if snodes is not None:
       snodes = self.expand_hosts(snodes)
-      argv = ['xtprocadmin', '-n', ''] # $xtprocadmin
       for node in snodes:
-        argv[2] = node
-        out, returncode = runproc(argv=argv, getstdout=True)
+        out, returncode = runproc("xtprocadmin -n " + node, getstdout=True)
         #if returncode==0:
         resarray = out.split('\n')
         answerarray = resarray[1].split(' ')
@@ -90,7 +88,7 @@ class PBSALPS(ResourceManager):
     if jobid==-1:
       print('You must specify the job step id to kill.')
       return 1
-    return runproc(argv=['apkill',str(jobid)])[1]
+    return runproc("apkill " + str(jobid))[1]
 
   # return a hash to define all unavailable (down or excluded) nodes and reason
   def list_down_nodes_with_reason(self,nodes=[], scr_env=None, free=False, cntldir_string=None, cachedir_string=None):

--- a/scripts/pyfe/pyfe/resmgr/slurm.py
+++ b/scripts/pyfe/pyfe/resmgr/slurm.py
@@ -32,8 +32,8 @@ class SLURM(ResourceManager):
     #   squeue -h -s -u $user -j $jobid -S "-i"
     # -h means print no header, so just the data in this order:
     # STEPID         NAME PARTITION     USER      TIME NODELIST
-    cmd = ['squeue', '-h', '-s', '-u', user, '-j', jobid, '-S', '\"-i\"']
-    output = runproc(argv=cmd, getstdout=True)[0]
+    cmd = "squeue -h -s -u " + user + " -j " + jobid + " -S \"-i\""
+    output = runproc(cmd, getstdout=True)[0]
     output = re.search('\d+', output)
     if output is None:
       return None
@@ -47,8 +47,7 @@ class SLURM(ResourceManager):
   def get_downnodes(self):
     nodelist = self.get_job_nodes()
     if nodelist is not None:
-      argv = ['sinfo', '-ho', '%N', '-t', 'down', '-n', nodelist]
-      down, returncode = runproc(argv=argv, getstdout=True)
+      down, returncode = runproc("sinfo -ho %N -t down -n " + nodelist, getstdout=True)
       if returncode == 0:
         down = down.strip()
         return down
@@ -58,7 +57,7 @@ class SLURM(ResourceManager):
     if jobid==-1:
       print('You must specify the job step id to kill.')
       return 1
-    return runproc(argv=['scancel',str(jobid)])[1]
+    return runproc('scancel ' + str(jobid))[1]
 
   # query SLURM for allocation endtime, expressed as secs since epoch
   def get_scr_end_time(self):
@@ -68,8 +67,7 @@ class SLURM(ResourceManager):
       return 0
 
     # ask scontrol for endtime of this job
-    argv = ['scontrol', '--oneliner', 'show', 'job', jobid]
-    output = runproc(argv=argv, getstdout=True)[0]
+    output = runproc("scontrol --oneliner show job " + jobid, getstdout=True)[0]
     m = re.search('EndTime=(\\S*)', output)
     if not m:
       return 0

--- a/scripts/pyfe/pyfe/scr_common.py
+++ b/scripts/pyfe/pyfe/scr_common.py
@@ -68,6 +68,14 @@ The default shell used by subprocess is /bin/sh. If youre using other shells, li
 # for the first return value (output) -> specify getstdout to get the stdout, getstderr to get stderr
 # specifying both getstdout and getstderr=True returns a list where [0] is stdout and [1] is stderr
 def runproc(argv,wait=True,getstdout=False,getstderr=False):
+  # allow caller to pass command as a string, as in:
+  #   "ls -lt" rather than ["ls", "-lt"]
+  # this does not support arguments that may have embedded spaces
+  #   "echo 'hello world'"
+  # one must pass argv as a list in such cases
+  if type(argv) is str:
+    argv = argv.strip().split()
+
   if len(argv)<1:
     return None, None
   try:


### PR DESCRIPTION
In cases where one can pass the runproc command as a string, it can help with readability (and also cut-and-paste into a shell for testing). This extends runproc to accept a string, which it splits on whitespace to create the argv list. This does not support a command with an argument that has embedded spaces.

This updates some of the ResourceManager classes to use the string option.