### PR TITLE
flux: remove 'mini' command from tests

### DIFF
--- a/cmake/SCR_ADD_TEST.cmake
+++ b/cmake/SCR_ADD_TEST.cmake
@@ -10,7 +10,7 @@ FUNCTION(SCR_LAUNCHER_PARMS procs)
         SET(test_param "--nrs ${procs} -r 1" PARENT_SCOPE)
     ELSEIF(${SCR_RESOURCE_MANAGER} STREQUAL "FLUX")
         SET(test_launcher "flux" PARENT_SCOPE)
-        SET(test_param "mini run --nodes ${procs} --ntasks ${procs}" PARENT_SCOPE)
+        SET(test_param "run --nodes ${procs} --ntasks ${procs}" PARENT_SCOPE)
     ENDIF(${SCR_RESOURCE_MANAGER} STREQUAL "NONE")
 ENDFUNCTION(SCR_LAUNCHER_PARMS procs)
 

--- a/scripts/python/scrjob/launchers/flux.py
+++ b/scripts/python/scrjob/launchers/flux.py
@@ -60,7 +60,7 @@ class FLUX(JobLauncher):
 
     # A jobspec is a yaml description of job and its resource requirements.
     # Building one lets us submit the job and get back the assigned jobid.
-    argv.insert(3, '--dry-run')
+    argv.insert(2, '--dry-run')
     compute_jobreq, exitcode = runproc(argv=argv, getstdout=True)
     if compute_jobreq == None:
         return None, None


### PR DESCRIPTION
Problem: 'flux mini submit' is now 'flux submit', and similarly for other 'mini' subcommands. The usage of 'mini' is deprecated.

Remove the 'mini' prefix.