### PR TITLE
simulate different work kernels in test_api

### DIFF
--- a/examples/test_api.c
+++ b/examples/test_api.c
@@ -119,35 +119,35 @@ int test_abtoull(char* str, unsigned long long* val)
   unsigned long long units = 1;
   if (*next != '\0') {
     switch(*next) {
-      case 'k':
-      case 'K':
-        units = kilo;
-        break;
-      case 'm':
-      case 'M':
-        units = mega;
-        break;
-      case 'g':
-      case 'G':
-        units = giga;
-        break;
-      case 't':
-      case 'T':
-        units = tera;
-        break;
-      case 'p':
-      case 'P':
-        units = peta;
-        break;
-      case 'e':
-      case 'E':
-        units = exa;
-        break;
-      default:
+    case 'k':
+    case 'K':
+      units = kilo;
+      break;
+    case 'm':
+    case 'M':
+      units = mega;
+      break;
+    case 'g':
+    case 'G':
+      units = giga;
+      break;
+    case 't':
+    case 'T':
+      units = tera;
+      break;
+    case 'p':
+    case 'P':
+      units = peta;
+      break;
+    case 'e':
+    case 'E':
+      units = exa;
+      break;
+    default:
       printf("test_abtoull: Unexpected byte string %s @ %s:%d",
              str, __FILE__, __LINE__
       );
-        return SCR_FAILURE;
+      return SCR_FAILURE;
     }
 
     next++;
@@ -461,12 +461,12 @@ double getbw(char* name, char* buf, int times)
         /* not using SCR, writing to file system instead,
          * need to create our directory */
         if (rank == 0) {
-          rc = mkdir(outpath, S_IRUSR | S_IWUSR | S_IXUSR);
-          if (rc != 0 && errno != EEXIST) {
+           rc = mkdir(outpath, S_IRUSR | S_IWUSR | S_IXUSR);
+           if (rc != 0 && errno != EEXIST) {
              printf("%d: mkdir failed: %s %d %s @%s:%d\n",
                     rank, outpath, errno, strerror(errno), __FILE__, __LINE__
              );
-          }
+           }
         }
         MPI_Barrier(MPI_COMM_WORLD);
       }
@@ -512,7 +512,7 @@ double getbw(char* name, char* buf, int times)
         }
         else {
             printf("%d: Failed to seek to 0x%08lx in %s : %s\n", rank, my_file_offset, file, strerror(errno));
-          valid = 0;
+            valid = 0;
         }
 
         /* make sure the close is without error */
@@ -573,6 +573,10 @@ double getbw(char* name, char* buf, int times)
           case 3: {
             work_allreduce_iters(timestep, reduce);
             break;
+          }
+          default: {
+            printf("Invalid Kernel Type %d\n", kernel);
+            return 1;
           }
         }
       }
@@ -740,7 +744,7 @@ void print_usage()
   printf("    -t, --times=<COUNT>  Number of iterations (default %d)\n", times);
   printf("    -z, --seconds=<SECS> Sleep for SECS seconds between iterations (default %d)\n", seconds);
   printf("    -w, --reduce=<COUNT> Allreduce iterations to execute between iterations (default %d)\n", reduce);
-  printf("-k, --kernel=<KERNEL_INDEX> Selected Kernel 0-CPU, 1-MEMORY, 2-ALL REDUCE, 3 -ALL REDUCE AVERAGE(default % d)\n ", kernel);
+  printf("    -k, --kernel=<KERNEL_INDEX> Selected Kernel 0-CPU, 1-MEMORY, 2-ALL REDUCE, 3 -ALL REDUCE AVERAGE(default %d)\n", kernel);
   printf("    -p, --path=<DIR>     Directory to create and write files to\n");
   printf("    -f, --flush=<COUNT>  Mark every Nth write as checkpoint+output (default %d)\n", ckptout);
   printf("    -o, --output=<COUNT> Mark every Nth write as pure output (default %d)\n", output);
@@ -764,18 +768,18 @@ int main (int argc, char* argv[])
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
   MPI_Comm_size(MPI_COMM_WORLD, &ranks);
 
-  static const char *opt_string = "s:t:z:w:p:f:o:a:c:h:k:";
+  static const char *opt_string = "s:t:z:w:p:f:o:a:c:k:h";
   static struct option long_options[] = {
     {"size",    required_argument, NULL, 's'},
     {"times",   required_argument, NULL, 't'},
-      {"seconds", required_argument, NULL, 'z'},
+    {"seconds", required_argument, NULL, 'z'},
     {"reduce",  required_argument, NULL, 'w'},
     {"path",    required_argument, NULL, 'p'},
     {"flush",   required_argument, NULL, 'f'},
     {"output",  required_argument, NULL, 'o'},
-      {"config-api", required_argument, NULL, 'a'},
+    {"config-api", required_argument, NULL, 'a'},
     {"conf-file",  required_argument, NULL, 'c'},
-      {"current", required_argument, NULL, 'C'},
+    {"current", required_argument, NULL, 'C'},
     {"nofsync", no_argument,       NULL, 'S'},
     {"noscr",   no_argument,       NULL, 'x'},
     {"noscrrestart", no_argument,  NULL, 'X'},

--- a/examples/test_api.c
+++ b/examples/test_api.c
@@ -32,6 +32,7 @@ off_t my_file_offset = 0;
 int times = 5;
 int seconds = 0;
 int reduce = 0;
+int kernel = 0;
 int ckptout = 0;
 int output = 0;
 int use_config_api = 0;
@@ -118,35 +119,35 @@ int test_abtoull(char* str, unsigned long long* val)
   unsigned long long units = 1;
   if (*next != '\0') {
     switch(*next) {
-    case 'k':
-    case 'K':
-      units = kilo;
-      break;
-    case 'm':
-    case 'M':
-      units = mega;
-      break;
-    case 'g':
-    case 'G':
-      units = giga;
-      break;
-    case 't':
-    case 'T':
-      units = tera;
-      break;
-    case 'p':
-    case 'P':
-      units = peta;
-      break;
-    case 'e':
-    case 'E':
-      units = exa;
-      break;
-    default:
+      case 'k':
+      case 'K':
+        units = kilo;
+        break;
+      case 'm':
+      case 'M':
+        units = mega;
+        break;
+      case 'g':
+      case 'G':
+        units = giga;
+        break;
+      case 't':
+      case 'T':
+        units = tera;
+        break;
+      case 'p':
+      case 'P':
+        units = peta;
+        break;
+      case 'e':
+      case 'E':
+        units = exa;
+        break;
+      default:
       printf("test_abtoull: Unexpected byte string %s @ %s:%d",
              str, __FILE__, __LINE__
       );
-      return SCR_FAILURE;
+        return SCR_FAILURE;
     }
 
     next++;
@@ -293,6 +294,7 @@ void work_cpu(int timestep, int iters)
   int i;
   for (i = 0; i < iters; i++) {
     double outval = inval * (double)i;
+    (void)outval;
   }
 
   double end = MPI_Wtime();
@@ -459,12 +461,12 @@ double getbw(char* name, char* buf, int times)
         /* not using SCR, writing to file system instead,
          * need to create our directory */
         if (rank == 0) {
-           rc = mkdir(outpath, S_IRUSR | S_IWUSR | S_IXUSR);
-           if (rc != 0 && errno != EEXIST) {
+          rc = mkdir(outpath, S_IRUSR | S_IWUSR | S_IXUSR);
+          if (rc != 0 && errno != EEXIST) {
              printf("%d: mkdir failed: %s %d %s @%s:%d\n",
                     rank, outpath, errno, strerror(errno), __FILE__, __LINE__
              );
-           }
+          }
         }
         MPI_Barrier(MPI_COMM_WORLD);
       }
@@ -510,7 +512,7 @@ double getbw(char* name, char* buf, int times)
         }
         else {
             printf("%d: Failed to seek to 0x%08lx in %s : %s\n", rank, my_file_offset, file, strerror(errno));
-            valid = 0;
+          valid = 0;
         }
 
         /* make sure the close is without error */
@@ -555,10 +557,24 @@ double getbw(char* name, char* buf, int times)
        * Timing how long this takes can be used to estimate
        * interference from a background flush. */
       if (reduce > 0) {
-//        work_cpu(timestep, reduce);
-        work_allreduce_iters(timestep, reduce);
-//        work_allreduce(timestep, reduce);
-//        work_memcpy(timestep, reduce, 1024L * 1024L * 1024L);
+        switch (kernel) {
+          case 0: {
+            work_cpu(timestep, reduce);
+            break;
+          }
+          case 1: {
+            work_memcpy(timestep, reduce, 1024L * 1024L * 1024L);
+            break;
+          }
+          case 2: {
+            work_allreduce(timestep, reduce);
+            break;
+          }
+          case 3: {
+            work_allreduce_iters(timestep, reduce);
+            break;
+          }
+        }
       }
     }
 
@@ -724,6 +740,7 @@ void print_usage()
   printf("    -t, --times=<COUNT>  Number of iterations (default %d)\n", times);
   printf("    -z, --seconds=<SECS> Sleep for SECS seconds between iterations (default %d)\n", seconds);
   printf("    -w, --reduce=<COUNT> Allreduce iterations to execute between iterations (default %d)\n", reduce);
+  printf("-k, --kernel=<KERNEL_INDEX> Selected Kernel 0-CPU, 1-MEMORY, 2-ALL REDUCE, 3 -ALL REDUCE AVERAGE(default % d)\n ", kernel);
   printf("    -p, --path=<DIR>     Directory to create and write files to\n");
   printf("    -f, --flush=<COUNT>  Mark every Nth write as checkpoint+output (default %d)\n", ckptout);
   printf("    -o, --output=<COUNT> Mark every Nth write as pure output (default %d)\n", output);
@@ -747,24 +764,25 @@ int main (int argc, char* argv[])
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
   MPI_Comm_size(MPI_COMM_WORLD, &ranks);
 
-  static const char *opt_string = "s:t:z:w:p:f:o:a:c:h";
+  static const char *opt_string = "s:t:z:w:p:f:o:a:c:h:k:";
   static struct option long_options[] = {
     {"size",    required_argument, NULL, 's'},
     {"times",   required_argument, NULL, 't'},
-    {"seconds", required_argument, NULL, 'z'},
+      {"seconds", required_argument, NULL, 'z'},
     {"reduce",  required_argument, NULL, 'w'},
     {"path",    required_argument, NULL, 'p'},
     {"flush",   required_argument, NULL, 'f'},
     {"output",  required_argument, NULL, 'o'},
-    {"config-api", required_argument, NULL, 'a'},
+      {"config-api", required_argument, NULL, 'a'},
     {"conf-file",  required_argument, NULL, 'c'},
-    {"current", required_argument, NULL, 'C'},
+      {"current", required_argument, NULL, 'C'},
     {"nofsync", no_argument,       NULL, 'S'},
     {"noscr",   no_argument,       NULL, 'x'},
     {"noscrrestart", no_argument,  NULL, 'X'},
     {"shared-file", no_argument,   NULL, 'y'},
     {"global-store", required_argument,  NULL, 'Y'},
     {"help",    no_argument,       NULL, 'h'},
+    {"kernel", required_argument, NULL, 'k'},
     {NULL,      no_argument,       NULL,   0}
   };
 
@@ -809,6 +827,9 @@ int main (int argc, char* argv[])
         break;
       case 'C':
         current = strdup(optarg);
+        break;
+      case 'k':
+        kernel = atoi(optarg);
         break;
       case 'S':
         use_fsync = 0;


### PR DESCRIPTION
To study and improve async flush performance in SCR, this extends ``test_api.c`` to execute various work kernels.  By focusing on certain operations, e.g., CPU intensive, memory intensive, network intensive, etc. the idea is to identify which types of operations are most susceptible to interference from a background flush.