### PR TITLE
tests: fix argument passing to scr_run.py

### DIFF
--- a/examples/run_test_py.sh
+++ b/examples/run_test_py.sh
@@ -23,14 +23,16 @@ fi
 scr_run="../scripts/python/scrjob/scr_run.py"
 export PYTHON_PATH=$PYTHON_PATH:$(realpath $(dirname $scr_run) )
 
-echo "Run: $scr_run $launch $launch_args $test $@"
-$scr_run $launch $launch_args $test \"$@\"
+if [ -z ${@+x} ]; then QUOTED_ARGS=""; else QUOTED_ARGS=\"$@\"; fi
+
+echo "Run: $scr_run $launch $launch_args $test $QUOTED_ARGS"
+$scr_run $launch $launch_args $test $QUOTED_ARGS
 RC=$?
 
 # only attempt a restart if requested and if first run succeeded
 if [ "$restart" = "restart" -a $RC -eq 0 ]; then
-    echo "Restart: $scr_run $launch $launch_args $test $@"
-    $scr_run $launch $launch_args $test \"$@\"
+    echo "Restart: $scr_run $launch $launch_args $test $QUOTED_ARGS"
+    $scr_run $launch $launch_args $test $QUOTED_ARGS
     RC=$?
 fi
 


### PR DESCRIPTION
Problem: the scr_run_py.sh script sometimes passes an extra argument to scr_run.py. The script passes \"$@\", which comes out to the string "" when $@ is empty. The string is forwarded on and eventually causes an error in 'test_api_multiple.c'.

Solution: when $@ is empty, don't pass anything to scr_run.py.