### PR TITLE
Treat '=' character as legal value in SCR_Config

### DIFF
--- a/doc/rst/users/api.rst
+++ b/doc/rst/users/api.rst
@@ -122,7 +122,10 @@ and a multi-item form that consists of a parent key/value pair and set of child 
 
 To set a simple parameter,
 one specifies a parameter name and its value in the form of a :code:`key=value` string as the :code:`config` argument.
-For example, passing the string :code:`SCR_FLUSH=10` sets :code:`SCR_FLUSH` to the value of 10.
+For example, passing the string :code:`SCR_FLUSH=10` sets :code:`SCR_FLUSH` to the value of 10. The `=` character
+is allowed as part of the value if the value is a string.  For example, passing the string
+:code:`SCR_PREFIX="/my/dir/with/=/sign"` sets :code:`SCR_PREFIX` to the value of "/my/dir/with/=/sign".
+
 If one sets the same parameter with multiple calls to :code:`SCR_Config`,
 SCR applies the most recent value.
 When setting a parameter, for C applications, :code:`SCR_Config` always returns :code:`NULL`.

--- a/examples/test_config.c
+++ b/examples/test_config.c
@@ -279,6 +279,16 @@ int main (int argc, char* argv[])
   SCR_Config("DEBUG=1");
   tests_passed &= test_cfg("DEBUG", "1", __LINE__);
 
+  /* test setting SCR_CACHE_BASE from with various names */
+  tests_passed &= test_cfg("SCR_CACHE_BASE=/dev/shm/boring_name", NULL, __LINE__);
+  tests_passed &= test_cfg("SCR_CACHE_BASE", "/dev/shm/boring_name", __LINE__);
+
+  tests_passed &= test_cfg("SCR_CACHE_BASE==/dev/shm/name_contains_preceding_=", NULL, __LINE__);
+  tests_passed &= test_cfg("SCR_CACHE_BASE", "=/dev/shm/name_contains_preceding_=", __LINE__);
+
+  tests_passed &= test_cfg("SCR_CACHE_BASE= =/dev/shm/==name_contains_=_signs_everywhere", NULL, __LINE__);
+  tests_passed &= test_cfg("SCR_CACHE_BASE", "=/dev/shm/==name_contains_=_signs_everywhere", __LINE__);
+
   SCR_Config("SCR_COPY_TYPE=RS");
   if (SCR_Init() == SCR_SUCCESS) {
 

--- a/src/scr.c
+++ b/src/scr.c
@@ -2788,10 +2788,6 @@ const char* SCR_Config(const char* config_string)
           state = done;
         } else if (*conf == ' ') {
           state = before_value;
-        } else if (*conf == '=') {
-          scr_abort(-1, "Invalid configuration string '%s' @ %s:%d",
-            config_string, __FILE__, __LINE__
-          );
         } else {
           value = conf;
           if (toplevel_value == NULL) {
@@ -2813,10 +2809,6 @@ const char* SCR_Config(const char* config_string)
         } else if (*conf == ' ') {
           *conf = '\0';
           state = before_key;
-        } else if (*conf == '=') {
-          scr_abort(-1, "Invalid configuration string '%s' @ %s:%d",
-            config_string, __FILE__, __LINE__
-          );
         } else {
           state = in_value;
         }


### PR DESCRIPTION
This is to address Issue #432

**Note**: I still need to write a test for this.  But I wanted to add this draft pull request so that the changes might be reviewed/debated.

Previously, the parser in SCR_Config was treating '=' as an invalid
character within a value for a given token.  This caused calling
applications to fail when they passed in directory path names that
contained an '=' character.

This failure behavior is inconsistent because when the application uses
environment variables instead of SCR_Config, this particular character
is allowed.

The fix was to remove the check when the parser is in 'in_value' state.