### PR TITLE
scr_common.py: Add choose_bindir() to use build binaries

### DIFF
--- a/scripts/python/scrjob/cli/scr_flush_file.py
+++ b/scripts/python/scrjob/cli/scr_flush_file.py
@@ -4,11 +4,12 @@ import os
 
 from scrjob import scr_const
 from scrjob.scr_common import runproc
+from scrjob.scr_common import choose_bindir
 
 
 class SCRFlushFile:
   def __init__(self, prefix, verbose=False):
-    self.bindir = scr_const.X_BINDIR  # path to SCR bin directory
+    self.bindir = choose_bindir()
     self.prefix = prefix  # path to SCR_PREFIX
     self.verbose = verbose
     self.exe = os.path.join(self.bindir, "scr_flush_file") + " --dir " + str(prefix)

--- a/scripts/python/scrjob/cli/scr_index.py
+++ b/scripts/python/scrjob/cli/scr_index.py
@@ -4,11 +4,12 @@ import os
 
 from scrjob import scr_const
 from scrjob.scr_common import runproc
+from scrjob.scr_common import choose_bindir
 
 
 class SCRIndex:
   def __init__(self, prefix, verbose=False):
-    self.bindir = scr_const.X_BINDIR  # path to SCR bin directory
+    self.bindir = choose_bindir()
     self.prefix = prefix  # path to SCR_PREFIX
     self.verbose = verbose
     self.exe = os.path.join(self.bindir, "scr_index") + " --prefix " + str(prefix)

--- a/scripts/python/scrjob/cli/scr_log.py
+++ b/scripts/python/scrjob/cli/scr_log.py
@@ -4,12 +4,12 @@ import os
 
 from scrjob import scr_const
 from scrjob.scr_common import runproc
+from scrjob.scr_common import choose_bindir
 
 
 class SCRLog:
   def __init__(self, prefix, jobid, jobname=None, user=None, jobstart=None, verbose=False):
-    self.bindir = scr_const.X_BINDIR  # path to SCR bin directory
-
+    self.bindir = choose_bindir()
     self.prefix = prefix  # path to SCR_PREFIX
     self.user = user
     self.jobid = jobid

--- a/scripts/python/scrjob/scr_common.py
+++ b/scripts/python/scrjob/scr_common.py
@@ -243,6 +243,26 @@ def pipeproc(argvs, wait=True, getstdout=False, getstderr=False):
     return None, 1
 
 
+def choose_bindir():
+  """Determine appropriate location of binaries.
+
+  Testing using "make test" or "make check" must operate based on the contents
+  of the build directory.
+
+  If the script is being run from the install directory, then return X_BINDIR
+  as defined by cmake so installed scripts use installed binaries.  Otherwise,
+  determine the appropriate build directory.
+  """
+  # Needed to find binaries in build dir when testing
+  parent_of_this_module = '/'.join(os.path.realpath(__file__).split('/')[:-1])
+  if scr_const.X_BINDIR in parent_of_this_module:
+      bindir = scr_const.X_BINDIR  # path to install bin directory
+  else:
+      bindir = os.path.join(scr_const.CMAKE_BINARY_DIR + "/src/")
+
+  return bindir
+
+
 def log(bindir=None,
         prefix=None,
         username=None,

--- a/scripts/python/scrjob/scr_const.py.in
+++ b/scripts/python/scrjob/scr_const.py.in
@@ -10,6 +10,7 @@ SCR_CNTL_BASE = '@SCR_CNTL_BASE@'
 SCR_CACHE_BASE = '@SCR_CACHE_BASE@'
 SCR_CACHE_SIZE = '1'  # '@SCR_CACHE_SIZE@'
 SCR_CONFIG_FILE = '@SCR_CONFIG_FILE@'
+CMAKE_BINARY_DIR = '@CMAKE_BINARY_DIR@'
 X_DATADIR = '@X_DATADIR@'
 X_BINDIR = '@X_BINDIR@'
 X_LIBDIR = '@X_LIBDIR@'
@@ -58,6 +59,7 @@ if __name__ == '__main__':
   print('SCR_CACHE_BASE = \"' + SCR_CACHE_BASE + '\"')
   print('SCR_CACHE_SIZE = \"' + SCR_CACHE_SIZE + '\"')
   print('SCR_CONFIG_FILE = \"' + SCR_CONFIG_FILE + '\"')
+  print('CMAKE_BINARY_DIR = \"' + CMAKE_BINARY_DIR + '\"')
   print('X_BINDIR = \"' + X_BINDIR + '\"')
   print('X_LIBDIR = \"' + X_LIBDIR + '\"')
   print('PDSH_EXE = \"' + PDSH_EXE + '\"')


### PR DESCRIPTION
The python scripts must be able to run binaries from the build directory (under CMAKE_BINARY_DIR) when "make check" or "make test" are run, rather than assuming they are in the install directory as they do now.

However when running from an installed instance, they must use the usual X_BINDIR path.

Add a function to determine which is the case and return an appropriate bindir.