### PR TITLE
scr_run.py: exit with non-zero exit code on failure

### DIFF
--- a/scripts/python/scrjob/scr_run.py
+++ b/scripts/python/scrjob/scr_run.py
@@ -341,6 +341,12 @@ def scr_run(launcher='',
   timestamp = datetime.now()
   print(prog + ': Ended: ' + str(timestamp))
 
+  if finished == True and success == True:
+    returncode = 0
+  else:
+    returncode = 1
+
+  sys.exit(returncode)
 
 def print_usage(launcher=''):
   available_launchers = '[srun/jsrun/mpirun]'


### PR DESCRIPTION
For use in testing, scr_run.py should exit with a nonzero exit code if the launched job fails, so ctest can detect that and report it.

Similarly, users running scru_run.py from a script should be able to detect failure so the script can do whatever is appropriate.