### PR TITLE
SCR_ADD_TEST: run python based tests for flux

### DIFF
--- a/cmake/SCR_ADD_TEST.cmake
+++ b/cmake/SCR_ADD_TEST.cmake
@@ -8,6 +8,9 @@ FUNCTION(SCR_LAUNCHER_PARMS procs)
     ELSEIF(${SCR_RESOURCE_MANAGER} STREQUAL "LSF")
         SET(test_launcher "jsrun" PARENT_SCOPE)
         SET(test_param "--nrs ${procs} -r 1" PARENT_SCOPE)
+    ELSEIF(${SCR_RESOURCE_MANAGER} STREQUAL "FLUX")
+        SET(test_launcher "flux" PARENT_SCOPE)
+        SET(test_param "mini run --nodes ${procs} --ntasks ${procs}" PARENT_SCOPE)
     ENDIF(${SCR_RESOURCE_MANAGER} STREQUAL "NONE")
 ENDFUNCTION(SCR_LAUNCHER_PARMS procs)
 
@@ -18,13 +21,27 @@ FUNCTION(SCR_LAUNCHER_JOBID testname)
 ENDFUNCTION(SCR_LAUNCHER_JOBID name)
 
 FUNCTION(SCR_ADD_TEST name args outputs)
-    # Single process tests
-    SCR_LAUNCHER_PARMS(1)
-    ADD_TEST(NAME serial_${name}_restart COMMAND run_test.sh ${test_launcher} ${test_param} ./${name} restart ${args})
-    SCR_LAUNCHER_JOBID("serial_${name}_restart")
+    IF(${SCR_RESOURCE_MANAGER} STREQUAL "FLUX")
+        # Use python scripting framework for testing flux, it has no bash scripts
+        # Single process tests
+        SCR_LAUNCHER_PARMS(1)
+        ADD_TEST(NAME serial_${name}_restart_py COMMAND run_test_py.sh ${test_launcher} ${test_param} ./${name} restart ${args})
+        SCR_LAUNCHER_JOBID("serial_${name}_restart_py")
 
-    # Multi-process, multi-node tests
-    SCR_LAUNCHER_PARMS(4)
-    ADD_TEST(NAME parallel_${name}_restart COMMAND run_test.sh ${test_launcher} ${test_param} ./${name} restart ${args})
-    SCR_LAUNCHER_JOBID("parallel_${name}_restart")
+        # Multi-process, multi-node tests
+        SCR_LAUNCHER_PARMS(4)
+        ADD_TEST(NAME parallel_${name}_restart_py COMMAND run_test_py.sh ${test_launcher} ${test_param} ./${name} restart ${args})
+        SCR_LAUNCHER_JOBID("parallel_${name}_restart_py")
+    ELSE(${SCR_RESOURCE_MANAGER} STREQUAL "FLUX")
+        # Single process tests
+        SCR_LAUNCHER_PARMS(1)
+        ADD_TEST(NAME serial_${name}_restart COMMAND run_test.sh ${test_launcher} ${test_param} ./${name} restart ${args})
+        SCR_LAUNCHER_JOBID("serial_${name}_restart")
+
+        # Multi-process, multi-node tests
+        SCR_LAUNCHER_PARMS(4)
+        ADD_TEST(NAME parallel_${name}_restart COMMAND run_test.sh ${test_launcher} ${test_param} ./${name} restart ${args})
+        SCR_LAUNCHER_JOBID("parallel_${name}_restart")
+    ENDIF(${SCR_RESOURCE_MANAGER} STREQUAL "FLUX")
+
 ENDFUNCTION(SCR_ADD_TEST name args outputs)


### PR DESCRIPTION
Run tests using the python scripts when under flux.  Use the existing shell scripts when testing under other RMs.

Bash scripts for flux were never written.

We decided to start by supporting the python scripts only under Flux, and finish testing/cleaning up python scripts for other RMs only after that is stable and working well.

Replaces #522 