### PR TITLE
Shared files in global cache

### DIFF
--- a/examples/test_api.c
+++ b/examples/test_api.c
@@ -721,9 +721,9 @@ int main (int argc, char* argv[])
       SCR_Config("SCR_DEBUG=1");
     }
 
-    if (use_shared_file) {
-      SCR_Config("SCR_CACHE_BYPASS=1");
-    }
+    // For a global cache, one must define a STORE descriptor
+    // and declare the path to have WORLD access, e.g.,
+    //   SCR_Config("STORE=/p/lustre1/$USER/scrcache GROUP=WORLD");
 
     if (SCR_Init() != SCR_SUCCESS){
       printf("Failed initializing SCR\n");

--- a/examples/test_common.c
+++ b/examples/test_common.c
@@ -133,7 +133,7 @@ int check_buffer(char* buf, size_t size, int rank, int ckpt)
 }
 
 /* get size of specified file */
-unsigned long get_filesize(char* file)
+unsigned long get_filesize(const char* file)
 {
   /* stat the file to get its size and other metadata */
   unsigned long filesize = 0;

--- a/examples/test_common.h
+++ b/examples/test_common.h
@@ -13,7 +13,7 @@ int init_buffer(char* buf, size_t size, int rank, int ckpt);
 int check_buffer(char* buf, size_t size, int rank, int ckpt);
 
 /* get size of specified file */
-unsigned long get_filesize(char* file);
+unsigned long get_filesize(const char* file);
 
 /* return size of buffer used to store checkpoint timestep */
 ssize_t checkpoint_timestep_size();

--- a/src/scr.c
+++ b/src/scr.c
@@ -1654,11 +1654,13 @@ static int scr_assign_ownership(scr_filemap* map, int bypass)
    * for which we are not rank 0 */
   int multiple_owner = 0;
   for (i = 0; i < count; i++) {
+#if 0
     /* check whether this file exists on multiple ranks */
     if (group_ranks[i] > 1) {
       /* found the same file on more than one rank */
       multiple_owner = 1;
 
+      // TODO: must be in bypass of use a cache location with WORLD access
       /* print error if we're not in bypass */
       if (! bypass) {
         scr_err("Multiple procs registered file while not in bypass mode: `%s' @ %s:%d",
@@ -1666,6 +1668,7 @@ static int scr_assign_ownership(scr_filemap* map, int bypass)
         );
       }
     }
+#endif
 
     /* only keep entry for this file in filemap if we're the
      * first rank in the set of ranks that have this file */
@@ -1674,6 +1677,8 @@ static int scr_assign_ownership(scr_filemap* map, int bypass)
     }
   }
 
+  // TODO: must be in bypass of use a cache location with WORLD access
+#if 0
   /* fatal error if any file is on more than one rank and not in bypass */
   int any_multiple_owner = 0;
   MPI_Allreduce(&multiple_owner, &any_multiple_owner, 1, MPI_INT, MPI_LOR, scr_comm_world);
@@ -1682,6 +1687,7 @@ static int scr_assign_ownership(scr_filemap* map, int bypass)
       __FILE__, __LINE__
     );
   }
+#endif
 
   /* free dtcmp buffers */
   scr_free(&group_id);

--- a/src/scr_reddesc.c
+++ b/src/scr_reddesc.c
@@ -329,6 +329,22 @@ int scr_reddesc_create_from_hash(
     d->copy_type = SCR_COPY_SINGLE;
   }
 
+  // TODO: want to do this?
+  /* CONVENIENCE: if writing to a cache location having WORLD access, change
+   * type to SINGLE */
+  const scr_storedesc* storedesc = scr_reddesc_get_store(d);
+  if (storedesc != NULL && storedesc->ranks == scr_ranks_world) {
+    if (scr_my_rank_world == 0) {
+      if (d->copy_type != SCR_COPY_SINGLE) {
+        /* print a warning if we changed things on the user */
+        scr_dbg(1, "Forcing copy type to SINGLE in redundancy descriptor %d @ %s:%d",
+          d->index, __FILE__, __LINE__
+        );
+      }
+    }
+    d->copy_type = SCR_COPY_SINGLE;
+  }
+
   /* ER uses XOR internally when set_failures == 1, so warn user if they also selected RS */
   if (set_failures == 1 && d->copy_type == SCR_COPY_RS) {
     if (scr_my_rank_world == 0) {


### PR DESCRIPTION
This enables one to define a ``STORE`` with ``GROUP=WORLD`` to use a global file system for cache.  Several large issues must be resolved, but this provides enough to run jobs for testing those other work items.

As an example, one can do the following:

First define a WORLD-enabled STORE descriptor.  This can be done via an SCR config file or through an SCR_Config API call within the application, e.g.,
```
SCR_Config("STORE=/p/lustre/$USER/scrcache GROUP=WORLD");
```
Then at run time, enable cache and point to the STORE location to be used as cache.
```
export SCR_CACHE_BYPASS=0
export SCR_CACHE_BASE=/p/lustre/$USER/scrcache
```
A new ``--global-store`` option in ``test_api`` can be used to specify a directory path.  If provided, ``test_api`` internally calls ``SCR_Config`` to configure that path to be a global store.  One can then run test_api and write a shared file to cache.  So the full usage looks something like:
```
export SCR_CACHE_BYPASS=0
export SCR_CACHE_BASE=/p/lustre/$USER/scrcache
srun -n4 -N4 ./test_api --shared-file --global-store $SCR_CACHE_BASE
```