### PR TITLE
check async flush progress during need_checkpoint and should_exit

### DIFF
--- a/src/scr.c
+++ b/src/scr.c
@@ -3123,6 +3123,12 @@ int SCR_Need_checkpoint(int* flag)
   /* rank 0 broadcasts the decision */
   MPI_Bcast(flag, 1, MPI_INT, 0, scr_comm_world);
 
+  /* if we have an async flush ongoing, take this chance to check whether it's completed */
+  if (scr_flush_async_in_progress()) {
+    /* got an outstanding async flush, let's check it */
+    scr_flush_async_progall(scr_cindex);
+  }
+
   return SCR_SUCCESS;
 }
 
@@ -3754,6 +3760,12 @@ int SCR_Should_exit(int* flag)
   /* check whether a halt condition is active */
   if (scr_bool_check_halt_and_decrement(SCR_TEST_BUT_DONT_HALT, 0)) {
     *flag = 1;
+  }
+
+  /* if we have an async flush ongoing, take this chance to check whether it's completed */
+  if (scr_flush_async_in_progress()) {
+    /* got an outstanding async flush, let's check it */
+    scr_flush_async_progall(scr_cindex);
   }
 
   return SCR_SUCCESS;


### PR DESCRIPTION
Ongoing work to improve async flush performance and usability.

Related issue: https://github.com/LLNL/scr/issues/531