### PR TITLE
move fetch from init to have_restart

### DIFF
--- a/doc/rst/users/config.rst
+++ b/doc/rst/users/config.rst
@@ -574,7 +574,7 @@ The table in this section specifies the full set of SCR configuration parameters
      - Set to 1 to delete all datasets from the prefix directory (both checkpoint and output) during :code:`SCR_Init`.
    * - :code:`SCR_CURRENT`
      - N/A
-     - Name of checkpoint to mark as current and attempt to fetch in a new run during :code:`SCR_Init`.
+     - Name of checkpoint to mark as current and attempt to load during a new run during :code:`SCR_Init`.
    * - :code:`SCR_DISTRIBUTE`
      - 1
      - Set to 0 to disable cache rebuild during :code:`SCR_Init`.
@@ -613,7 +613,7 @@ The table in this section specifies the full set of SCR configuration parameters
        Typically, one should also set :code:`SCR_FETCH=0` when enabling this option.
    * - :code:`SCR_GLOBAL_RESTART`
      - 0
-     - Set to 1 to flush checkpoints to the prefix directory during :code:`SCR_Init` and internally switch fetch to use cache bypass mode.
+     - Set to 1 to flush checkpoints to and restart from the prefix directory during :code:`SCR_Init`.
        This is needed by applications that use the SCR Restart API but require a global file system to restart,
        e.g., because multiple processes read the same file.
    * - :code:`SCR_RUNS`

--- a/doc/rst/users/manage.rst
+++ b/doc/rst/users/manage.rst
@@ -12,11 +12,11 @@ The library updates the index file as an application runs and during scavenge op
 While restarting a job, the SCR library reads the index file during :code:`SCR_Init`
 to determine which checkpoints are available.
 The library attempts to restart with the most recent checkpoint and works backwards
-until it successfully fetches a valid checkpoint.
-SCR does not fetch any checkpoint marked as "incomplete" or "failed".
+until it successfully loads a valid checkpoint.
+SCR does not restart from any checkpoint marked as "incomplete" or "failed".
 A checkpoint is marked as incomplete if it was determined to be invalid during the flush or scavenge.
 Additionally, the library marks a checkpoint as failed if it detected a problem
-during a previous fetch attempt (e.g., detected data corruption).
+during a previous restart attempt (e.g., detected data corruption).
 In this way, the library avoids invalid or problematic checkpoints.
 
 One may list or modify the contents of the index file via the :code:`scr_index` command.
@@ -43,7 +43,7 @@ providing the dataset name as an argument::
   scr_index --current ckpt.12
 
 If no dataset is marked as current,
-SCR starts with most recent checkpoint that is valid.
+SCR starts with most recent valid checkpoint.
 
 One may drop entries from the index file using the :code:`--drop` option.
 This operation does not delete the corresponding dataset files.

--- a/doc/rst/users/overview.rst
+++ b/doc/rst/users/overview.rst
@@ -322,8 +322,6 @@ By default, SCR inspects the cache for existing checkpoints when a run starts.
 It attempts to rebuild all datasets in cache,
 and then it attempts to restart the job from the most recent checkpoint.
 If a dataset fails to rebuild, SCR deletes it from cache.
-To disable restarting from cache, set the :code:`SCR_DISTRIBUTE` parameter to 0.
-When disabled, SCR deletes all files from cache and restarts from a checkpoint on the parallel file system.
 
 An example restart scenario is illustrated in Figure :ref:`sec-restart`
 in which a 4-node job using the :code:`Partner` scheme allocates 5 nodes

--- a/doc/rst/users/overview.rst
+++ b/doc/rst/users/overview.rst
@@ -394,25 +394,22 @@ latest checkpoint and any output datasets are copied to the parallel file system
 We say that these scripts scavenge those datasets.
 
 Each time an SCR job starts,
-SCR first inspects the cache and attempts to distribute files for a scalable restart
+SCR first inspects the cache and attempts to rebuild files for a scalable restart
 as discussed in :ref:`sec-restart`.
-If the cache is empty or the distribute operation fails or is disabled,
-SCR attempts to fetch a checkpoint from the prefix directory to fill the cache.
-SCR reads the index file and attempts to fetch the most recent checkpoint,
-or otherwise the checkpoint that is marked as current within the index file.
-For a given checkpoint, SCR records whether the fetch attempt succeeds or fails in the index file.
-SCR does not attempt to fetch a checkpoint that is marked as being incomplete
-nor does it attempt to fetch a checkpoint for which a previous fetch attempt has failed.
-If SCR attempts but fails to fetch a checkpoint, it prints an error and
-it will attempt to fetch the next most recent checkpoint if one is available.
+If the cache is empty or the rebuild fails,
+SCR attempts to load a checkpoint from the prefix directory.
+SCR reads the index file and attempts to load the checkpoint that is marked as current.
+If no checkpoint is designated as current, SCR attempts to load the most recent checkpoint.
+When restarting from a checkpoint, SCR records whether the restart attempt succeeds or fails in the index file.
+SCR does not attempt to load a checkpoint that is marked as being incomplete
+nor does SCR attempt to load a checkpoint for which a previous restart attempt has failed.
+If SCR attempts but fails to load a checkpoint, it prints an error and
+it will attempt to load the next most recent checkpoint if one is available.
 
+By default, SCR fetches the checkpoint into cache and applies a redundancy scheme.
 To disable the fetch operation, set the :code:`SCR_FETCH` parameter to 0.
-If an application disables the fetch feature,
-the application is responsible for reading its checkpoint directly from
-the parallel file system upon a restart.
-In this case, the application should call :code:`SCR_Current` to notify SCR
-which checkpoint it loaded.
-This enables SCR to set its internal state to maintain proper ordering in the checkpoint sequence.
+If the fetch is disabled, SCR directs the application to read its
+checkpoint files directly from the prefix directory.
 
 To withstand catastrophic failures,
 it is necessary to write checkpoints out to the parallel file system with some moderate frequency.
@@ -422,9 +419,7 @@ This frequency can be configured by setting the :code:`SCR_FLUSH` parameter.
 When this parameter is set, SCR decrements a counter with each successful checkpoint.
 When the counter hits 0, SCR writes the current checkpoint out to the file system and resets the counter
 to the value specified in :code:`SCR_FLUSH`.
-SCR preserves this counter between scalable restarts,
-and when used in conjunction with :code:`SCR_FETCH` or :code:`SCR_Current`,
-it also preserves this counter between fetch and flush operations
+SCR can preserve this counter between restarts 
 such that it is possible to maintain periodic checkpoint writes across runs.
 Set :code:`SCR_FLUSH` to 0 to disable periodic writes in SCR.
 If an application disables the periodic flush feature,

--- a/src/scr.c
+++ b/src/scr.c
@@ -3469,6 +3469,12 @@ int SCR_Have_restart(int* flag, char* name)
   /* TODO: a more proper check would be to examine the filemap, perhaps across ranks */
 
   if (! scr_have_restart) {
+    /* clear our ids which may have been set by a call to SCR_Current,
+     * we'll reset these during the search for a checkpoint below */
+    scr_dataset_id    = 0;
+    scr_checkpoint_id = 0;
+    scr_ckpt_dset_id  = 0;
+
     /* get ordered list of datasets we have in our cache */
     int ndsets;
     int* dsets;

--- a/src/scr.c
+++ b/src/scr.c
@@ -1024,6 +1024,7 @@ static int scr_get_params()
   /* whether to fetch files from the parallel file system */
   if ((value = scr_param_get("SCR_FETCH")) != NULL) {
     scr_fetch = atoi(value);
+    scr_fetch_bypass = !scr_fetch;
   }
   if (scr_my_rank_world == 0) {
     scr_dbg(1, "SCR_FETCH=%d", scr_fetch);
@@ -3528,7 +3529,7 @@ int SCR_Have_restart(int* flag, char* name)
     scr_free(&dsets);
 
     /* attempt to fetch files from parallel file system */
-    if (!found_checkpoint && scr_fetch) {
+    if (!found_checkpoint) {
       /* sets scr_dataset_id and scr_checkpoint_id upon success */
       int fetch_attempted = 0;
       int rc = scr_fetch_latest(scr_cindex, &fetch_attempted);

--- a/src/scr.c
+++ b/src/scr.c
@@ -1241,7 +1241,7 @@ static int scr_get_params()
     scr_checkpoint_seconds = atoi(value);
   }
   if (scr_my_rank_world == 0) {
-    scr_dbg(1, "SCR_CHECKPOINT_SECONDS=%d", scr_checkpoint_seconds); 
+    scr_dbg(1, "SCR_CHECKPOINT_SECONDS=%d", scr_checkpoint_seconds);
   }
 
   /* override default maximum allowed checkpointing overhead */
@@ -1575,7 +1575,7 @@ static int scr_start_output(const char* name, int flags)
     scr_dbg(1, "Starting dataset %d `%s'", scr_dataset_id, dataset_name);
 
     /* start a timer to measure just the application write time,
-     * also report the total time we spent in scr_start_output */ 
+     * also report the total time we spent in scr_start_output */
     scr_time_write_start = MPI_Wtime();
     double time_diff = scr_time_write_start - time_start;
     scr_dbg(1, "scr_start_output: %f secs", time_diff);
@@ -1713,7 +1713,7 @@ static int scr_complete_output(int valid)
   /* assume we'll succeed */
   int rc = SCR_SUCCESS;
 
-  /* capture time to mark start of complete output and 
+  /* capture time to mark start of complete output and
    * to note stop timer for measuring app write performance */
   MPI_Barrier(scr_comm_world);
   double time_start;
@@ -2510,41 +2510,6 @@ int SCR_Init()
     scr_flush_file_rebuild(scr_cindex);
   }
 
-  /* attempt to fetch files from parallel file system */
-  int fetch_attempted = 0;
-  if ((rc != SCR_SUCCESS || scr_global_restart) && scr_fetch) {
-    /* sets scr_dataset_id and scr_checkpoint_id upon success */
-    rc = scr_fetch_latest(scr_cindex, &fetch_attempted);
-    if (scr_my_rank_world == 0) {
-      scr_dbg(2, "scr_fetch_latest attempted on restart");
-    }
-  }
-
-  /* TODO: there is some risk here of cleaning the cache when we shouldn't
-   * if given a badly placed nodeset for a restart job step within an
-   * allocation with lots of spares. */
-
-  /* if the fetch fails, lets clear the cache */
-  if (rc != SCR_SUCCESS) {
-    /* clear the cache of all files */
-    scr_cache_purge(scr_cindex);
-    scr_dataset_id    = 0;
-    scr_checkpoint_id = 0;
-    scr_ckpt_dset_id  = 0;
-  }
-
-  /* both the distribute and the fetch failed */
-  if (rc != SCR_SUCCESS) {
-    /* if a fetch was attempted but failed, print a warning */
-    if (scr_my_rank_world == 0 && fetch_attempted) {
-      scr_err("Failed to fetch checkpoint set into cache. Restarting from the beginning @ %s:%d",
-        __FILE__, __LINE__
-      );
-    }
-    /* We are restarting from the trivial checkpoint (full restart) */
-    rc = SCR_SUCCESS;
-  }
-
   /* set flag depending on whether checkpoint_id is greater than 0,
    * we'll take this to mean that we have a checkpoint in cache */
   scr_have_restart = (scr_checkpoint_id > 0);
@@ -2568,7 +2533,7 @@ int SCR_Init()
   }
 
   /* all done, ready to go */
-  return rc;
+  return SCR_SUCCESS;
 }
 
 /* Close down and clean up */
@@ -3503,8 +3468,81 @@ int SCR_Have_restart(int* flag, char* name)
 
   /* TODO: a more proper check would be to examine the filemap, perhaps across ranks */
 
-  /* set flag depending on whether checkpoint_id is greater than 0,
-   * we'll take this to mean that we have a checkpoint in cache */
+  if (! scr_have_restart) {
+    /* get ordered list of datasets we have in our cache */
+    int ndsets;
+    int* dsets;
+    scr_cache_index_list_datasets(scr_cindex, &ndsets, &dsets);
+
+    int found_checkpoint = 0;
+
+    /* loop backwards through datasets looking for most recent checkpoint */
+    int idx = ndsets - 1;
+    while (idx >= 0 && scr_checkpoint_id == 0) {
+      /* get next most recent dataset */
+      int current_id = dsets[idx];
+
+      /* get dataset for this id */
+      scr_dataset* dataset = scr_dataset_new();
+      scr_cache_index_get_dataset(scr_cindex, current_id, dataset);
+
+      /* see if we have a checkpoint */
+      int is_ckpt = scr_dataset_is_ckpt(dataset);
+      if (is_ckpt) {
+        /* if we rebuild any checkpoint, return success */
+        found_checkpoint = 1;
+
+        /* if id of dataset we just rebuilt is newer,
+         * update scr_dataset_id */
+        if (current_id > scr_dataset_id) {
+          scr_dataset_id = current_id;
+        }
+
+        /* get checkpoint id for dataset */
+        int ckpt_id;
+        scr_dataset_get_ckpt(dataset, &ckpt_id);
+
+        /* if checkpoint id of dataset we just rebuilt is newer,
+         * update scr_checkpoint_id and scr_ckpt_dset_id */
+        if (ckpt_id > scr_checkpoint_id) {
+          /* got a more recent checkpoint, update our checkpoint info */
+          scr_checkpoint_id = ckpt_id;
+          scr_ckpt_dset_id = current_id;
+        }
+      }
+
+      /* release the dataset object */
+      scr_dataset_delete(&dataset);
+
+      /* move on to next most recent dataset */
+      idx--;
+    }
+
+    /* free our list of dataset ids */
+    scr_free(&dsets);
+
+    /* attempt to fetch files from parallel file system */
+    if (!found_checkpoint && scr_fetch) {
+      /* sets scr_dataset_id and scr_checkpoint_id upon success */
+      int fetch_attempted = 0;
+      int rc = scr_fetch_latest(scr_cindex, &fetch_attempted);
+
+      /* if the fetch fails, lets clear the cache */
+      if (rc != SCR_SUCCESS) {
+        /* clear the cache of all files */
+        scr_cache_purge(scr_cindex);
+        scr_dataset_id    = 0;
+        scr_checkpoint_id = 0;
+        scr_ckpt_dset_id  = 0;
+      }
+    }
+
+    /* set flag depending on whether checkpoint_id is greater than 0,
+     * we'll take this to mean that we have a checkpoint in cache */
+    scr_have_restart = (scr_checkpoint_id > 0);
+  }
+
+  /* inform caller whether we have identified a checkpoint to restart from */
   *flag = scr_have_restart;
 
   /* read dataset name from filemap */
@@ -3554,14 +3592,6 @@ int SCR_Start_restart(char* name)
   /* this is not required, but it helps ensure apps
    * are calling this as a collective */
   MPI_Barrier(scr_comm_world);
-
-  /* bail out if there is no checkpoint to restart from */
-  if (! scr_have_restart) {
-    scr_abort(-1, "SCR has no checkpoint for restart @ %s:%d",
-      __FILE__, __LINE__
-    );
-    return SCR_FAILURE;
-  }
 
   /* read dataset name from filemap */
   if (name != NULL) {
@@ -3655,70 +3685,6 @@ int SCR_Complete_restart(int valid)
     scr_dataset_id    = 0;
     scr_checkpoint_id = 0;
     scr_ckpt_dset_id  = 0;
-
-    /* get ordered list of datasets we have in our cache */
-    int ndsets;
-    int* dsets;
-    scr_cache_index_list_datasets(scr_cindex, &ndsets, &dsets);
-
-    int found_checkpoint = 0;
-
-    /* loop backwards through datasets looking for most recent checkpoint */
-    int idx = ndsets - 1;
-    while (idx >= 0 && scr_checkpoint_id == 0) {
-      /* get next most recent dataset */
-      int current_id = dsets[idx];
-
-      /* get dataset for this id */
-      scr_dataset* dataset = scr_dataset_new();
-      scr_cache_index_get_dataset(scr_cindex, current_id, dataset);
-
-      /* see if we have a checkpoint */
-      int is_ckpt = scr_dataset_is_ckpt(dataset);
-      if (is_ckpt) {
-        /* if we rebuild any checkpoint, return success */
-        found_checkpoint = 1;
-
-        /* if id of dataset we just rebuilt is newer,
-         * update scr_dataset_id */
-        if (current_id > scr_dataset_id) {
-          scr_dataset_id = current_id;
-        }
-
-        /* get checkpoint id for dataset */
-        int ckpt_id;
-        scr_dataset_get_ckpt(dataset, &ckpt_id);
-
-        /* if checkpoint id of dataset we just rebuilt is newer,
-         * update scr_checkpoint_id and scr_ckpt_dset_id */
-        if (ckpt_id > scr_checkpoint_id) {
-          /* got a more recent checkpoint, update our checkpoint info */
-          scr_checkpoint_id = ckpt_id;
-          scr_ckpt_dset_id = current_id;
-        }
-      }
-
-      /* release the dataset object */
-      scr_dataset_delete(&dataset);
-
-      /* move on to next most recent dataset */
-      idx--;
-    }
-
-    /* free our list of dataset ids */
-    scr_free(&dsets);
-
-    /* if we still don't have a checkpoint and fetch is enabled,
-     * attempt to fetch files from parallel file system */
-    if (!found_checkpoint && scr_fetch) {
-      /* sets scr_dataset_id and scr_checkpoint_id upon success */
-      int fetch_attempted = 0;
-      scr_fetch_latest(scr_cindex, &fetch_attempted);
-    }
-
-    /* set flag depending on whether checkpoint_id is greater than 0,
-     * we'll take this to mean that we have a checkpoint in cache */
-    scr_have_restart = (scr_checkpoint_id > 0);
   }
 
   return rc;
@@ -3885,8 +3851,8 @@ int SCR_Current(const char* name)
     /* free list of dataset ids */
     scr_free(&dsets);
 
-    /* we don't want to support a restart from this since it is not
-     * loaded, we just allow the user to initialize the counters */
+    /* forget about any loaded checkpoint in case the
+     * user intends to skip calling the restart API */
     scr_have_restart = 0;
   }
 


### PR DESCRIPTION
This moves the fetch operation from ``SCR_Init`` to ``SCR_Have_restart``.  Datasets are still rebuilt during ``SCR_Init``, and flushed if ``SCR_GLOBAL_RESTART`` is set.

This allows a user to specify the checkpoint that SCR should load by calling ``SCR_Current`` before ``SCR_Have_restart``.  Currently, one must specify the checkpoint name before calling ``SCR_Init``, but some applications would prefer to call ``SCR_Init`` before they have identified the name of the checkpoint they want to load.  In particular, for applications that scan the parallel file system for checkpoints, this enables SCR to rebuild and flush any cached checkpoints during ``SCR_Init`` to make those checkpoints visible to the scan.  The application can then call ``SCR_Current`` to provide the name and before calling ``SCR_Have_restart``.

Resolves https://github.com/LLNL/scr/issues/475

This PR also enables a user to call the Restart API after having written a dataset with the Output API.  This is useful for some applications that test checkpoint/restart by writing a checkpoint and then immediately reading it back to restart.

Resolves https://github.com/LLNL/scr/issues/392

This PR also modifies the behavior of ``SCR_FETCH=0``.  The previous behavior disabled SCR from loading a checkpoint from the prefix directory.  Now this setting causes SCR to switch into bypass mode during restart so that ``SCR_Route_file`` directs the application to read its files directly from the prefix directory.