### PR TITLE
disable bbapi by default

### DIFF
--- a/cmake/SCR_OPTIONS.cmake
+++ b/cmake/SCR_OPTIONS.cmake
@@ -40,7 +40,7 @@ ELSE()
     MESSAGE(FATAL_ERROR "SCR_RESOURCE_MANAGER: ${SCR_RESOURCE_MANAGER} is invalid, pick one of: ${RMLIST}")
 ENDIF()
 
-OPTION(ENABLE_IBM_BBAPI "Whether to enable IBM Burst Buffer support" ON)
+OPTION(ENABLE_IBM_BBAPI "Whether to enable IBM Burst Buffer support" OFF)
 MESSAGE(STATUS "ENABLE_IBM_BBAPI: ${ENABLE_IBM_BBAPI}")
 
 OPTION(ENABLE_CRAY_DW "Whether to enable Cray Datawarp support" OFF)

--- a/doc/rst/users/build.rst
+++ b/doc/rst/users/build.rst
@@ -85,7 +85,7 @@ One can disable portions of the SCR build if they are not needed:
 * :code:`-DENABLE_EXAMPLES=[ON/OFF]` : Whether to build programs in :code:`examples` directory, defaults to :code:`ON`
 * :code:`-DENABLE_TESTS=[ON/OFF]` : Whether to support :code:`make check` tests, defaults to :code:`ON`
 
-* :code:`-DENABLE_IBM_BBAPI=[ON/OFF]` : Whether to enable IBM Burst Buffer support for file transfers, defaults to :code:`ON`
+* :code:`-DENABLE_IBM_BBAPI=[ON/OFF]` : Whether to enable IBM Burst Buffer support for file transfers, defaults to :code:`OFF`
 * :code:`-DENABLE_CRAY_DW=[ON/OFF]` : Whether to enable Cray DataWarp support for file transfers, defaults to :code:`OFF`
 
 * :code:`-DENABLE_PDSH=[ON/OFF]` : Whether to use pdsh to check node health and scavenge files, defalts to :code:`ON`


### PR DESCRIPTION
This disables the IBM BBAPI by default.  To enable, one must now configure with ``-DSCR_ENABLE_BBAPI=ON``.

Some people use newer versions of boost, which are incompatible with the build of the bbapi library.  Also some users link with SCR statically, and in that case, the BBAPI library adds an extraneous dependency when not used.

Resolves https://github.com/LLNL/scr/issues/464