### PR TITLE
move default system config file from /etc to install path

### DIFF
--- a/cmake/SCR_OPTIONS.cmake
+++ b/cmake/SCR_OPTIONS.cmake
@@ -46,9 +46,12 @@ MESSAGE(STATUS "ENABLE_IBM_BBAPI: ${ENABLE_IBM_BBAPI}")
 OPTION(ENABLE_CRAY_DW "Whether to enable Cray Datawarp support" OFF)
 MESSAGE(STATUS "ENABLE_CRAY_DW: ${ENABLE_CRAY_DW}")
 
+# define CMAKE_INSTALL_SYSCONFDIR for SCR_CONFIG_FILE path
+INCLUDE(GNUInstallDirs)
+
 SET(SCR_CACHE_BASE "/dev/shm" CACHE PATH "Default base path for SCR cache directory")
 SET(SCR_CNTL_BASE "/dev/shm" CACHE PATH "Default base path for SCR control directory")
-SET(SCR_CONFIG_FILE "/etc/scr/scr.conf" CACHE FILEPATH "Default full path and filename for SCR config file")
+SET(SCR_CONFIG_FILE ${CMAKE_INSTALL_FULL_SYSCONFDIR}/scr.conf CACHE FILEPATH "Default full path and filename for SCR config file")
 MESSAGE(STATUS "SCR_CACHE_BASE: ${SCR_CACHE_BASE}")
 MESSAGE(STATUS "SCR_CNTL_BASE: ${SCR_CNTL_BASE}")
 MESSAGE(STATUS "SCR_CONFIG_FILE: ${SCR_CONFIG_FILE}")

--- a/doc/rst/users/build.rst
+++ b/doc/rst/users/build.rst
@@ -65,7 +65,7 @@ Some common CMake command line options:
 
 * :code:`-DSCR_CNTL_BASE=[path]` : Path to SCR Control directory, defaults to :code:`/dev/shm`
 * :code:`-DSCR_CACHE_BASE=[path]` : Path to SCR Cache directory, defaults to :code:`/dev/shm`
-* :code:`-DSCR_CONFIG_FILE=[path]` : Path to SCR system configuration file, defaults to :code:`/etc/scr/scr.conf`
+* :code:`-DSCR_CONFIG_FILE=[path]` : Path to SCR system configuration file, defaults to :code:`<install>/etc/scr.conf`
 
 * :code:`-DSCR_FILE_LOCK=[FLOCK/FCNTL/NONE]` : Specify type of file locking to use, defaults to :code:`FLOCK`
 
@@ -85,17 +85,17 @@ One can disable portions of the SCR build if they are not needed:
 * :code:`-DENABLE_EXAMPLES=[ON/OFF]` : Whether to build programs in :code:`examples` directory, defaults to :code:`ON`
 * :code:`-DENABLE_TESTS=[ON/OFF]` : Whether to support :code:`make check` tests, defaults to :code:`ON`
 
-* :code:`-DENABLE_IBM_BBAPI[ON/OFF]` : Whether to enable IBM Burst Buffer support for file transfers, defaults to :code:`ON`
-* :code:`-DENABLE_CRAY_DW[ON/OFF]` : Whether to enable Cray DataWarp support for file transfers, defaults to :code:`OFF`
+* :code:`-DENABLE_IBM_BBAPI=[ON/OFF]` : Whether to enable IBM Burst Buffer support for file transfers, defaults to :code:`ON`
+* :code:`-DENABLE_CRAY_DW=[ON/OFF]` : Whether to enable Cray DataWarp support for file transfers, defaults to :code:`OFF`
 
-* :code:`-DENABLE_PDSH=[ON/OFF]` : Whether to use pdsh, defalts to :code:`ON`
-* :code:`-DBUILD_PDSH=[OFF/ON]`: CMake can automatically download and build the PDSH dependency, defaults to :code:`OFF`
+* :code:`-DENABLE_PDSH=[ON/OFF]` : Whether to use pdsh to check node health and scavenge files, defalts to :code:`ON`
+* :code:`-DBUILD_PDSH=[ON/OFF]`: CMake can automatically download and build the PDSH dependency, defaults to :code:`OFF`
 * :code:`-DWITH_PDSH_PREFIX=[path to PDSH]`: Path to an existing PDSH installation (should not be used with :code:`BUILD_PDSH`)
 
-* :code:`-DENABLE_YOGRT=[ON/OFF]` : Whether to use libyogrt, defaults to :code:`ON`
+* :code:`-DENABLE_YOGRT=[ON/OFF]` : Whether to use libyogrt for determining allocation end time, defaults to :code:`ON`
 * :code:`-DWITH_YOGRT_PREFIX:PATH=[path to libyogrt]`
 
-* :code:`-DENABLE_MYSQL=[ON/OFF]` : Whether to use MySQL, defaults to :code:`OFF`
+* :code:`-DENABLE_MYSQL=[ON/OFF]` : Whether to use MySQL for logging, defaults to :code:`OFF`
 * :code:`-DWITH_MYSQL_PREFIX=[path to MySQL]`
 
 .. _sec-build-spack:

--- a/doc/rst/users/config.rst
+++ b/doc/rst/users/config.rst
@@ -44,7 +44,7 @@ by setting the :code:`SCR_CONF_FILE` environment variable at run time, e.g.,::
   export SCR_CONF_FILE=~/myscr.conf
 
 The location of the system configuration file is hard-coded into SCR at build time.
-This defaults to :code:`/etc/scr/scr.conf`.
+This defaults to :code:`<install>/etc/scr.conf`.
 One may choose a different path using the :code:`SCR_CONFIG_FILE` CMake option, e.g.,::
 
   cmake -DSCR_CONFIG_FILE=/path/to/scr.conf ...


### PR DESCRIPTION
This moves the default path for a system config file to ``<install>/etc/scr.conf`` rather than using ``/etc/scr/scr.conf``.  Since SCR is often installed by normal users, this new location picks a default location to which they have write access rather than using a system-level directory owned by root.

This uses ``CMAKE_INSTALL_FULL_SYSCONFDIR`` from:
https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html

Resolves https://github.com/LLNL/scr/issues/463