### PR TITLE
resmgrs: flux should check for flux jobid

### DIFF
--- a/doc/rst/users/build.rst
+++ b/doc/rst/users/build.rst
@@ -61,7 +61,7 @@ Some common CMake command line options:
 * :code:`-DCMAKE_BUILD_TYPE=[Debug/Release]`: Build with debugging or optimizations, defaults to :code:`Release`
 * :code:`-DBUILD_SHARED_LIBS=[ON/OFF]`: Whether to build shared libraries, defaults to :code:`ON`
 
-* :code:`-DSCR_RESOURCE_MANAGER=[SLURM/APRUN/LSF/NONE]` : Resource manager for job allocations, defaults to :code:`SLURM`
+* :code:`-DSCR_RESOURCE_MANAGER=[SLURM/APRUN/FLUX/LSF/NONE]` : Resource manager for job allocations, defaults to :code:`SLURM`
 
 * :code:`-DSCR_CNTL_BASE=[path]` : Path to SCR Control directory, defaults to :code:`/dev/shm`
 * :code:`-DSCR_CACHE_BASE=[path]` : Path to SCR Cache directory, defaults to :code:`/dev/shm`

--- a/scripts/python/scrjob/resmgrs/flux.py
+++ b/scripts/python/scrjob/resmgrs/flux.py
@@ -39,6 +39,8 @@ class FLUX(ResourceManager):
   def getjobid(self):
     if self.jobid is not None:
       return self.jobid
+    if scr_const.SCR_RESOURCE_MANAGER == 'FLUX':
+      return os.environ.get('FLUX_JOB_ID')
     if scr_const.SCR_RESOURCE_MANAGER == 'SLURM':
       return os.environ.get('SLURM_JOBID')
     if scr_const.SCR_RESOURCE_MANAGER == 'LSF':


### PR DESCRIPTION
When flux is the resource manager, we should use its job ID