### PR TITLE
WIP: SCR_ADD_TEST: run python based tests

### DIFF
--- a/cmake/SCR_ADD_TEST.cmake
+++ b/cmake/SCR_ADD_TEST.cmake
@@ -8,6 +8,9 @@ FUNCTION(SCR_LAUNCHER_PARMS procs)
     ELSEIF(${SCR_RESOURCE_MANAGER} STREQUAL "LSF")
         SET(test_launcher "jsrun" PARENT_SCOPE)
         SET(test_param "--nrs ${procs} -r 1" PARENT_SCOPE)
+    ELSEIF(${SCR_RESOURCE_MANAGER} STREQUAL "FLUX")
+        SET(test_launcher "flux" PARENT_SCOPE)
+        SET(test_param "mini run --nodes ${procs} --ntasks ${procs}" PARENT_SCOPE)
     ENDIF(${SCR_RESOURCE_MANAGER} STREQUAL "NONE")
 ENDFUNCTION(SCR_LAUNCHER_PARMS procs)
 
@@ -18,13 +21,27 @@ FUNCTION(SCR_LAUNCHER_JOBID testname)
 ENDFUNCTION(SCR_LAUNCHER_JOBID name)
 
 FUNCTION(SCR_ADD_TEST name args outputs)
+    # First run bash based tests; these scripts were not written for flux
+    IF(NOT ${SCR_RESOURCE_MANAGER} STREQUAL "FLUX")
+        # Single process tests
+        SCR_LAUNCHER_PARMS(1)
+        ADD_TEST(NAME serial_${name}_restart COMMAND run_test.sh ${test_launcher} ${test_param} ./${name} restart ${args})
+        SCR_LAUNCHER_JOBID("serial_${name}_restart")
+
+        # Multi-process, multi-node tests
+        SCR_LAUNCHER_PARMS(4)
+        ADD_TEST(NAME parallel_${name}_restart COMMAND run_test.sh ${test_launcher} ${test_param} ./${name} restart ${args})
+        SCR_LAUNCHER_JOBID("parallel_${name}_restart")
+    ENDIF(NOT ${SCR_RESOURCE_MANAGER} STREQUAL "FLUX")
+
+    # Then run python based tests
     # Single process tests
     SCR_LAUNCHER_PARMS(1)
-    ADD_TEST(NAME serial_${name}_restart COMMAND run_test.sh ${test_launcher} ${test_param} ./${name} restart ${args})
-    SCR_LAUNCHER_JOBID("serial_${name}_restart")
+    ADD_TEST(NAME serial_${name}_restart_py COMMAND run_test_py.sh ${test_launcher} ${test_param} ./${name} restart ${args})
+    SCR_LAUNCHER_JOBID("serial_${name}_restart_py")
 
     # Multi-process, multi-node tests
     SCR_LAUNCHER_PARMS(4)
-    ADD_TEST(NAME parallel_${name}_restart COMMAND run_test.sh ${test_launcher} ${test_param} ./${name} restart ${args})
-    SCR_LAUNCHER_JOBID("parallel_${name}_restart")
+    ADD_TEST(NAME parallel_${name}_restart_py COMMAND run_test_py.sh ${test_launcher} ${test_param} ./${name} restart ${args})
+    SCR_LAUNCHER_JOBID("parallel_${name}_restart_py")
 ENDFUNCTION(SCR_ADD_TEST name args outputs)


### PR DESCRIPTION
Run tests using the python scripts in addition to the existing tests which use the shell scripts.

Do not run bash tests under flux; bash scripts for flux do not exist.

Tested under flux and slurm so far.

Results under flux, where only the python-based tests are run since bash scripts do not exist:
```
[faaland1@fluke6 branch:b-cmake-test-9 build] $grep Passed /tmp/t1
 1/14 Test  #1: serial_test_api_restart_py .................   Passed    3.30 sec
 2/14 Test  #2: parallel_test_api_restart_py ...............   Passed    3.57 sec
 3/14 Test  #3: serial_test_api_shared_file_restart_py .....   Passed    2.78 sec
 4/14 Test  #4: parallel_test_api_shared_file_restart_py ...   Passed    3.42 sec
 5/14 Test  #5: serial_test_config_restart_py ..............   Passed    2.49 sec
 6/14 Test  #6: parallel_test_config_restart_py ............   Passed    3.03 sec
 7/14 Test  #7: serial_test_api_multiple_restart_py ........   Passed    1.62 sec
 8/14 Test  #8: parallel_test_api_multiple_restart_py ......   Passed    1.63 sec
 9/14 Test  #9: serial_test_ckpt_restart_py ................   Passed    2.48 sec
10/14 Test #10: parallel_test_ckpt_restart_py ..............   Passed    3.04 sec
11/14 Test #11: serial_test_ckpt_F_restart_py ..............   Passed    2.95 sec
12/14 Test #12: parallel_test_ckpt_F_restart_py ............   Passed    3.70 sec
13/14 Test #13: serial_test_ckpt_F90_restart_py ............   Passed    2.94 sec
14/14 Test #14: parallel_test_ckpt_F90_restart_py ..........   Passed    3.42 sec
```