### PR TITLE
test_api: usage output missing some newlines

### DIFF
--- a/examples/test_api.c
+++ b/examples/test_api.c
@@ -605,8 +605,8 @@ void print_usage()
   printf("        --nofsync        Disable fsync after writing files\n");
   printf("        --noscr          Disable SCR calls\n");
   printf("        --noscrrestart   Disable SCR restart calls\n");
-  printf("        --shared-file    Use single shared file instead of file per rank");
-  printf("        --global-store=<DIR> Specify DIR as a global storage location for cache");
+  printf("        --shared-file    Use single shared file instead of file per rank\n");
+  printf("        --global-store=<DIR> Specify DIR as a global storage location for cache\n");
   printf("    -h, --help           Print usage\n");
   printf("\n");
   return;


### PR DESCRIPTION
Add newlines to the end of two lines of the usage message.

```
  Usage: test_api [options]

  Options:
    -s, --size=<SIZE>    Rank checkpoint size in bytes, e.g., 1MB (default 524288)
    -t, --times=<COUNT>  Number of iterations (default 5)
    -z, --seconds=<SECS> Sleep for SECS seconds between iterations (default 0)
    -p, --path=<DIR>     Directory to create and write files to
    -f, --flush=<COUNT>  Mark every Nth write as checkpoint+output (default 0)
    -o, --output=<COUNT> Mark every Nth write as pure output (default 0)
    -a, --config-api=<BOOL> Use SCR_Config to set values (default no)
    -c, --conf-file=<BOOL>  Use SCR_CONF_FILE file to set values (default yes)
        --current=<CKPT> Specify checkpoint name to load on restart
        --nofsync        Disable fsync after writing files
        --noscr          Disable SCR calls
        --noscrrestart   Disable SCR restart calls
        --shared-file    Use single shared file instead of file per rank        --global-store=<DIR> Specify DIR as a global storage location for cache    -h, --help           Print usage
```