### PR TITLE
add SCR_FETCH_BYPASS config param

### DIFF
--- a/doc/rst/users/config.rst
+++ b/doc/rst/users/config.rst
@@ -621,6 +621,9 @@ The table in this section specifies the full set of SCR configuration parameters
    * - :code:`SCR_FETCH`
      - 1
      - Set to 0 to disable SCR from fetching files from the parallel file system during :code:`SCR_Init`.
+   * - :code:`SCR_FETCH_BYPASS`
+     - 0
+     - Set to 1 to read files directly from the parallel file system during fetch.
    * - :code:`SCR_FETCH_WIDTH`
      - 256
      - Specify the number of processes that may read simultaneously from the parallel file system.

--- a/src/scr.c
+++ b/src/scr.c
@@ -1024,10 +1024,18 @@ static int scr_get_params()
   /* whether to fetch files from the parallel file system */
   if ((value = scr_param_get("SCR_FETCH")) != NULL) {
     scr_fetch_enable = atoi(value);
-    scr_fetch_bypass = !scr_fetch_enable;
   }
   if (scr_my_rank_world == 0) {
     scr_dbg(1, "SCR_FETCH=%d", scr_fetch_enable);
+  }
+
+  /* rather than copy files to cache on fetch,
+   * have route_file point to them in the prefix directory */
+  if ((value = scr_param_get("SCR_FETCH_BYPASS")) != NULL) {
+    scr_fetch_bypass = atoi(value);
+  }
+  if (scr_my_rank_world == 0) {
+    scr_dbg(1, "SCR_FETCH_BYPASS=%d", scr_fetch_bypass);
   }
 
   /* specify number of processes to read files simultaneously */
@@ -3544,7 +3552,7 @@ int SCR_Have_restart(int* flag, char* name)
     scr_free(&dsets);
 
     /* attempt to fetch files from parallel file system */
-    if (!found_checkpoint) {
+    if (!found_checkpoint && scr_fetch_enable) {
       /* sets scr_dataset_id and scr_checkpoint_id upon success */
       int fetch_attempted = 0;
       int rc = scr_fetch_latest(scr_cindex, &fetch_attempted);

--- a/src/scr.c
+++ b/src/scr.c
@@ -1023,11 +1023,11 @@ static int scr_get_params()
 
   /* whether to fetch files from the parallel file system */
   if ((value = scr_param_get("SCR_FETCH")) != NULL) {
-    scr_fetch = atoi(value);
-    scr_fetch_bypass = !scr_fetch;
+    scr_fetch_enable = atoi(value);
+    scr_fetch_bypass = !scr_fetch_enable;
   }
   if (scr_my_rank_world == 0) {
-    scr_dbg(1, "SCR_FETCH=%d", scr_fetch);
+    scr_dbg(1, "SCR_FETCH=%d", scr_fetch_enable);
   }
 
   /* specify number of processes to read files simultaneously */

--- a/src/scr_globals.c
+++ b/src/scr_globals.c
@@ -117,7 +117,7 @@ int scr_halt_exit        = SCR_HALT_EXIT;    /* whether SCR will call exit if ha
 
 int   scr_purge            = 0;                    /* whether to delete all datasets from cache during SCR_Init */
 int   scr_distribute       = SCR_DISTRIBUTE;       /* whether to call scr_distribute_files during SCR_Init */
-int   scr_fetch            = SCR_FETCH;            /* whether to call scr_fetch_files during SCR_Init */
+int   scr_fetch_enable     = SCR_FETCH;            /* whether to call scr_fetch_files during SCR_Init */
 int   scr_fetch_width      = SCR_FETCH_WIDTH;      /* specify number of processes to read files simultaneously */
 int   scr_fetch_bypass     = SCR_FETCH_BYPASS;     /* whether to use implied bypass mode on fetch */
 char* scr_fetch_current    = NULL;                 /* name of checkpoint to start with during fetch */

--- a/src/scr_globals.h
+++ b/src/scr_globals.h
@@ -171,7 +171,7 @@ extern int scr_halt_exit;    /* whether SCR will call exit if halt condition is 
 
 extern int   scr_purge;            /* delete all datasets from cache on restart for debugging */
 extern int   scr_distribute;       /* whether to call scr_distribute_files during SCR_Init */
-extern int   scr_fetch;            /* whether to call scr_fetch_files during SCR_Init */
+extern int   scr_fetch_enable;     /* whether to call scr_fetch_files during SCR_Init */
 extern int   scr_fetch_width;      /* specify number of processes to read files simultaneously */
 extern int   scr_fetch_bypass;     /* whether to use implied bypass on fetch operations */
 extern char* scr_fetch_current;    /* specify name of checkpoint to start with in fetch_latest */


### PR DESCRIPTION
This restores the ability to completely disable fetch by setting ``SCR_FETCH=0``.  It had instead been tied to fetch bypass when bypass support was added, so that setting ``SCR_FETCH=0`` kept the fetch active but switched to "fetch bypass" mode.  Fetch bypass enables one to read files directly from the prefix directory on a restart, rather than have SCR first copy those files to cache.

However, a problem arises when restarting an application with a different number of ranks.  Even in fetch bypass mode, SCR executes a numbers of checks, including whether the number of ranks listed in the checkpoint matches the number of ranks in the current run.  If there is a mismatch, SCR prints a warning and moves on to the next checkpoint.  This means SCR would print a bunch of warning messages for apps that actually want to restart with a different number of ranks.

To solve this, the fetch feature can be disabled fully (once again) by setting ``SCR_FETCH=0``.  For apps that need to restart with a different number of ranks, they can disable fetch to skip those SCR checks and silence the warnings.

If one wants to use fetch in bypass mode, a new ``SCR_FETCH_BYPASS`` param has been added.  So now an app can rely on SCR to identify the most recent checkpoint, but tell SCR not to copy those files to cache during restart.  Instead, ``SCR_Route_file`` would point to the files directly on the prefix directory:

```
export SCR_FETCH=1
export SCR_FETCH_BYPASS=1
```