### PR TITLE
fix: update python test for new config/need_checkpoint behavior

### DIFF
--- a/python/scr_example.py
+++ b/python/scr_example.py
@@ -11,6 +11,9 @@ print("SCR_DEBUG:", scr.config("SCR_DEBUG"))
 scr.config("SCR_DEBUG=1")
 print("SCR_DEBUG:", scr.config("SCR_DEBUG"))
 
+# configure scr.need_checkpoint() to return True every second time it's called
+scr.config("SCR_CHECKPOINT_INTERVAL=2")
+
 # initialize library, rebuild cached datasets, fetch latest checkpoint
 scr.init()
 

--- a/python/scr_test.py
+++ b/python/scr_test.py
@@ -17,7 +17,7 @@ timestep = 1
 # optionally set and get SCR parameters with scr.config() before scr.init()
 val = scr.config("SCR_DEBUG")
 if test == 0: assert val is None, "SCR_DEBUG should not be set on first run"
-if test > 0:  assert val == "1", "SCR_DEBUG should remember its value from earlier runs"
+if test > 0:  assert val is None, "SCR_DEBUG should assume its default value even after being changed in an earlier run"
 
 val = scr.config("SCR_DEBUG=1")
 assert val is None, "scr.config should not return a value when setting a param"
@@ -25,6 +25,9 @@ assert val is None, "scr.config should not return a value when setting a param"
 val = scr.config("SCR_DEBUG")
 assert val == "1", "SCR_DEBUG should now be 1"
 print("SCR_DEBUG:", val)
+
+# enable scr.need_checkpoint() so that it returns True
+scr.config("SCR_CHECKPOINT_INTERVAL=1")
 
 # check that scr.init can throw an exception
 if test == 5:
@@ -121,7 +124,7 @@ while timestep < laststep:
 
   # save checkpoint if needed
   rc = scr.need_checkpoint()
-  assert rc is True, "scr.need_checkpoint should return True since we're not configuring SCR to do otherwise"
+  assert rc is True, "scr.need_checkpoint should always return True since SCR_CHECKPOINT_INTERVAL=1"
   if rc:
     # define name of checkpoint to be something like "timestep_10"
     name = 'timestep_' + str(timestep)


### PR DESCRIPTION
The python test needs to be updated to match new semantics for ``scr.config`` and ``scr.need_checkpoint``.  The values set in calls to ``scr.config`` are no longer preserved between runs.  And ``scr.need_checkpoint`` now returns ``False`` unless that user has configured one of the ``SCR_CHECKPOINT_*`` settings to be active.