### PR TITLE
Add shared file testing to test_api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ scr.user.conf
 *.o
 *.lo
 *.la
+*.swp
 
 src/Makefile
 src/scr_copy

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -51,6 +51,10 @@ ADD_EXECUTABLE(test_api test_common.c test_api.c)
 TARGET_LINK_LIBRARIES(test_api ${SCR_LINK_TO})
 SCR_ADD_TEST(test_api "" "ckpt.*")
 
+ADD_EXECUTABLE(test_api_shared_file test_common.c test_api.c)
+TARGET_LINK_LIBRARIES(test_api_shared_file ${SCR_LINK_TO})
+SCR_ADD_TEST(test_api_shared_file "--shared" "ckpt.*")
+
 ADD_EXECUTABLE(test_config test_config.c)
 TARGET_LINK_LIBRARIES(test_config ${SCR_LINK_TO})
 SCR_ADD_TEST(test_config "" "test_config.d")

--- a/examples/test_api.c
+++ b/examples/test_api.c
@@ -470,7 +470,9 @@ int restart_scr(char* name, char* buf, size_t filesize)
     if (rank == 0) {
       printf("At least one rank (perhaps all) did not find its checkpoint\n");
     }
+    return -1;
   }
+  return 0;
 }
 
 int restart(char* dset, char* name, char* buf, size_t filesize)
@@ -515,7 +517,9 @@ int restart(char* dset, char* name, char* buf, size_t filesize)
     if (rank == 0) {
       printf("At least one rank (perhaps all) did not find its checkpoint\n");
     }
+    return -1;
   }
+  return 0;
 }
 
 void print_usage()

--- a/examples/test_api.c
+++ b/examples/test_api.c
@@ -209,7 +209,7 @@ int create_file(char* file)
 
   if (use_shared_file) {
     if (rank == 0) {
-      if ( (fd = open(file, O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR)) > 0) {
+      if ( (fd = open(file, O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR)) >= 0) {
         if (truncate(file, total_filesize) < 0) {
           printf("%d: Could not truncate file %s : %s\n", rank, file, strerror(errno));
           close(fd);
@@ -220,14 +220,14 @@ int create_file(char* file)
         printf("%d: Could not create file %s : %s\n", rank, file, strerror(errno));
       }
 
-      if (fd > 0) {
+      if (fd >= 0) {
         close(fd);
       };
     }
 
     MPI_Bcast(&fd, 1, MPI_INT, 0, MPI_COMM_WORLD); /* Wait for rank 0 to complete creation */
 
-    if (fd > 0) {
+    if (fd >= 0) {
       if ((fd = open(file, O_WRONLY)) < 0) {
         printf("%d: Could not open file %s : %s\n", rank, file, strerror(errno));
       }
@@ -331,7 +331,7 @@ double getbw(char* name, char* buf, int times)
       int my_fd = create_file(file);
 
       /* write the checkpoint and close */
-      if (my_fd > 0) {
+      if (my_fd >= 0) {
         count++;
         valid = 1;
 

--- a/examples/test_api.c
+++ b/examples/test_api.c
@@ -192,8 +192,8 @@ int test_abtoull(char* str, unsigned long long* val)
 
 size_t get_my_shared_file_offset()
 {
-  size_t file_offset;
-  size_t send_buf;
+  uint64_t file_offset;
+  uint64_t send_buf;
 
   if (rank == 0) {
     send_buf = total_filesize % ranks;

--- a/examples/test_api.c
+++ b/examples/test_api.c
@@ -195,17 +195,9 @@ size_t get_my_file_offset()
   uint64_t file_offset = 0;
 
   if (use_shared_file) {
-    uint64_t send_buf;
-
-    if (rank == 0) {
-      send_buf = 0;
-    }
-    else {
-      send_buf = my_filesize;
-    }
-
-    int count = 1;
-    MPI_Scan(&send_buf, &file_offset, count, MPI_UINT64_T, MPI_SUM, MPI_COMM_WORLD);
+    uint64_t send_buf = my_filesize;
+    MPI_Scan(&send_buf, &file_offset, 1, MPI_UINT64_T, MPI_SUM, MPI_COMM_WORLD);
+    file_offset -= my_filesize;
   }
 
   return file_offset;

--- a/examples/test_common.c
+++ b/examples/test_common.c
@@ -150,32 +150,6 @@ int write_checkpoint(int fd, int ckpt, char* buf, size_t size)
   return 1;
 }
 
-/* write the checkpoint data to shared fd, and return whether the write was successful */
-int write_shared_checkpoint(int fd, int ckpt, char* buf, size_t size, size_t offset)
-{
-  ssize_t rc;
-  int rank;
-
-  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-
-  if (lseek(fd, offset, SEEK_SET) < 0) {
-      printf("%d: Failed to seek to 0x%08lx in file\n", rank, offset);
-      return 0;
-  }
-
-  /* write the checkpoint id (application timestep) */
-  checkpoint_buf_t ckpt_buf;
-  sprintf(ckpt_buf.buf, "%06d", ckpt);
-  rc = reliable_write(fd, ckpt_buf.buf, sizeof(ckpt_buf));
-  if (rc < 0) return 0;
-
-  /* write the checkpoint data */
-  rc = reliable_write(fd, buf, size);
-  if (rc < 0) return 0;
-
-  return 1;
-}
-
 ssize_t checkpoint_timestep_size()
 {
   return sizeof(checkpoint_buf_t);

--- a/examples/test_common.c
+++ b/examples/test_common.c
@@ -11,6 +11,8 @@
 #include <stdarg.h>
 #include "mpi.h"
 
+typedef struct checkpoint_buf_t { char buf[7]; } checkpoint_buf_t;
+
 /* reliable read from file descriptor (retries, if necessary, until hard error) */
 ssize_t reliable_read(int fd, void* buf, size_t size)
 {
@@ -136,9 +138,9 @@ int write_checkpoint(int fd, int ckpt, char* buf, size_t size)
   ssize_t rc;
 
   /* write the checkpoint id (application timestep) */
-  char ckpt_buf[7];
-  sprintf(ckpt_buf, "%06d", ckpt);
-  rc = reliable_write(fd, ckpt_buf, sizeof(ckpt_buf));
+  checkpoint_buf_t ckpt_buf;
+  sprintf(ckpt_buf.buf, "%06d", ckpt);
+  rc = reliable_write(fd, ckpt_buf.buf, sizeof(ckpt_buf));
   if (rc < 0) return 0;
 
   /* write the checkpoint data */
@@ -148,16 +150,47 @@ int write_checkpoint(int fd, int ckpt, char* buf, size_t size)
   return 1;
 }
 
+/* write the checkpoint data to shared fd, and return whether the write was successful */
+int write_shared_checkpoint(int fd, int ckpt, char* buf, size_t size, size_t offset)
+{
+  ssize_t rc;
+  int rank;
+
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+  if (lseek(fd, offset, SEEK_SET) < 0) {
+      printf("%d: Failed to seek to 0x%08lx in file\n", rank, offset);
+      return 0;
+  }
+
+  /* write the checkpoint id (application timestep) */
+  checkpoint_buf_t ckpt_buf;
+  sprintf(ckpt_buf.buf, "%06d", ckpt);
+  rc = reliable_write(fd, ckpt_buf.buf, sizeof(ckpt_buf));
+  if (rc < 0) return 0;
+
+  /* write the checkpoint data */
+  rc = reliable_write(fd, buf, size);
+  if (rc < 0) return 0;
+
+  return 1;
+}
+
+ssize_t checkpoint_timestep_size()
+{
+  return sizeof(checkpoint_buf_t);
+}
+
 /* read the checkpoint data from file into buf, and return whether the read was successful */
 int read_checkpoint(char* file, int* ckpt, char* buf, size_t size)
 {
   ssize_t n;
-  char ckpt_buf[7];
+  checkpoint_buf_t ckpt_buf;
 
   int fd = open(file, O_RDONLY);
   if (fd > 0) {
     /* read the checkpoint id */
-    n = reliable_read(fd, ckpt_buf, sizeof(ckpt_buf));
+    n = reliable_read(fd, ckpt_buf.buf, sizeof(ckpt_buf));
 
     /* read the checkpoint data, and check the file size */
     n = reliable_read(fd, buf, size);
@@ -177,7 +210,62 @@ int read_checkpoint(char* file, int* ckpt, char* buf, size_t size)
     }
 
     /* if the file looks good, set the timestep and return */
-    (*ckpt) = atoi(ckpt_buf);
+    (*ckpt) = atoi(ckpt_buf.buf);
+
+    close(fd);
+
+    return 1;
+  }
+  else {
+  	printf("Could not open file %s\n", file);
+  }
+
+  return 0;
+}
+
+/* read the checkpoint data from shared file into buf, and return whether the read was successful */
+int read_shared_checkpoint(char* file, int* ckpt, char* buf, size_t size, size_t offset)
+{
+  ssize_t n;
+  checkpoint_buf_t ckpt_buf;
+  int rank;
+  int ranks;
+
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  MPI_Comm_size(MPI_COMM_WORLD, &ranks);
+
+  int fd = open(file, O_RDONLY);
+  if (fd > 0) {
+    if (lseek(fd, offset, SEEK_SET) < 0) {
+        printf("%d: Failed to seek to 0x%08lx in file %s for reading\n", rank, offset, file);
+        close(fd);
+        return 0;
+    }
+
+    /* read the checkpoint id */
+    n = reliable_read(fd, ckpt_buf.buf, sizeof(ckpt_buf));
+
+    /* read the checkpoint data, and check the file size */
+    n = reliable_read(fd, buf, size);
+    if (n != size) {
+      printf("Filesize not correct. Expected %lu, got %lu\n", size, n);
+      close(fd);
+      return 0;
+    }
+
+    /* read one byte past the expected size to verify we've hit the end of the file */
+    if (rank == ranks-1) {
+      char endbuf[1];
+      n = reliable_read(fd, endbuf, sizeof(endbuf));
+      if (n != 0) {
+        printf("Filesize not correct. Expected %lu, got %lu\n", size, size+n);
+        close(fd);
+        return 0;
+      }
+    }
+
+    /* if the file looks good, set the timestep and return */
+    (*ckpt) = atoi(ckpt_buf.buf);
 
     close(fd);
 

--- a/examples/test_common.h
+++ b/examples/test_common.h
@@ -15,8 +15,17 @@ int check_buffer(char* buf, size_t size, int rank, int ckpt);
 /* write the checkpoint data to fd, and return whether the write was successful */
 int write_checkpoint(int fd, int ckpt, char* buf, size_t size);
 
+/* write the checkpoint data to shared fd, and return whether the write was successful */
+int write_shared_checkpoint(int fd, int ckpt, char* buf, size_t size, size_t offset);
+
 /* read the checkpoint data from file into buf, and return whether the read was successful */
 int read_checkpoint(char* file, int* ckpt, char* buf, size_t size);
 
+/* read the checkpoint data from shared file into buf, and return whether the read was successful */
+int read_shared_checkpoint(char* file, int* ckpt, char* buf, size_t size, size_t offset);
+
 /* check for truncation on snprintf */
 int safe_snprintf(char* buf, size_t size, const char* fmt, ...);
+
+/* return size of buffer used to store checkpoint timestep */
+ssize_t checkpoint_timestep_size();

--- a/examples/test_common.h
+++ b/examples/test_common.h
@@ -15,9 +15,6 @@ int check_buffer(char* buf, size_t size, int rank, int ckpt);
 /* write the checkpoint data to fd, and return whether the write was successful */
 int write_checkpoint(int fd, int ckpt, char* buf, size_t size);
 
-/* write the checkpoint data to shared fd, and return whether the write was successful */
-int write_shared_checkpoint(int fd, int ckpt, char* buf, size_t size, size_t offset);
-
 /* read the checkpoint data from file into buf, and return whether the read was successful */
 int read_checkpoint(char* file, int* ckpt, char* buf, size_t size);
 


### PR DESCRIPTION
A new option (--shared-file) was added to test_api that will cause all of the participating ranks to share the same file with each process using a unique section of the file for its I/O operations.