### PR TITLE
Adding file that names contributors to SCR project

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,26 @@
+# SCR Contributors since 2008
+
+
+* Adam Moody
+* Greg Bronevetsky
+* Bronis de Supinski
+* Kathryn Mohror
+* Tanzima Islam
+* Kento Sato
+* Sagar Thapaliya
+* Raghunath Raja Chandrasekar
+* Xiang Ni
+* Teng Wang
+* Greg Becker
+* Elsa Gonsiorowski
+* Cameron Stanavige
+* Kathleen Shoga
+* Tony Hutter
+* Greg Kosinovsky
+* Roland Haas
+* Robert Brunner
+* Greg Bauer
+* Chase Phelps
+* HB Chen
+* Olaf Faaland
+* Marty McFadden


### PR DESCRIPTION
We wanted a way to give credit to the contributors to the SCR project, some of whom may not be reflected in the GitHub history. I added this file with the names of people contributing since 2008.