### PR TITLE
SCR_ADD_TEST: prepare to add python script support

### DIFF
--- a/cmake/SCR_ADD_TEST.cmake
+++ b/cmake/SCR_ADD_TEST.cmake
@@ -1,35 +1,30 @@
-FUNCTION(SCR_ADD_TEST name args outputs)
-
-    # Single process tests
-    SET(s_nodes "1")
+FUNCTION(SCR_LAUNCHER_PARMS procs)
     IF(${SCR_RESOURCE_MANAGER} STREQUAL "NONE")
-        SET(test_param "mpirun -np ${s_nodes}")
+        SET(test_launcher "mpirun" PARENT_SCOPE)
+        SET(test_param "-np ${procs}" PARENT_SCOPE)
     ELSEIF(${SCR_RESOURCE_MANAGER} STREQUAL "SLURM")
-        SET(test_param "srun -t 5 -N ${s_nodes}") 
+        SET(test_launcher "srun" PARENT_SCOPE)
+        SET(test_param "-t 5 -N ${procs} -n ${procs}" PARENT_SCOPE)
     ELSEIF(${SCR_RESOURCE_MANAGER} STREQUAL "LSF")
-        SET(test_param "jsrun --nrs ${s_nodes} -r 1") 
+        SET(test_launcher "jsrun" PARENT_SCOPE)
+        SET(test_param "--nrs ${procs} -r 1" PARENT_SCOPE)
     ENDIF(${SCR_RESOURCE_MANAGER} STREQUAL "NONE")
+ENDFUNCTION(SCR_LAUNCHER_PARMS procs)
 
-    ADD_TEST(NAME serial_${name}_restart COMMAND run_test.sh ${test_param} ./${name} restart ${args})
-
+FUNCTION(SCR_LAUNCHER_JOBID testname)
     IF(${SCR_RESOURCE_MANAGER} STREQUAL "NONE")
-        SET_PROPERTY(TEST serial_${name}_restart APPEND PROPERTY ENVIRONMENT "SCR_JOB_ID=439")
+        SET_PROPERTY(TEST ${testname} APPEND PROPERTY ENVIRONMENT "SCR_JOB_ID=439")
     ENDIF(${SCR_RESOURCE_MANAGER} STREQUAL "NONE")
+ENDFUNCTION(SCR_LAUNCHER_JOBID name)
+
+FUNCTION(SCR_ADD_TEST name args outputs)
+    # Single process tests
+    SCR_LAUNCHER_PARMS(1)
+    ADD_TEST(NAME serial_${name}_restart COMMAND run_test.sh ${test_launcher} ${test_param} ./${name} restart ${args})
+    SCR_LAUNCHER_JOBID("serial_${name}_restart")
 
     # Multi-process, multi-node tests
-    SET(p_nodes "4")
-    IF(${SCR_RESOURCE_MANAGER} STREQUAL "NONE")
-        SET(test_param "mpirun -np ${p_nodes}")
-    ELSEIF(${SCR_RESOURCE_MANAGER} STREQUAL "SLURM")
-        SET(test_param "srun -t 5 -N ${p_nodes} -n ${p_nodes}")
-    ELSEIF(${SCR_RESOURCE_MANAGER} STREQUAL "LSF")
-        SET(test_param "jsrun --nrs ${p_nodes} -r 1")
-    ENDIF(${SCR_RESOURCE_MANAGER} STREQUAL "NONE")
-
-    ADD_TEST(NAME parallel_${name}_restart COMMAND run_test.sh ${test_param} ./${name} restart ${args})
-
-    IF(${SCR_RESOURCE_MANAGER} STREQUAL "NONE")
-        SET_PROPERTY(TEST parallel_${name}_restart APPEND PROPERTY ENVIRONMENT "SCR_JOB_ID=439")
-    ENDIF(${SCR_RESOURCE_MANAGER} STREQUAL "NONE")
-
+    SCR_LAUNCHER_PARMS(4)
+    ADD_TEST(NAME parallel_${name}_restart COMMAND run_test.sh ${test_launcher} ${test_param} ./${name} restart ${args})
+    SCR_LAUNCHER_JOBID("parallel_${name}_restart")
 ENDFUNCTION(SCR_ADD_TEST name args outputs)

--- a/examples/run_test.sh
+++ b/examples/run_test.sh
@@ -6,6 +6,11 @@ if [  "$1" != "" ]; then
 fi
 
 if [  "$1" != "" ]; then
+    launch_args=$1
+    shift
+fi
+
+if [  "$1" != "" ]; then
     test=$1
     shift
 fi
@@ -15,14 +20,14 @@ if [ "$1" != "" ]; then
     shift
 fi
 
-echo "Run: $launch $test $@"
-$launch $test "$@"
+echo "Run: $launch $launch_args $test $@"
+$launch $launch_args $test "$@"
 RC=$?
 
 # only attempt a restart if requested and if first run succeeded
 if [ "$restart" = "restart" -a $RC -eq 0 ]; then
-    echo "Restart: $launch $test $@"
-    $launch $test "$@"
+    echo "Restart: $launch $launch_args $test $@"
+    $launch $launch_args $test "$@"
     RC=$?
 fi
 


### PR DESCRIPTION
The python script launcher, scr_run.py, needs the launcher (e.g. "srun") to be specified separately from the arguments for the launcher, (e.g. -N5 indicating 5 nodes).

Refactor SCR_ADD_TEST to prepare for calling tests under the python scripts in addition to the existing scripts.

Clean up some redundant code by specifying -n 1 to slurm where process/node count==1.  This and allows the srun arguments to be uniform regardless of process count, without changing srun's behavior.