### PR TITLE
test_api: replace snprintf with safe_snprintf

### DIFF
--- a/examples/test_api.c
+++ b/examples/test_api.c
@@ -217,11 +217,11 @@ double getbw(char* name, char* buf, size_t size, int times)
       if (output > 0 && timestep % output == 0) {
         /* if output is enabled, mark every Nth as pure output */
         flags |= SCR_FLAG_OUTPUT;
-        sprintf(outname, "output.%d", timestep);
+        safe_snprintf(outname, sizeof(outname), "output.%d", timestep);
       } else {
         /* otherwise we have a checkpoint */
         flags |= SCR_FLAG_CHECKPOINT;
-        sprintf(outname, "ckpt.%d", timestep);
+        safe_snprintf(outname, sizeof(outname), "ckpt.%d", timestep);
       }
 
       /* if ckptout is enabled, mark every Nth write as output also */
@@ -232,9 +232,9 @@ double getbw(char* name, char* buf, size_t size, int times)
       /* compute directory path to hold output files */
       char outpath[SCR_MAX_FILENAME];
       if (path != NULL) {
-        sprintf(outpath, "%s/%s", path, outname);
+        safe_snprintf(outpath, sizeof(outpath), "%s/%s", path, outname);
       } else {
-        sprintf(outpath, "%s", outname);
+        safe_snprintf(outpath, sizeof(outpath), "%s", outname);
       }
 
       if (use_scr) {
@@ -529,7 +529,7 @@ int main (int argc, char* argv[])
 
   /* define base name for our checkpoint files */
   char name[256];
-  sprintf(name, "rank_%d.ckpt", rank);
+  safe_snprintf(name, sizeof(name), "rank_%d.ckpt", rank);
 
   /* get the name of our checkpoint file to open for read on restart */
   int scr_retval;

--- a/examples/test_common.c
+++ b/examples/test_common.c
@@ -160,9 +160,18 @@ int read_checkpoint(char* file, int* ckpt, char* buf, size_t size)
     n = reliable_read(fd, ckpt_buf, sizeof(ckpt_buf));
 
     /* read the checkpoint data, and check the file size */
-    n = reliable_read(fd, buf, size+1);
+    n = reliable_read(fd, buf, size);
     if (n != size) {
       printf("Filesize not correct. Expected %lu, got %lu\n", size, n);
+      close(fd);
+      return 0;
+    }
+
+    /* read one byte past the expected size to verify we've hit the end of the file */
+    char endbuf[1];
+    n = reliable_read(fd, endbuf, 1);
+    if (n != 0) {
+      printf("Filesize not correct. Expected %lu, got %lu\n", size, size+1);
       close(fd);
       return 0;
     }


### PR DESCRIPTION
Clean up errors reported by gcc 10.2 with ``-Wall -Werror``.