### PR TITLE
flux: save string form of jobid

### DIFF
--- a/scripts/python/scrjob/resmgrs/flux.py
+++ b/scripts/python/scrjob/resmgrs/flux.py
@@ -47,7 +47,7 @@ class FLUX(ResourceManager):
     else:
       jobid = self.flux.job.JobID.id_parse(jobid_str)
 
-    return jobid
+    return str(jobid)
 
   # get node list
   def get_job_nodes(self):


### PR DESCRIPTION
SCR uses the jobid as a component of file or directory names, so we should save the string form so we don't need to convert repeatedly.