### PR TITLE
Branch for update SCR Config default setup value

### DIFF
--- a/src/scr_conf.h
+++ b/src/scr_conf.h
@@ -144,12 +144,12 @@
 /* buffer size to use for MPI send / recv operations */
 #ifndef SCR_MPI_BUF_SIZE
 /* #define SCR_MPI_BUF_SIZE (1*1024*1024) */
-#define SCR_MPI_BUF_SIZE (128*1024)  /* very strange that this lower number beats the upper one, but whatever ... */
+#define SCR_MPI_BUF_SIZE (1024*1024)  /* very strange that this lower number beats the upper one, but whatever ... */
 #endif
 
 /* buffer size to use for file I/O operations */
 #ifndef SCR_FILE_BUF_SIZE
-#define SCR_FILE_BUF_SIZE (1024*1024)
+#define SCR_FILE_BUF_SIZE (1024*1024*32)
 #endif
 
 /* whether file metadata should also be copied */

--- a/src/scr_conf.h
+++ b/src/scr_conf.h
@@ -143,8 +143,7 @@
 
 /* buffer size to use for MPI send / recv operations */
 #ifndef SCR_MPI_BUF_SIZE
-/* #define SCR_MPI_BUF_SIZE (1*1024*1024) */
-#define SCR_MPI_BUF_SIZE (1024*1024)  /* very strange that this lower number beats the upper one, but whatever ... */
+#define SCR_MPI_BUF_SIZE (1024*1024)
 #endif
 
 /* buffer size to use for file I/O operations */


### PR DESCRIPTION
Update  scr_conf.h 
Use new values for buffer size used on MPI and FILE IO

 /* =========================================================================
 * Default buffer sizes for MPI and file I/O operations.
 * ========================================================================= */

/* buffer size to use for MPI send / recv operations */
#ifndef SCR_MPI_BUF_SIZE
/* #define SCR_MPI_BUF_SIZE (1*1024*1024) */
/* change from 128KB to 1MB */ 
#define SCR_MPI_BUF_SIZE (1024*1024)  /* very strange that this lower number beats the upper one, but whatever ... */
#endif

/* buffer size to use for file I/O operations */
/* change from 1MB tp 32MB */
#ifndef SCR_FILE_BUF_SIZE
#define SCR_FILE_BUF_SIZE (1024*1024*32)
#endif
