### PR TITLE
define functions to return scr dirs in scr_env

### DIFF
--- a/scripts/pyfe/pyfe/postrun.py
+++ b/scripts/pyfe/pyfe/postrun.py
@@ -135,7 +135,7 @@ def postrun(prefix_dir=None, scr_env=None, verbose=False, log=None):
           break
 
         # build full path to dataset directory
-        datadir = os.path.join(pardir, '.scr', 'scr.dataset.' + d)
+        datadir = scr_env.dir_dset(d)
         os.makedirs(datadir, exist_ok=True)
 
         # Gather files from cache to parallel file system
@@ -210,7 +210,7 @@ def postrun(prefix_dir=None, scr_env=None, verbose=False, log=None):
           continue
 
         # build full path to dataset directory
-        datadir = os.path.join(pardir, '.scr', 'scr.dataset.' + d)
+        datadir = scr_env.dir_dset(d)
         os.makedirs(datadir, exist_ok=True)
 
         # Gather files from cache to parallel file system

--- a/scripts/pyfe/pyfe/scr_env.py
+++ b/scripts/pyfe/pyfe/scr_env.py
@@ -64,23 +64,24 @@ if __name__ == '__main__':
                       '--prefix',
                       metavar='<dir>',
                       type=str,
+                      default=None,
                       help='Specify the prefix directory.')
   parser.add_argument('-r',
                       '--runnodes',
                       action='store_true',
                       help='List the number of nodes used in the last run.')
   args = vars(parser.parse_args())
-  scr_env = SCR_Env()
+
+  scr_env = SCR_Env(prefix=args['prefix'])
   scr_env.resmgr = AutoResourceManager()
   scr_env.launcher = AutoJobLauncher()
   scr_env.param = SCR_Param()
+
   if len(args) == 0:
     printobject(scr_env, 'scr_env')
   elif 'help' in args:
     parser.print_help()
   else:
-    if 'prefix' in args:
-      scr_env.set_prefix(args['prefix'])
     if 'user' in args:
       print(str(scr_env.get_user()), end='')
     if 'jobid' in args:

--- a/scripts/pyfe/pyfe/scr_environment.py
+++ b/scripts/pyfe/pyfe/scr_environment.py
@@ -10,34 +10,39 @@ from pyfe.scr_common import scr_prefix, runproc
 
 
 class SCR_Env:
-  def __init__(self):
+  def __init__(self, prefix=None):
     # we can keep a reference to the other objects
     self.param = None
     self.launcher = None
     self.resmgr = None
+
+    # record SCR_PREFIX directory, default to scr_prefix if not specified
+    if prefix is None:
+      prefix = scr_prefix()
+    self.prefix = prefix
+
     # initialize the infos
-    self.prefix = scr_prefix()
-    self.nodes_file = scr_const.X_BINDIR + '/scr_nodes_file'
-    self.user = os.environ.get('USER')
-    self.nodes = os.environ.get('SCR_NODELIST')
+    bindir = scr_const.X_BINDIR
+    self.nodes_file = os.path.join(bindir, 'scr_nodes_file')
 
   def get_user(self):
-    return self.user
+    return os.environ.get('USER')
 
   def get_scr_nodelist(self):
-    return self.nodes
+    return os.environ.get('SCR_NODELIST')
 
-  # set the nodelist (called if the environment variable wasn't set)
-  def set_nodelist(self, nodelist):
-    self.nodes = nodelist
-    os.environ['SCR_NODELIST'] = nodelist
-
+  # return path to $SCR_PREFIX
   def get_prefix(self):
     return self.prefix
 
-  # set the prefix
-  def set_prefix(self, prefix):
-    self.prefix = prefix
+  # return path to $SCR_PREFIX/.scr
+  def dir_scr(self):
+    return os.path.join(self.prefix, '.scr')
+
+  # given a dataset id, return dataset directory within prefix
+  # ${SCR_PREFIX}/.scr/scr.dataset.<id>
+  def dir_dset(self, d):
+    return os.path.join(self.dir_scr(), 'scr.dataset.' + str(d))
 
   # list the number of nodes used in the last run
   def get_runnode_count(self):

--- a/scripts/pyfe/pyfe/scr_postrun.py
+++ b/scripts/pyfe/pyfe/scr_postrun.py
@@ -37,10 +37,11 @@ if __name__ == '__main__':
                       default=False,
                       help='Verbose output.')
   args = vars(parser.parse_args())
+
   if 'help' in args:
     parser.print_help()
   else:
-    scr_env = SCR_Env()
+    scr_env = SCR_Env(prefix=args['prefix'])
     scr_env.resmgr = AutoResourceManager()
     ret = postrun(prefix_dir=args['prefix'],
                   scr_env=scr_env,

--- a/scripts/pyfe/pyfe/scr_prerun.py
+++ b/scripts/pyfe/pyfe/scr_prerun.py
@@ -12,14 +12,14 @@ import argparse
 from datetime import datetime
 from time import time
 
-from pyfe.scr_common import tracefunction, scr_prefix
+from pyfe.scr_common import tracefunction
 from pyfe.scr_test_runtime import scr_test_runtime
+from pyfe.scr_environment import SCR_Env
 
-
-def scr_prerun(prefix=None):
+def scr_prerun(scr_env=None):
   # bail out if not enabled
   val = os.environ.get('SCR_ENABLE')
-  if val is None or val == '0':
+  if val == '0':
     return 0
 
   # enable verbosity
@@ -36,10 +36,9 @@ def scr_prerun(prefix=None):
     print('scr_prerun: exit code: 1')
     return 1
 
-  pardir = scr_prefix() if prefix is None else prefix
-
   # create the .scr subdirectory in the prefix directory
-  os.makedirs(os.path.join(pardir, '.scr'), exist_ok=True)
+  dir_scr = scr_env.dir_scr()
+  os.makedirs(dir_scr, exist_ok=True)
 
   # TODO: It would be nice to clear the cache and control directories
   # here in preparation for the run.  However, a simple rm -rf is too
@@ -53,12 +52,12 @@ def scr_prerun(prefix=None):
   # requested the job to halt
   # remove files: ${pardir}/.scr/{flush.scr,nodes.scr}
   try:
-    os.remove(os.path.join(pardir, '.scr', 'flush.scr'))
+    os.remove(os.path.join(dir_scr, 'flush.scr'))
   except:  # error on doesn't exist / etc ...
     pass
 
   try:
-    os.remove(os.path.join(pardir, '.scr', 'nodes.scr'))
+    os.remove(os.path.join(dir_scr, 'nodes.scr'))
   except:
     pass
 
@@ -88,8 +87,10 @@ if __name__ == '__main__':
                       default=None,
                       help='Specify the prefix directory.')
   args = vars(parser.parse_args())
+
   if 'help' in args:
     parser.print_help()
   else:
-    ret = scr_prerun(prefix=args['prefix'])
+    scr_env = SCR_Env(prefix=args['prefix'])
+    ret = scr_prerun(scr_env=scr_env)
     sys.exit(ret)

--- a/scripts/pyfe/pyfe/scr_run.py
+++ b/scripts/pyfe/pyfe/scr_run.py
@@ -102,11 +102,13 @@ def scr_run(launcher='',
 
   # TODO: if not in job allocation, bail out
 
-  param = SCR_Param()
-  # env contains general environment infos independent of resmgr/launcher
-  scr_env = SCR_Env()
   # get prefix directory
-  prefix = scr_env.get_prefix()
+  prefix = scr_prefix()
+
+  param = SCR_Param()
+
+  # env contains general environment infos independent of resmgr/launcher
+  scr_env = SCR_Env(prefix=prefix)
 
   # resource manager (SLURM/LSF/ ...) set by argument or compile constant
   resourcemgr = AutoResourceManager()
@@ -170,7 +172,7 @@ def scr_run(launcher='',
   log = SCRLog(prefix, jobid, user=user, jobstart=start_secs)
 
   # test runtime, ensure filepath exists,
-  if scr_prerun(prefix=prefix) != 0:
+  if scr_prerun(scr_env=scr_env) != 0:
     print(prog + ': ERROR: Command failed: scr_prerun -p ' + prefix)
     sys.exit(1)
 

--- a/scripts/pyfe/pyfe/scr_scavenge.py
+++ b/scripts/pyfe/pyfe/scr_scavenge.py
@@ -41,7 +41,7 @@ def scr_scavenge(nodeset_job=None,
   # for now just hardcode the values
 
   if scr_env is None:
-    scr_env = SCR_Env()
+    scr_env = SCR_Env(prefix=prefixdir)
   if scr_env.param is None:
     scr_env.param = SCR_Param()
   if scr_env.resmgr is None:
@@ -70,8 +70,9 @@ def scr_scavenge(nodeset_job=None,
     return 1
 
   # build the output filenames
-  output = prefixdir + '/.scr/scr.dataset.' + dataset_id + '/scr_scavenge.pdsh.o' + jobid
-  error = prefixdir + '/.scr/scr.dataset.' + dataset_id + '/scr_scavenge.pdsh.e' + jobid
+  dset_dir = scr_env.dir_dset(dataset_id)
+  output = os.path.join(dset_dir, 'scr_scavenge.pdsh.o' + jobid)
+  error = os.path.join(dset_dir, 'scr_scavenge.pdsh.e' + jobid)
 
   if verbose:
     print('scr_scavenge: nodeset_up =   ' + nodeset_up)


### PR DESCRIPTION
@chaseleif , this one defines functions in scr_env to return the path to ``$SCR_PREFIX/.scr`` and ``$SCR_PREFIX/.scr/scr.dataset.<id>``.

When creating an ``SCR_Env`` object, one should specify the prefix directory in the constructor.