### PR TITLE
update to lwgrp-1.0.5 and dtcmp-1.1.4

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -55,15 +55,15 @@ mkdir -p install
 
 cd deps
 
-lwgrp=lwgrp-1.0.4
-dtcmp=dtcmp-1.1.3
+lwgrp=lwgrp-1.0.5
+dtcmp=dtcmp-1.1.4
 pdsh=pdsh-2.34
 
 if [ ! -f ${lwgrp}.tar.gz ] ; then
-  wget https://github.com/LLNL/lwgrp/releases/download/v1.0.4/${lwgrp}.tar.gz
+  wget https://github.com/LLNL/lwgrp/releases/download/v1.0.5/${lwgrp}.tar.gz
 fi
 if [ ! -f ${dtcmp}.tar.gz ] ; then
-  wget https://github.com/LLNL/dtcmp/releases/download/v1.1.3/${dtcmp}.tar.gz
+  wget https://github.com/LLNL/dtcmp/releases/download/v1.1.4/${dtcmp}.tar.gz
 fi
 if [ ! -f ${pdsh}.tar.gz ] ; then
   wget https://github.com/chaos/pdsh/releases/download/${pdsh}/${pdsh}.tar.gz

--- a/dist/builddist
+++ b/dist/builddist
@@ -6,7 +6,8 @@ print_usage() {
     echo "Tags:"
     echo "  develop - build tarball of latest"
 #    echo "  v3.0rc1"
-    echo "  v3.0rc2"
+#    echo "  v3.0rc2"
+    echo "  v3.0"
 }
 
 # check that we got an argument or print usage
@@ -44,11 +45,25 @@ if [ "$1" == "develop" ] ; then
 #        "rankstr"  "ecp-veloc" "v0.0.3"
 #        "scr"      "llnl"      "v3.0rc1"
 #    )
-elif [ "$1" == "v3.0rc2" ] ; then
-    # to build the scr-v3.0rc2 release
+#elif [ "$1" == "v3.0rc2" ] ; then
+#    # to build the scr-v3.0rc2 release
+#    ORGS=(
+#        "lwgrp"    "llnl"      "v1.0.4"
+#        "dtcmp"    "llnl"      "v1.1.3"
+#        "kvtree"   "ecp-veloc" "v1.2.0"
+#        "axl"      "ecp-veloc" "v0.5.0"
+#        "spath"    "ecp-veloc" "v0.1.0"
+#        "shuffile" "ecp-veloc" "v0.1.0"
+#        "redset"   "ecp-veloc" "v0.1.0"
+#        "er"       "ecp-veloc" "v0.1.0"
+#        "rankstr"  "ecp-veloc" "v0.1.0"
+#        "scr"      "llnl"      "v3.0rc2"
+#    )
+elif [ "$1" == "v3.0" ] ; then
+    # to build the scr-v3.0 release
     ORGS=(
-        "lwgrp"    "llnl"      "v1.0.4"
-        "dtcmp"    "llnl"      "v1.1.3"
+        "lwgrp"    "llnl"      "v1.0.5"
+        "dtcmp"    "llnl"      "v1.1.4"
         "kvtree"   "ecp-veloc" "v1.2.0"
         "axl"      "ecp-veloc" "v0.5.0"
         "spath"    "ecp-veloc" "v0.1.0"
@@ -56,7 +71,7 @@ elif [ "$1" == "v3.0rc2" ] ; then
         "redset"   "ecp-veloc" "v0.1.0"
         "er"       "ecp-veloc" "v0.1.0"
         "rankstr"  "ecp-veloc" "v0.1.0"
-        "scr"      "llnl"      "v3.0rc2"
+        "scr"      "llnl"      "v3.0"
     )
 else
     echo "Error: unknown tag: $1"

--- a/doc/rst/users/build.rst
+++ b/doc/rst/users/build.rst
@@ -46,9 +46,9 @@ To build SCR from a release tarball:
 
 .. code-block:: bash
 
-  wget https://github.com/LLNL/scr/releases/download/v3.0rc2/scr-v3.0rc2.tgz
-  tar -zxf scr-v3.0rc2.tgz
-  cd scr-v3.0rc2
+  wget https://github.com/LLNL/scr/releases/download/v3.0/scr-v3.0.tgz
+  tar -zxf scr-v3.0.tgz
+  cd scr-v3.0
 
   mkdir build
   cd build
@@ -202,13 +202,13 @@ For SLURM systems, SCR can be installed with:
 
 .. code-block:: bash
 
-  spack install scr@3.0rc2 resource_manager=SLURM
+  spack install scr@3.0 resource_manager=SLURM
 
 For LSF, systems, SCR can be installed with:
 
 .. code-block:: bash
 
-  spack install scr@3.0rc2 resource_manager=LSF
+  spack install scr@3.0 resource_manager=LSF
 
 The SCR Spack package provides other variants that may be useful.
 To see the full list, type:

--- a/doc/rst/users/quick.rst
+++ b/doc/rst/users/quick.rst
@@ -32,9 +32,9 @@ To download and build SCR with CMake:
 
 .. code-block:: bash
 
-  wget https://github.com/LLNL/scr/releases/download/v3.0rc2/scr-v3.0rc2.tgz
-  tar -zxf scr-v3.0rc2.tgz
-  cd scr-v3.0rc2
+  wget https://github.com/LLNL/scr/releases/download/v3.0/scr-v3.0.tgz
+  tar -zxf scr-v3.0.tgz
+  cd scr-v3.0
 
   mkdir build install
   cd build
@@ -61,7 +61,7 @@ SCR can then be installed for SLURM systems with:
 
 .. code-block:: bash
 
-  spack install scr@3.0rc2
+  spack install scr@3.0
 
 This downloads, builds, and installs SCR and its dependencies.
 


### PR DESCRIPTION
Both lwgrp and dtcmp have been updated to support builds on macOS.  Additionally, dtcmp includes fixes for a segfault and for use with Cray MPI.