### PR TITLE
flux launcher should detect failed jobs

### DIFF
--- a/scripts/python/scrjob/launchers/joblauncher.py
+++ b/scripts/python/scrjob/launchers/joblauncher.py
@@ -18,6 +18,8 @@ class JobLauncher(object):
   launchruncmd() may return scr_common.runproc(argv, wait=False) and use the
   provided waitonprocess() and scr_kill_jobstep() methods
 
+  waitonprocess() returns a tuple of 2 boolean values: (completed, success)
+
   Default methods
   ---------------
   clustershell_exec()
@@ -67,18 +69,26 @@ class JobLauncher(object):
 
     Returns
     -------
-    integer
-        0 - indicates the process is no longer running, or if some exception occured
-        1 - indicates we waited for the timeout and the process is still running
+       A tuple containing (completed, success)
+       completed:
+           None -  an exception occurred
+           True -  the process is no longer running
+           False - we waited for the timeout and the process is still running
+       success:
+           None -  the job wasn't found or has not finished, no status
+           True -  the process exited 0
+           False - the process failed (exit code nonzero)
     """
     if proc is not None:
       try:
         proc.communicate(timeout=timeout)
       except TimeoutExpired:
-        return 1
-      except:
-        pass
-    return 0
+        return (False, None)
+      except e:
+        print(f'waitonprocess for proc {proc} failed with exception {e}')
+        return (None, None)
+
+    return (True, proc.returncode)
 
   def prepareforprerun(self):
     """This method is called (without arguments) before scr_prerun.py

--- a/scripts/python/scrjob/scr_run.py
+++ b/scripts/python/scrjob/scr_run.py
@@ -281,14 +281,17 @@ def scr_run(launcher='',
                                       down_nodes=down_nodes,
                                       launcher_args=launch_cmd)
     if watchdog is None:
-      launcher.waitonprocess(proc)
+      (finished, success) = launcher.waitonprocess(proc)
     else:
       print(prog + ': Entering watchdog method')
       # watchdog returned error or a watcher process was launched
       if watchdog.watchproc(proc, jobstep) != 0:
         print(prog + ': Error launching watchdog')
-        launcher.waitonprocess(proc)
+        (finished, success) = launcher.waitonprocess(proc)
       # else the watchdog returned because the process has finished/been killed
+      else:
+        #TODO: verify this really works for case where watchproc() returns 0 / succeeds
+        (finished, success) = launcher.waitonprocess(proc)
 
     #print('Process has finished or has been terminated.')
 

--- a/scripts/python/scrjob/scr_watchdog.py
+++ b/scripts/python/scrjob/scr_watchdog.py
@@ -52,7 +52,8 @@ class SCR_Watchdog:
     lastCheckpointLoc = None
     while True:
       # wait up to 'timeToSleep' to see if the process terminates normally
-      if self.launcher.waitonprocess(proc, timeout=timeToSleep) == 0:
+      (finished, success) = self.launcher.waitonprocess(proc, timeout=timeToSleep)
+      if finished == True:
         # when the wait returns zero the process is no longer running
         return 0
 

--- a/scripts/python/tests/test_launch.py
+++ b/scripts/python/tests/test_launch.py
@@ -117,14 +117,15 @@ def dolaunch(launcher, launch_cmd):
   print('proc = ' + str(proc))
   print('pid = ' + str(jobstep))
   print('testing : Entering watchdog method')
+  success = False
   if watchdog.watchproc(proc, jobstep) != 0:
     print('watchdog.watchproc returned nonzero')
     print('calling launcher.waitonprocess . . .')
-    launcher.waitonprocess(proc)
+    (finished, success) = launcher.waitonprocess(proc)
   else:
     print('watchdog returned zero and didn\'t launch another process')
     print('this means the process is terminated')
-  print('Process has finished or has been terminated.')
+  print(f'Process has finished or has been terminated with success == {success}.')
 
 if __name__ == '__main__':
   if len(sys.argv) < 3:

--- a/scripts/python/tests/test_watchdog.py
+++ b/scripts/python/tests/test_watchdog.py
@@ -88,7 +88,8 @@ def testwatchdog(launcher, launcher_args):
   if watchdog.watchproc(proc, jobstep) != 0:
     print('The watchdog failed to start')
     print('Waiting for the original process for 15 seconds')
-    if launcher.waitonprocess(proc=proc,timeout=timeout) == 1:
+    (finished, success) = launcher.waitonprocess(proc=proc,timeout=timeout)
+    if finished == True:
       print('The process is still running, asking the launcher to kill it . . .')
       launcher.scr_kill_jobstep(jobstep=jobstep)
 


### PR DESCRIPTION
launcher.waitonprocess() should return both whether the process finished (which it might not have it we timed out waiting for it, for example) and whether it succeeded, if it did finish.

Update the default implementation, the flux implementation, and the consumers.