### PR TITLE
yapf: format python files

### DIFF
--- a/python/scr.py.in
+++ b/python/scr.py.in
@@ -162,28 +162,32 @@ int SCR_Drop(const char* name);
 _libscr = _ffi.dlopen('@X_LIBDIR@/libscr.so')
 #print('Loaded lib {0}'.format(libscr))
 
-FLAG_NONE       = _libscr.SCR_FLAG_NONE
+FLAG_NONE = _libscr.SCR_FLAG_NONE
 FLAG_CHECKPOINT = _libscr.SCR_FLAG_CHECKPOINT
-FLAG_OUTPUT     = _libscr.SCR_FLAG_OUTPUT
+FLAG_OUTPUT = _libscr.SCR_FLAG_OUTPUT
 
 # determine whether we have python 2 or 3
 import sys
+
 _PY3 = (sys.version_info[0] >= 3)
+
 
 # encode python string into C char array (char[])
 def _cstr(val):
-  if _PY3:
-    return val.encode("utf-8")
-  return val
+    if _PY3:
+        return val.encode("utf-8")
+    return val
+
 
 # decode C char array into python string
 def _pystr(val):
-  if _PY3:
-    return _ffi.string(val).decode("utf-8")
-  return _ffi.string(val)
+    if _PY3:
+        return _ffi.string(val).decode("utf-8")
+    return _ffi.string(val)
+
 
 def config(conf):
-  """Query, set, or unset an SCR configuration parameter.
+    """Query, set, or unset an SCR configuration parameter.
 
   Must be called before init().
 
@@ -214,13 +218,14 @@ def config(conf):
   str
       current value of SCR configuration parameter if set
   """
-  val = _libscr.SCR_Config(_cstr(conf))
-  if val != _ffi.NULL:
-    return _pystr(val)
-  return None
+    val = _libscr.SCR_Config(_cstr(conf))
+    if val != _ffi.NULL:
+        return _pystr(val)
+    return None
+
 
 def init():
-  """Initialize the SCR library.
+    """Initialize the SCR library.
 
   Must be called before any other SCR method, except config().
   When restarting a job, this method rebuilds any cached datasets.
@@ -237,12 +242,13 @@ def init():
   RuntimeError
       if SCR_Init returns an error
   """
-  rc = _libscr.SCR_Init()
-  if rc != _libscr.SCR_SUCCESS:
-    raise RuntimeError("SCR_Init failed")
+    rc = _libscr.SCR_Init()
+    if rc != _libscr.SCR_SUCCESS:
+        raise RuntimeError("SCR_Init failed")
+
 
 def finalize():
-  """Shut down the SCR library.
+    """Shut down the SCR library.
 
   Should be called before exiting a program, and no other SCR methods
   can be called after calling finalize().
@@ -259,12 +265,13 @@ def finalize():
   RuntimeError
       if SCR_Finalize returns an error
   """
-  rc = _libscr.SCR_Finalize()
-  if rc != _libscr.SCR_SUCCESS:
-    raise RuntimeError("SCR_Finalize failed")
+    rc = _libscr.SCR_Finalize()
+    if rc != _libscr.SCR_SUCCESS:
+        raise RuntimeError("SCR_Finalize failed")
+
 
 def route_file(fname):
-  """Acquire the SCR path to a given file.
+    """Acquire the SCR path to a given file.
 
   During a restart phase, returns the path that the calling process must use
   to open the file named in fname for reading.
@@ -297,14 +304,15 @@ def route_file(fname):
   RuntimeError
       if SCR_Route_file returns an error
   """
-  ptr = _ffi.new("char[1024]")
-  rc = _libscr.SCR_Route_file(_cstr(fname), ptr)
-  if rc != _libscr.SCR_SUCCESS:
-    raise RuntimeError("SCR_Route_file failed")
-  return _pystr(ptr)
+    ptr = _ffi.new("char[1024]")
+    rc = _libscr.SCR_Route_file(_cstr(fname), ptr)
+    if rc != _libscr.SCR_SUCCESS:
+        raise RuntimeError("SCR_Route_file failed")
+    return _pystr(ptr)
+
 
 def have_restart():
-  """Determines whether SCR has loaded a checkpoint that the application can read.
+    """Determines whether SCR has loaded a checkpoint that the application can read.
 
   An application does not need to read a checkpoint, even if have_restart()
   indicates that a checkpoint has been loaded.
@@ -325,16 +333,17 @@ def have_restart():
   RuntimeError
       if SCR_Have_restart returns an error
   """
-  flag_ptr = _ffi.new("int[1]")
-  name_ptr = _ffi.new("char[1024]")
-  rc = _libscr.SCR_Have_restart(flag_ptr, name_ptr)
-  if rc != _libscr.SCR_SUCCESS:
-    raise RuntimeError("SCR_Have_restart failed")
-  if flag_ptr[0]:
-    return _pystr(name_ptr)
+    flag_ptr = _ffi.new("int[1]")
+    name_ptr = _ffi.new("char[1024]")
+    rc = _libscr.SCR_Have_restart(flag_ptr, name_ptr)
+    if rc != _libscr.SCR_SUCCESS:
+        raise RuntimeError("SCR_Have_restart failed")
+    if flag_ptr[0]:
+        return _pystr(name_ptr)
+
 
 def start_restart():
-  """Opens a restart phase for reading checkpoint files.
+    """Opens a restart phase for reading checkpoint files.
 
   Can only be called if have_restart() indicates that a
   checkpoint is loaded.
@@ -351,14 +360,15 @@ def start_restart():
   RuntimeError
       if SCR_Start_restart returns an error
   """
-  ptr = _ffi.new("char[1024]")
-  rc = _libscr.SCR_Start_restart(ptr)
-  if rc != _libscr.SCR_SUCCESS:
-    raise RuntimeError("SCR_Start_restart failed")
-  return _pystr(ptr)
+    ptr = _ffi.new("char[1024]")
+    rc = _libscr.SCR_Start_restart(ptr)
+    if rc != _libscr.SCR_SUCCESS:
+        raise RuntimeError("SCR_Start_restart failed")
+    return _pystr(ptr)
+
 
 def complete_restart(valid=True):
-  """Close a restart phase after reading checkpoint files.
+    """Close a restart phase after reading checkpoint files.
 
   Each calling process must indicate whether it restarted successfully.
 
@@ -376,11 +386,12 @@ def complete_restart(valid=True):
       Returns True if all processes restarted successfully,
       and False if any process indicated that it failed.
   """
-  rc = _libscr.SCR_Complete_restart(int(valid))
-  return rc == _libscr.SCR_SUCCESS
+    rc = _libscr.SCR_Complete_restart(int(valid))
+    return rc == _libscr.SCR_SUCCESS
+
 
 def need_checkpoint():
-  """Ask SCR whether a checkpoint should be taken.
+    """Ask SCR whether a checkpoint should be taken.
 
   It is optional for an application to call need_checkpoint(),
   and an application is free to ignore the value it returns.
@@ -400,14 +411,15 @@ def need_checkpoint():
   RuntimeError
       if SCR_Need_checkpoint returns an error
   """
-  ptr = _ffi.new("int[1]")
-  rc = _libscr.SCR_Need_checkpoint(ptr)
-  if rc != _libscr.SCR_SUCCESS:
-    raise RuntimeError("SCR_Need_checkpoint failed")
-  return bool(ptr[0])
+    ptr = _ffi.new("int[1]")
+    rc = _libscr.SCR_Need_checkpoint(ptr)
+    if rc != _libscr.SCR_SUCCESS:
+        raise RuntimeError("SCR_Need_checkpoint failed")
+    return bool(ptr[0])
+
 
 def start_output(name, flags):
-  """Open an output phase.
+    """Open an output phase.
 
   The caller provides the name of the dataset and a set of flags.
   The flags value is a bitmask of the flag attributes, e.g.,:
@@ -444,12 +456,13 @@ def start_output(name, flags):
   RuntimeError
       if SCR_Start_output returns an error
   """
-  rc = _libscr.SCR_Start_output(_cstr(name), int(flags))
-  if rc != _libscr.SCR_SUCCESS:
-    raise RuntimeError("SCR_Start_output failed")
+    rc = _libscr.SCR_Start_output(_cstr(name), int(flags))
+    if rc != _libscr.SCR_SUCCESS:
+        raise RuntimeError("SCR_Start_output failed")
+
 
 def complete_output(valid=True):
-  """Close an output phase.
+    """Close an output phase.
 
   Each calling process must indicate whether it wrote its portion
   of the output successfully.
@@ -468,11 +481,12 @@ def complete_output(valid=True):
       Returns True if all processes wrote their output successfully,
       and False if any process indicated that it failed.
   """
-  rc = _libscr.SCR_Complete_output(int(valid))
-  return rc == _libscr.SCR_SUCCESS
+    rc = _libscr.SCR_Complete_output(int(valid))
+    return rc == _libscr.SCR_SUCCESS
+
 
 def should_exit():
-  """Ask SCR whether the application should exit early.
+    """Ask SCR whether the application should exit early.
 
   This method indicates whether the application should stop early.
   This condition may arise when the job allocation is about to expire
@@ -493,14 +507,15 @@ def should_exit():
   RuntimeError
       if SCR_Should_exit returns an error
   """
-  ptr = _ffi.new("int[1]")
-  rc = _libscr.SCR_Should_exit(ptr)
-  if rc != _libscr.SCR_SUCCESS:
-    raise RuntimeError("SCR_Should_exit failed")
-  return bool(ptr[0])
+    ptr = _ffi.new("int[1]")
+    rc = _libscr.SCR_Should_exit(ptr)
+    if rc != _libscr.SCR_SUCCESS:
+        raise RuntimeError("SCR_Should_exit failed")
+    return bool(ptr[0])
+
 
 def current(name):
-  """Indicate from which checkpoint an application restarted.
+    """Indicate from which checkpoint an application restarted.
 
   It is preferred for an application to restart using the SCR Restart API.
   However, not all applications can do so.
@@ -530,12 +545,13 @@ def current(name):
   RuntimeError
       if SCR_Current returns an error
   """
-  rc = _libscr.SCR_Current(_cstr(name))
-  if rc != _libscr.SCR_SUCCESS:
-    raise RuntimeError("SCR_Current failed")
+    rc = _libscr.SCR_Current(_cstr(name))
+    if rc != _libscr.SCR_SUCCESS:
+        raise RuntimeError("SCR_Current failed")
+
 
 def delete(name):
-  """Request SCR to delete a dataset.
+    """Request SCR to delete a dataset.
 
   SCR deletes all data files associated with the dataset.
   SCR also deletes any directories up to the prefix directory
@@ -560,12 +576,13 @@ def delete(name):
   RuntimeError
       if SCR_Delete returns an error
   """
-  rc = _libscr.SCR_Delete(_cstr(name))
-  if rc != _libscr.SCR_SUCCESS:
-    raise RuntimeError("SCR_Delete failed")
+    rc = _libscr.SCR_Delete(_cstr(name))
+    if rc != _libscr.SCR_SUCCESS:
+        raise RuntimeError("SCR_Delete failed")
+
 
 def drop(name):
-  """Inform SCR to forget about a dataset.
+    """Inform SCR to forget about a dataset.
 
   SCR drops information about the named dataset from its internal metadata.
   However, SCR does not attempt to delete files for that dataset.
@@ -589,6 +606,6 @@ def drop(name):
   RuntimeError
       if SCR_Drop returns an error
   """
-  rc = _libscr.SCR_Drop(_cstr(name))
-  if rc != _libscr.SCR_SUCCESS:
-    raise RuntimeError("SCR_Drop failed")
+    rc = _libscr.SCR_Drop(_cstr(name))
+    if rc != _libscr.SCR_SUCCESS:
+        raise RuntimeError("SCR_Drop failed")

--- a/python/scr_example.py
+++ b/python/scr_example.py
@@ -19,90 +19,90 @@ scr.init()
 
 # attempt to restart from a previous checkpoint
 while True:
-  # see if we have a restart to load
-  if not scr.have_restart():
-    # no restart to load, give up
-    break
+    # see if we have a restart to load
+    if not scr.have_restart():
+        # no restart to load, give up
+        break
 
-  # got a restart to load, start restart phase and get its name
-  name = scr.start_restart()
-  print("restart name: ", name)
+    # got a restart to load, start restart phase and get its name
+    name = scr.start_restart()
+    print("restart name: ", name)
 
-  # extract timestep value from name like "timestep_10"
-  timestep = int(name[9:])
+    # extract timestep value from name like "timestep_10"
+    timestep = int(name[9:])
 
-  # build file name for this timestep and rank
-  fname = 'ckpt_' + str(timestep) + '_' + str(rank) + '.txt'
+    # build file name for this timestep and rank
+    fname = 'ckpt_' + str(timestep) + '_' + str(rank) + '.txt'
 
-  # ask scr for path from which to read our file
-  newfname = scr.route_file(fname)
-  print("restart route: ", fname, "-->", newfname)
+    # ask scr for path from which to read our file
+    newfname = scr.route_file(fname)
+    print("restart route: ", fname, "-->", newfname)
 
-  # read checkpoint file
-  valid = True
-  try:
-    with open(newfname, "r") as f:
-      data = f.readlines()
-      print(str(data))
-  except:
-    # failed to read file
-    valid = False
+    # read checkpoint file
+    valid = True
+    try:
+        with open(newfname, "r") as f:
+            data = f.readlines()
+            print(str(data))
+    except:
+        # failed to read file
+        valid = False
 
-  # test: fake a bad file on rank 0 for timestep 6
-  if rank == 0 and timestep == 6:
-    valid = False
+    # test: fake a bad file on rank 0 for timestep 6
+    if rank == 0 and timestep == 6:
+        valid = False
 
-  # check whether everyone read their checkpoint file successfully
-  if scr.complete_restart(valid):
-    # success, bump timestep to next value and break restart loop
-    timestep += 1
-    break
-  else:
-    # someone failed, loop to try another checkpoint
-    timestep = 1
+    # check whether everyone read their checkpoint file successfully
+    if scr.complete_restart(valid):
+        # success, bump timestep to next value and break restart loop
+        timestep += 1
+        break
+    else:
+        # someone failed, loop to try another checkpoint
+        timestep = 1
 
 # work loop to execute new timesteps in the job
 laststep = timestep + 2
 while timestep < laststep:
-  #####
-  # do work ...
-  #####
+    #####
+    # do work ...
+    #####
 
-  # save checkpoint if needed
-  if scr.need_checkpoint():
-    # define name of checkpoint to be something like "timestep_10"
-    name = 'timestep_' + str(timestep)
+    # save checkpoint if needed
+    if scr.need_checkpoint():
+        # define name of checkpoint to be something like "timestep_10"
+        name = 'timestep_' + str(timestep)
 
-    # start checkpoint phase
-    scr.start_output(name, scr.FLAG_CHECKPOINT)
-  
-    # define name of checkpoint file for this timestep and rank
-    fname = 'ckpt_' + str(timestep) + '_' + str(rank) + '.txt'
+        # start checkpoint phase
+        scr.start_output(name, scr.FLAG_CHECKPOINT)
 
-    # register our checkpoint file with scr, and get path to write file from scr
-    newfname = scr.route_file(fname)
-    print("output route: ", fname, "-->", newfname)
-  
-    # write checkpoint file
-    valid = True
-    try:
-      with open(newfname, "w") as f:
-        f.write('time=' + str(timestep) + "\n")
-        f.write('rank=' + str(rank) + "\n")
-    except:
-      # failed to write file
-      valid = False
-  
-    # complete the checkpoint phase
-    rc = scr.complete_output(valid)
-    print("complete output: ", rc)
+        # define name of checkpoint file for this timestep and rank
+        fname = 'ckpt_' + str(timestep) + '_' + str(rank) + '.txt'
 
-  # break timestep loop early if scr informs us to exit
-  if scr.should_exit():
-    break
-  
-  # otherwise go on to next timestep
-  timestep += 1
+        # register our checkpoint file with scr, and get path to write file from scr
+        newfname = scr.route_file(fname)
+        print("output route: ", fname, "-->", newfname)
+
+        # write checkpoint file
+        valid = True
+        try:
+            with open(newfname, "w") as f:
+                f.write('time=' + str(timestep) + "\n")
+                f.write('rank=' + str(rank) + "\n")
+        except:
+            # failed to write file
+            valid = False
+
+        # complete the checkpoint phase
+        rc = scr.complete_output(valid)
+        print("complete output: ", rc)
+
+    # break timestep loop early if scr informs us to exit
+    if scr.should_exit():
+        break
+
+    # otherwise go on to next timestep
+    timestep += 1
 
 # shut down library and flush cached datasets
 scr.finalize()

--- a/python/scr_test.py
+++ b/python/scr_test.py
@@ -17,7 +17,8 @@ timestep = 1
 # optionally set and get SCR parameters with scr.config() before scr.init()
 val = scr.config("SCR_DEBUG")
 if test == 0: assert val is None, "SCR_DEBUG should not be set on first run"
-if test > 0:  assert val is None, "SCR_DEBUG should assume its default value even after being changed in an earlier run"
+if test > 0:
+    assert val is None, "SCR_DEBUG should assume its default value even after being changed in an earlier run"
 
 val = scr.config("SCR_DEBUG=1")
 assert val is None, "scr.config should not return a value when setting a param"
@@ -31,13 +32,13 @@ scr.config("SCR_CHECKPOINT_INTERVAL=1")
 
 # check that scr.init can throw an exception
 if test == 5:
-  scr.config("SCR_ENABLE=0")
-  try:
-    scr.init()
-    assert False, "scr.init should throw an exception if SCR_Init returns an error"
-  except:
-    # success, but nothing else we can do in this run
-    quit()
+    scr.config("SCR_ENABLE=0")
+    try:
+        scr.init()
+        assert False, "scr.init should throw an exception if SCR_Init returns an error"
+    except:
+        # success, but nothing else we can do in this run
+        quit()
 
 # initialize library, rebuild cached datasets, fetch latest checkpoint
 val = scr.init()
@@ -46,141 +47,152 @@ assert val is None, "scr.init should always return None"
 # attempt to restart from a previous checkpoint
 attempt = 0
 while True:
-  # see if we have a restart to load
-  name = scr.have_restart()
-  if test == 0: assert name is None, "Should not have a checkpoint to read on first run"
-  if test > 0:  assert type(name) is str, "scr.have_restart should return checkpoint name as a str on later runs"
-  if not name:
-    # no restart to load, give up
-    break
+    # see if we have a restart to load
+    name = scr.have_restart()
+    if test == 0:
+        assert name is None, "Should not have a checkpoint to read on first run"
+    if test > 0:
+        assert type(
+            name
+        ) is str, "scr.have_restart should return checkpoint name as a str on later runs"
+    if not name:
+        # no restart to load, give up
+        break
 
-  attempt += 1
+    attempt += 1
 
-  # got a restart to load, start restart phase and get its name
-  name = scr.start_restart()
-  assert name is not None, "Should always get a valid name after have_restart"
-  if test == 1: assert name == "timestep_2", "Should restart from timestep 2 after one run"
-  if test == 2: assert name == "timestep_4", "Should restart from timestep 4 after two runs"
-  if test == 3 and attempt == 1: assert name == "timestep_6", "Should restart from timestep 6 after three runs and first attempt"
-  if test == 3 and attempt == 2: assert name == "timestep_5", "Should restart from timestep 5 after three runs and second attempt"
-  if test == 4: assert name == "timestep_7", "Should restart from timestep 7 after four runs"
-  print("restart name: ", name)
+    # got a restart to load, start restart phase and get its name
+    name = scr.start_restart()
+    assert name is not None, "Should always get a valid name after have_restart"
+    if test == 1:
+        assert name == "timestep_2", "Should restart from timestep 2 after one run"
+    if test == 2:
+        assert name == "timestep_4", "Should restart from timestep 4 after two runs"
+    if test == 3 and attempt == 1:
+        assert name == "timestep_6", "Should restart from timestep 6 after three runs and first attempt"
+    if test == 3 and attempt == 2:
+        assert name == "timestep_5", "Should restart from timestep 5 after three runs and second attempt"
+    if test == 4:
+        assert name == "timestep_7", "Should restart from timestep 7 after four runs"
+    print("restart name: ", name)
 
-  # extract timestep value from name like "timestep_10"
-  timestep = int(name[9:])
+    # extract timestep value from name like "timestep_10"
+    timestep = int(name[9:])
 
-  # build file name for this timestep and rank
-  fname = 'ckpt_' + str(timestep) + '_' + str(rank) + '.txt'
+    # build file name for this timestep and rank
+    fname = 'ckpt_' + str(timestep) + '_' + str(rank) + '.txt'
 
-  # ask scr for path from which to read our file
-  newfname = scr.route_file(fname)
-  assert newfname is not None, "scr.route_file should return a valid filename in restart"
-  print("restart route: ", fname, "-->", newfname)
+    # ask scr for path from which to read our file
+    newfname = scr.route_file(fname)
+    assert newfname is not None, "scr.route_file should return a valid filename in restart"
+    print("restart route: ", fname, "-->", newfname)
 
-  # check that route file throws an exception for a bad file on restart
-  try:
-    scr.route_file("file_that_does_not_exist.txt")
-    assert False, "scr.route_file should throw an exception if given a file it doesn't know about"
-  except:
-    pass
+    # check that route file throws an exception for a bad file on restart
+    try:
+        scr.route_file("file_that_does_not_exist.txt")
+        assert False, "scr.route_file should throw an exception if given a file it doesn't know about"
+    except:
+        pass
 
-  # read checkpoint file
-  valid = 1
-  try:
-    with open(newfname, "r") as f:
-      data = f.readlines()
-      print(str(data))
-  except:
-    # failed to read file
-    valid = 0
+    # read checkpoint file
+    valid = 1
+    try:
+        with open(newfname, "r") as f:
+            data = f.readlines()
+            print(str(data))
+    except:
+        # failed to read file
+        valid = 0
 
-  # test: fake a bad file on rank 0 for timestep 6
-  if rank == 0 and timestep == 6:
-    valid = 0
+    # test: fake a bad file on rank 0 for timestep 6
+    if rank == 0 and timestep == 6:
+        valid = 0
 
-  # check whether everyone read their checkpoint file successfully
-  rc = scr.complete_restart(valid)
-  if timestep == 6: assert rc is False, "scr.complete_restart should return False when any rank sets valid=False"
-  if timestep != 6: assert rc is True, "scr.complete_restart should return True when all ranks set valid=True"
-  if rc:
-    # success, bump timestep to next value and break restart loop
-    timestep += 1
-    break
-  else:
-    # someone failed, loop to try another checkpoint
-    timestep = 1
+    # check whether everyone read their checkpoint file successfully
+    rc = scr.complete_restart(valid)
+    if timestep == 6:
+        assert rc is False, "scr.complete_restart should return False when any rank sets valid=False"
+    if timestep != 6:
+        assert rc is True, "scr.complete_restart should return True when all ranks set valid=True"
+    if rc:
+        # success, bump timestep to next value and break restart loop
+        timestep += 1
+        break
+    else:
+        # someone failed, loop to try another checkpoint
+        timestep = 1
 
 # call scr.complete_output without first calling scr.start_output to check that we throw an exception
 if test == 4:
-  scr.complete_output(True)
-  assert False, "The SCR library should have called MPI_Abort if complete_output is called before start_output"
+    scr.complete_output(True)
+    assert False, "The SCR library should have called MPI_Abort if complete_output is called before start_output"
 
 # work loop to execute new timesteps in the job
 laststep = timestep + 2
 while timestep < laststep:
-  #####
-  # do work ...
-  #####
+    #####
+    # do work ...
+    #####
 
-  # save checkpoint if needed
-  rc = scr.need_checkpoint()
-  assert rc is True, "scr.need_checkpoint should always return True since SCR_CHECKPOINT_INTERVAL=1"
-  if rc:
-    # define name of checkpoint to be something like "timestep_10"
-    name = 'timestep_' + str(timestep)
+    # save checkpoint if needed
+    rc = scr.need_checkpoint()
+    assert rc is True, "scr.need_checkpoint should always return True since SCR_CHECKPOINT_INTERVAL=1"
+    if rc:
+        # define name of checkpoint to be something like "timestep_10"
+        name = 'timestep_' + str(timestep)
 
-    # start checkpoint phase
-    rc = scr.start_output(name, scr.FLAG_CHECKPOINT)
-    assert rc is None, "scr.start_output should return None"
-  
-    # define name of checkpoint file for this timestep and rank
-    fname = 'ckpt_' + str(timestep) + '_' + str(rank) + '.txt'
+        # start checkpoint phase
+        rc = scr.start_output(name, scr.FLAG_CHECKPOINT)
+        assert rc is None, "scr.start_output should return None"
 
-    # register our checkpoint file with scr, and get path to write file from scr
-    newfname = scr.route_file(fname)
-    assert type(newfname) is str, "scr.route_file should return a string"
-    print("output route: ", fname, "-->", newfname)
-  
-    # write checkpoint file
-    valid = 1
-    try:
-      with open(newfname, "w") as f:
-        f.write('time=' + str(timestep) + "\n")
-        f.write('rank=' + str(rank) + "\n")
-    except:
-      # failed to write file
-      valid = 0
-  
-    # complete the checkpoint phase
-    rc = scr.complete_output(valid)
-    assert rc is True, "scr.complete_output should return True if all procs set valid=True"
-    print("complete output: ", rc)
+        # define name of checkpoint file for this timestep and rank
+        fname = 'ckpt_' + str(timestep) + '_' + str(rank) + '.txt'
 
-  # break timestep loop early if scr informs us to exit
-  rc = scr.should_exit()
-  assert type(rc) is bool, "scr.should_exit returns a bool"
-  if rc:
-    break
-  
-  # otherwise go on to next timestep
-  timestep += 1
+        # register our checkpoint file with scr, and get path to write file from scr
+        newfname = scr.route_file(fname)
+        assert type(newfname) is str, "scr.route_file should return a string"
+        print("output route: ", fname, "-->", newfname)
+
+        # write checkpoint file
+        valid = 1
+        try:
+            with open(newfname, "w") as f:
+                f.write('time=' + str(timestep) + "\n")
+                f.write('rank=' + str(rank) + "\n")
+        except:
+            # failed to write file
+            valid = 0
+
+        # complete the checkpoint phase
+        rc = scr.complete_output(valid)
+        assert rc is True, "scr.complete_output should return True if all procs set valid=True"
+        print("complete output: ", rc)
+
+    # break timestep loop early if scr informs us to exit
+    rc = scr.should_exit()
+    assert type(rc) is bool, "scr.should_exit returns a bool"
+    if rc:
+        break
+
+    # otherwise go on to next timestep
+    timestep += 1
 
 # test drop and delete
 if test == 3:
-  # test dropping a known checkpoint
-  rc = scr.drop('timestep_1')
-  assert rc is None, "Failed to drop timestep_1"
-  
-  # test dropping a known checkpoint
-  rc = scr.delete('timestep_2')
-  assert rc is None, "Failed to delete timestep_2"
+    # test dropping a known checkpoint
+    rc = scr.drop('timestep_1')
+    assert rc is None, "Failed to drop timestep_1"
 
-  # test dropping an unknown checkpoint
-  # TODO: this succeeds since SCR_Drop always succeeds
-  # it perhaps could be changed to return an error, and have python throw an exception
-  rc = scr.drop('timestep_doesnotexist')
-  assert rc is None, "Failed to drop timestep_doesnotexist"
-  
+    # test dropping a known checkpoint
+    rc = scr.delete('timestep_2')
+    assert rc is None, "Failed to delete timestep_2"
+
+    # test dropping an unknown checkpoint
+    # TODO: this succeeds since SCR_Drop always succeeds
+    # it perhaps could be changed to return an error, and have python throw an exception
+    rc = scr.drop('timestep_doesnotexist')
+    assert rc is None, "Failed to drop timestep_doesnotexist"
+
 # shut down library and flush cached datasets
 rc = scr.finalize()
 assert rc is None, "scr.finalize should return None"

--- a/python/setup.py
+++ b/python/setup.py
@@ -6,33 +6,28 @@ from distutils.core import setup
 longtext = """Python module for the SCR library (libscr.so). For usage: ``python -c 'import scr; help(scr)'``"""
 
 setup(
-  name='scr',
-  version='3.0',
-
-  author='LLNL',
-  author_email='moody20@llnl.gov',
-
-  url='https://github.com/llnl/scr',
-  description='Scalable Checkpoint / Restart (SCR) Library',
-  long_description=longtext,
-#  long_description_content_type='text/markdown',
-  keywords='scalable, checkpoint, restart, mpi, scr',
-
-  py_modules=['scr'],
-#  install_requires=['cffi'],
-  platforms=['posix'],
-
-  license='BSD 3-clause + addendum',
-  classifiers=[
-    # How mature is this project? Common values are
-    #   3 - Alpha
-    #   4 - Beta
-    #   5 - Production/Stable
-    'Development Status :: 4 - Beta',
-
-    'License :: OSI Approved :: BSD License',
-    'Operating System :: POSIX :: Linux',
-    'Programming Language :: Python :: 2',
-    'Programming Language :: Python :: 3',
-  ],
+    name='scr',
+    version='3.0',
+    author='LLNL',
+    author_email='moody20@llnl.gov',
+    url='https://github.com/llnl/scr',
+    description='Scalable Checkpoint / Restart (SCR) Library',
+    long_description=longtext,
+    #  long_description_content_type='text/markdown',
+    keywords='scalable, checkpoint, restart, mpi, scr',
+    py_modules=['scr'],
+    #  install_requires=['cffi'],
+    platforms=['posix'],
+    license='BSD 3-clause + addendum',
+    classifiers=[
+        # How mature is this project? Common values are
+        #   3 - Alpha
+        #   4 - Beta
+        #   5 - Production/Stable
+        'Development Status :: 4 - Beta',
+        'License :: OSI Approved :: BSD License',
+        'Operating System :: POSIX :: Linux',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 3',
+    ],
 )

--- a/scripts/python/scrjob/cli/scr_flush_file.py
+++ b/scripts/python/scrjob/cli/scr_flush_file.py
@@ -8,58 +8,71 @@ from scrjob.scr_common import choose_bindir
 
 
 class SCRFlushFile:
-  def __init__(self, prefix, verbose=False):
-    self.bindir = choose_bindir()
-    self.prefix = prefix  # path to SCR_PREFIX
-    self.verbose = verbose
-    self.exe = os.path.join(self.bindir, "scr_flush_file") + " --dir " + str(prefix)
 
-  # return list of output datasets
-  def list_dsets_output(self):
-    dsets, rc = runproc(self.exe + " --list-output", getstdout=True, verbose=self.verbose)
-    if rc == 0:
-      return dsets.split()
-    return []
+    def __init__(self, prefix, verbose=False):
+        self.bindir = choose_bindir()
+        self.prefix = prefix  # path to SCR_PREFIX
+        self.verbose = verbose
+        self.exe = os.path.join(self.bindir,
+                                "scr_flush_file") + " --dir " + str(prefix)
 
-  # return list of checkpoints
-  def list_dsets_ckpt(self, before=None):
-    cmd = self.exe + " --list-ckpt"
-    if before:
-      cmd = cmd + " --before " + str(before)
-    dsets, rc = runproc(cmd, getstdout=True, verbose=self.verbose)
-    if rc == 0:
-      return dsets.split()
-    return []
+    # return list of output datasets
+    def list_dsets_output(self):
+        dsets, rc = runproc(self.exe + " --list-output",
+                            getstdout=True,
+                            verbose=self.verbose)
+        if rc == 0:
+            return dsets.split()
+        return []
 
-  # determine whether this dataset needs to be flushed
-  def need_flush(self, d):
-    rc = runproc(self.exe + " --need-flush " + str(d), verbose=self.verbose)[1]
-    return (rc == 0)
+    # return list of checkpoints
+    def list_dsets_ckpt(self, before=None):
+        cmd = self.exe + " --list-ckpt"
+        if before:
+            cmd = cmd + " --before " + str(before)
+        dsets, rc = runproc(cmd, getstdout=True, verbose=self.verbose)
+        if rc == 0:
+            return dsets.split()
+        return []
 
-  # return name of specified dataset
-  def name(self, d):
-    name, rc = runproc(self.exe + " --name " + str(d), getstdout=True, verbose=self.verbose)
-    if rc == 0:
-      return name.rstrip()
+    # determine whether this dataset needs to be flushed
+    def need_flush(self, d):
+        rc = runproc(self.exe + " --need-flush " + str(d),
+                     verbose=self.verbose)[1]
+        return (rc == 0)
 
-  # return the latest dataset id, or None
-  def latest(self):
-    dset, rc = runproc(self.exe + " --latest", getstdout=True, verbose=self.verbose)
-    if rc == 0:
-      return dset.rstrip()
+    # return name of specified dataset
+    def name(self, d):
+        name, rc = runproc(self.exe + " --name " + str(d),
+                           getstdout=True,
+                           verbose=self.verbose)
+        if rc == 0:
+            return name.rstrip()
 
-  # return the location string for the given dataset id
-  def location(self, d):
-    dset, rc = runproc(self.exe + " --location " + str(d), getstdout=True, verbose=self.verbose)
-    if rc == 0:
-      return dset.rstrip()
+    # return the latest dataset id, or None
+    def latest(self):
+        dset, rc = runproc(self.exe + " --latest",
+                           getstdout=True,
+                           verbose=self.verbose)
+        if rc == 0:
+            return dset.rstrip()
 
-  # resume a transfer of specified dataset id, used in poststage
-  def resume(self, d):
-    dset, rc = runproc(self.exe + " --resume --name " + str(d), verbose=self.verbose)[1]
-    return (rc == 0)
+    # return the location string for the given dataset id
+    def location(self, d):
+        dset, rc = runproc(self.exe + " --location " + str(d),
+                           getstdout=True,
+                           verbose=self.verbose)
+        if rc == 0:
+            return dset.rstrip()
 
-  # create summary file for specified dataset id, used in prestage
-  def write_summary(self, d):
-    dset, rc = runproc(self.exe + " --summary --name " + str(d), verbose=self.verbose)[1]
-    return (rc == 0)
+    # resume a transfer of specified dataset id, used in poststage
+    def resume(self, d):
+        dset, rc = runproc(self.exe + " --resume --name " + str(d),
+                           verbose=self.verbose)[1]
+        return (rc == 0)
+
+    # create summary file for specified dataset id, used in prestage
+    def write_summary(self, d):
+        dset, rc = runproc(self.exe + " --summary --name " + str(d),
+                           verbose=self.verbose)[1]
+        return (rc == 0)

--- a/scripts/python/scrjob/cli/scr_index.py
+++ b/scripts/python/scrjob/cli/scr_index.py
@@ -8,29 +8,35 @@ from scrjob.scr_common import choose_bindir
 
 
 class SCRIndex:
-  def __init__(self, prefix, verbose=False):
-    self.bindir = choose_bindir()
-    self.prefix = prefix  # path to SCR_PREFIX
-    self.verbose = verbose
-    self.exe = os.path.join(self.bindir, "scr_index") + " --prefix " + str(prefix)
 
-  # capture and return verbatim output from the --list command
-  def list(self):
-    output, rc = runproc(self.exe + " --list", getstdout=True, verbose=self.verbose)
-    if rc == 0:
-      return output
+    def __init__(self, prefix, verbose=False):
+        self.bindir = choose_bindir()
+        self.prefix = prefix  # path to SCR_PREFIX
+        self.verbose = verbose
+        self.exe = os.path.join(self.bindir,
+                                "scr_index") + " --prefix " + str(prefix)
 
-  # make named dataset as current
-  def current(self, name):
-    rc = runproc(self.exe + " --current " + str(name), verbose=self.verbose)[1]
-    return (rc == 0)
+    # capture and return verbatim output from the --list command
+    def list(self):
+        output, rc = runproc(self.exe + " --list",
+                             getstdout=True,
+                             verbose=self.verbose)
+        if rc == 0:
+            return output
 
-  # add dataset to index file (must already exist)
-  def add(self, dset):
-    rc = runproc(self.exe + " --add " + str(dset), verbose=self.verbose)[1]
-    return (rc == 0)
+    # make named dataset as current
+    def current(self, name):
+        rc = runproc(self.exe + " --current " + str(name),
+                     verbose=self.verbose)[1]
+        return (rc == 0)
 
-  # run build command to inspect and rebuild dataset files
-  def build(self, dset):
-    rc = runproc(self.exe + " --build " + str(dset), verbose=self.verbose)[1]
-    return (rc == 0)
+    # add dataset to index file (must already exist)
+    def add(self, dset):
+        rc = runproc(self.exe + " --add " + str(dset), verbose=self.verbose)[1]
+        return (rc == 0)
+
+    # run build command to inspect and rebuild dataset files
+    def build(self, dset):
+        rc = runproc(self.exe + " --build " + str(dset),
+                     verbose=self.verbose)[1]
+        return (rc == 0)

--- a/scripts/python/scrjob/cli/scr_log.py
+++ b/scripts/python/scrjob/cli/scr_log.py
@@ -8,57 +8,64 @@ from scrjob.scr_common import choose_bindir
 
 
 class SCRLog:
-  def __init__(self, prefix, jobid, jobname=None, user=None, jobstart=None, verbose=False):
-    self.bindir = choose_bindir()
-    self.prefix = prefix  # path to SCR_PREFIX
-    self.user = user
-    self.jobid = jobid
-    self.jobname = jobname
-    self.jobstart = jobstart
-    self.verbose = verbose
 
-    self.exe_event = os.path.join(self.bindir, "scr_log_event")
-    self.eve_transfer = os.path.join(self.bindir, "scr_log_transfer")
+    def __init__(self,
+                 prefix,
+                 jobid,
+                 jobname=None,
+                 user=None,
+                 jobstart=None,
+                 verbose=False):
+        self.bindir = choose_bindir()
+        self.prefix = prefix  # path to SCR_PREFIX
+        self.user = user
+        self.jobid = jobid
+        self.jobname = jobname
+        self.jobstart = jobstart
+        self.verbose = verbose
 
-  # return list of output datasets
-  def event(self,
-            event_type,
-            dset=None,
-            name=None,
-            start=None,
-            secs=None,
-            note=None):
-    argv = [self.exe_event, '-p', self.prefix]
+        self.exe_event = os.path.join(self.bindir, "scr_log_event")
+        self.eve_transfer = os.path.join(self.bindir, "scr_log_transfer")
 
-    if self.user is not None:
-      argv.extend(['-u', str(self.user)])
+    # return list of output datasets
+    def event(self,
+              event_type,
+              dset=None,
+              name=None,
+              start=None,
+              secs=None,
+              note=None):
+        argv = [self.exe_event, '-p', self.prefix]
 
-    if self.jobid is not None:
-      argv.extend(['-i', str(self.jobid)])
+        if self.user is not None:
+            argv.extend(['-u', str(self.user)])
 
-    if self.jobname is not None:
-      argv.extend(['-j', str(self.jobname)])
+        if self.jobid is not None:
+            argv.extend(['-i', str(self.jobid)])
 
-    if self.jobstart is not None:
-      argv.extend(['-s', str(self.jobstart)])
+        if self.jobname is not None:
+            argv.extend(['-j', str(self.jobname)])
 
-    if event_type is not None:
-      argv.extend(['-T', str(event_type)])
+        if self.jobstart is not None:
+            argv.extend(['-s', str(self.jobstart)])
 
-    if dset is not None:
-      argv.extend(['-D', str(dset)])
+        if event_type is not None:
+            argv.extend(['-T', str(event_type)])
 
-    if name is not None:
-      argv.extend(['-n', str(name)])
+        if dset is not None:
+            argv.extend(['-D', str(dset)])
 
-    if start is not None:
-      argv.extend(['-S', str(start)])
+        if name is not None:
+            argv.extend(['-n', str(name)])
 
-    if secs is not None:
-      argv.extend(['-L', str(secs)])
+        if start is not None:
+            argv.extend(['-S', str(start)])
 
-    if note is not None:
-      argv.extend(['-N', str(note)])
+        if secs is not None:
+            argv.extend(['-L', str(secs)])
 
-    rc = runproc(argv, verbose=self.verbose)[1]
-    return (rc == 0)
+        if note is not None:
+            argv.extend(['-N', str(note)])
+
+        rc = runproc(argv, verbose=self.verbose)[1]
+        return (rc == 0)

--- a/scripts/python/scrjob/launchers/aprun.py
+++ b/scripts/python/scrjob/launchers/aprun.py
@@ -11,104 +11,106 @@ from scrjob.scr_common import runproc, pipeproc
 
 
 class APRUN(JobLauncher):
-  def __init__(self, launcher='aprun'):
-    super(APRUN, self).__init__(launcher=launcher)
 
-  # a command to run immediately before prerun is ran
-  # NOP srun to force every node to run prolog to delete files from cache
-  # TODO: remove this if admins find a better place to clear cache
-  def prepareforprerun(self):
-    # NOP aprun to force every node to run prolog to delete files from cache
+    def __init__(self, launcher='aprun'):
+        super(APRUN, self).__init__(launcher=launcher)
+
+    # a command to run immediately before prerun is ran
+    # NOP srun to force every node to run prolog to delete files from cache
     # TODO: remove this if admins find a better place to clear cache
-    argv = ['aprun', '/bin/hostname']  # ,'>','/dev/null']
-    runproc(argv=argv)
+    def prepareforprerun(self):
+        # NOP aprun to force every node to run prolog to delete files from cache
+        # TODO: remove this if admins find a better place to clear cache
+        argv = ['aprun', '/bin/hostname']  # ,'>','/dev/null']
+        runproc(argv=argv)
 
-  # returns the process and PID of the launched process
-  # as returned by runproc(argv=argv, wait=False)
-  def launchruncmd(self, up_nodes='', down_nodes='', launcher_args=[]):
-    if type(launcher_args) is str:
-      launcher_args = launcher_args.split()
-    # ap run needs to specify nodes to use
-    if len(launcher_args) == 0 or len(up_nodes) == 0:
-      return None, -1
-    argv = [self.launcher]
-    argv.extend(['-L', up_nodes])
-    argv.extend(launcher_args)
-    ### TODO: #ensure the Popen.terminate() works here too.
-    if scr_const.USE_JOBLAUNCHER_KILL != '1':
-      return runproc(argv=argv, wait=False)
-    proc = runproc(argv=argv, wait=False)[0]
-    jobstepid = self.get_jobstep_id(pid = proc.pid)
-    if jobstepid is not None:
-      return proc, jobstepid
-    else:
-      return proc, proc
+    # returns the process and PID of the launched process
+    # as returned by runproc(argv=argv, wait=False)
+    def launchruncmd(self, up_nodes='', down_nodes='', launcher_args=[]):
+        if type(launcher_args) is str:
+            launcher_args = launcher_args.split()
+        # ap run needs to specify nodes to use
+        if len(launcher_args) == 0 or len(up_nodes) == 0:
+            return None, -1
+        argv = [self.launcher]
+        argv.extend(['-L', up_nodes])
+        argv.extend(launcher_args)
+        ### TODO: #ensure the Popen.terminate() works here too.
+        if scr_const.USE_JOBLAUNCHER_KILL != '1':
+            return runproc(argv=argv, wait=False)
+        proc = runproc(argv=argv, wait=False)[0]
+        jobstepid = self.get_jobstep_id(pid=proc.pid)
+        if jobstepid is not None:
+            return proc, jobstepid
+        else:
+            return proc, proc
 
-  # perform a generic pdsh / clustershell command
-  # returns [ [ stdout, stderr ] , returncode ]
-  def parallel_exec(self, argv=[], runnodes=''):
-    if len(argv) == 0:
-      return [['', ''], 0]
-    if self.clustershell_task != False:
-      return self.clustershell_exec(argv=argv,
-                                    runnodes=runnodes)
-    pdshcmd = [scr_const.PDSH_EXE, '-Rexec', '-f', '256', '-S', '-w', runnodes]
-    pdshcmd.extend(argv)
-    return runproc(argv=pdshcmd, getstdout=True, getstderr=True)
+    # perform a generic pdsh / clustershell command
+    # returns [ [ stdout, stderr ] , returncode ]
+    def parallel_exec(self, argv=[], runnodes=''):
+        if len(argv) == 0:
+            return [['', ''], 0]
+        if self.clustershell_task != False:
+            return self.clustershell_exec(argv=argv, runnodes=runnodes)
+        pdshcmd = [
+            scr_const.PDSH_EXE, '-Rexec', '-f', '256', '-S', '-w', runnodes
+        ]
+        pdshcmd.extend(argv)
+        return runproc(argv=pdshcmd, getstdout=True, getstderr=True)
 
-  # perform the scavenge files operation for scr_scavenge
-  # uses either pdsh or clustershell
-  # returns a list -> [ 'stdout', 'stderr' ]
-  def scavenge_files(self,
-                     prog='',
-                     upnodes='',
-                     downnodes_spaced='',
-                     cntldir='',
-                     dataset_id='',
-                     prefixdir='',
-                     buf_size='',
-                     crc_flag=''):
-    argv = [
-        'aprun', '-n', '1', 'L', '%h', prog, '--cntldir', cntldir, '--id',
-        dataset_id, '--prefix', prefixdir, '--buf', buf_size, crc_flag
-    ]
-    argv.append(downnodes_spaced)
-    output = self.parallel_exec(argv=argv, runnodes=upnodes)[0]
-    return output
+    # perform the scavenge files operation for scr_scavenge
+    # uses either pdsh or clustershell
+    # returns a list -> [ 'stdout', 'stderr' ]
+    def scavenge_files(self,
+                       prog='',
+                       upnodes='',
+                       downnodes_spaced='',
+                       cntldir='',
+                       dataset_id='',
+                       prefixdir='',
+                       buf_size='',
+                       crc_flag=''):
+        argv = [
+            'aprun', '-n', '1', 'L', '%h', prog, '--cntldir', cntldir, '--id',
+            dataset_id, '--prefix', prefixdir, '--buf', buf_size, crc_flag
+        ]
+        argv.append(downnodes_spaced)
+        output = self.parallel_exec(argv=argv, runnodes=upnodes)[0]
+        return output
 
-  def get_jobstep_id(self, pid=-1):
-    # allow launched job to show in apstat
-    sleep(10)
-    output = runproc(['apstat', '-avv'], getstdout=True)[0].split('\n')
-    nid = None
-    try:
-      with open('/proc/cray_xt/nid', 'r') as NIDfile:
-        nid = NIDfile.read()[:-1]
-    except:
-      return None
-    pid = str(pid)
-    currApid = None
-    for line in output:
-      line = line.strip()
-      fields = re.split('\s+', line)
-      if len(fields) < 8:
-        continue
-      if fields[0].startswith('Ap'):
-        currApid = fields[2][:-1]
-      elif fields[1].startswith('Originator:'):
-        #did we find the apid that corresponds to the pid?
-        # also check to see if it was launched from this MOM node in case two
-        # happen to have the same pid
-        thisnid = fields[5][:-1]
-        if thisnid == nid and fields[7] == pid:
-          break
+    def get_jobstep_id(self, pid=-1):
+        # allow launched job to show in apstat
+        sleep(10)
+        output = runproc(['apstat', '-avv'], getstdout=True)[0].split('\n')
+        nid = None
+        try:
+            with open('/proc/cray_xt/nid', 'r') as NIDfile:
+                nid = NIDfile.read()[:-1]
+        except:
+            return None
+        pid = str(pid)
         currApid = None
-    return currApid
+        for line in output:
+            line = line.strip()
+            fields = re.split('\s+', line)
+            if len(fields) < 8:
+                continue
+            if fields[0].startswith('Ap'):
+                currApid = fields[2][:-1]
+            elif fields[1].startswith('Originator:'):
+                #did we find the apid that corresponds to the pid?
+                # also check to see if it was launched from this MOM node in case two
+                # happen to have the same pid
+                thisnid = fields[5][:-1]
+                if thisnid == nid and fields[7] == pid:
+                    break
+                currApid = None
+        return currApid
 
-  # Only use akill to kill the jobstep if desired and get_jobstep_id was successful
-  def scr_kill_jobstep(self, jobstep=None):
-    # it looks like the Popen.terminate is working with srun
-    if type(jobstep) is str:
-      runproc(argv=['apkill', jobstep])
-    else:
-      super().scr_kill_jobstep(jobstep)
+    # Only use akill to kill the jobstep if desired and get_jobstep_id was successful
+    def scr_kill_jobstep(self, jobstep=None):
+        # it looks like the Popen.terminate is working with srun
+        if type(jobstep) is str:
+            runproc(argv=['apkill', jobstep])
+        else:
+            super().scr_kill_jobstep(jobstep)

--- a/scripts/python/scrjob/launchers/auto.py
+++ b/scripts/python/scrjob/launchers/auto.py
@@ -21,27 +21,28 @@ from scrjob.launchers import (
 
 
 class AutoJobLauncher:
-  def __new__(cls, launcher=None):
-    if launcher == 'srun':
-      return SRUN()
-    if launcher == 'jsrun':
-      return JSRUN()
-    if launcher == 'mpirun':
-      return MPIRUN()
-    if launcher == 'lrun':
-      return LRUN()
-    if launcher == 'aprun':
-      return APRUN()
-    if launcher == 'flux':
-      return FLUX()
-    return JobLauncher()
+
+    def __new__(cls, launcher=None):
+        if launcher == 'srun':
+            return SRUN()
+        if launcher == 'jsrun':
+            return JSRUN()
+        if launcher == 'mpirun':
+            return MPIRUN()
+        if launcher == 'lrun':
+            return LRUN()
+        if launcher == 'aprun':
+            return APRUN()
+        if launcher == 'flux':
+            return FLUX()
+        return JobLauncher()
 
 
 if __name__ == '__main__':
-  joblauncher = AutoJobLauncher()
-  #joblauncher = AutoJobLauncher(launcher='srun')
-  #joblauncher = AutoJobLauncher(launcher='jsrun')
-  #joblauncher = AutoJobLauncher(launcher='mpirun')
-  #joblauncher = AutoJobLauncher(launcher='lrun')
-  #joblauncher = AutoJobLauncher(launcher='aprun')
-  print(type(joblauncher))
+    joblauncher = AutoJobLauncher()
+    #joblauncher = AutoJobLauncher(launcher='srun')
+    #joblauncher = AutoJobLauncher(launcher='jsrun')
+    #joblauncher = AutoJobLauncher(launcher='mpirun')
+    #joblauncher = AutoJobLauncher(launcher='lrun')
+    #joblauncher = AutoJobLauncher(launcher='aprun')
+    print(type(joblauncher))

--- a/scripts/python/scrjob/launchers/flux.py
+++ b/scripts/python/scrjob/launchers/flux.py
@@ -9,156 +9,157 @@ from scrjob.scr_glob_hosts import scr_glob_hosts
 
 # flux imports
 try:
-  import flux
-  #import json
-  from flux.job import JobspecV1
-  from flux.job.JobID import JobID
-  from flux.resource import ResourceSet
-  from flux.rpc import RPC
+    import flux
+    #import json
+    from flux.job import JobspecV1
+    from flux.job.JobID import JobID
+    from flux.resource import ResourceSet
+    from flux.rpc import RPC
 except:
-  pass
+    pass
 
 
 class FLUX(JobLauncher):
-  def __init__(self, launcher='flux'):
-    super(FLUX, self).__init__(launcher=launcher)
-    # connect to the running Flux instance
-    try:
-      self.flux = flux.Flux()
-    except:
-      raise ImportError('Error importing flux, ensure that the flux daemon is running.')
 
-  def waitonprocess(self, proc, timeout=None):
-    try:
-      future = flux.job.wait_async(self.flux, proc)
-      if timeout is None:
-        (jobid, success, errstr) = future.get_status()
-      else:
-        (jobid, success, errstr) = future.wait_for(int(timeout))
-        # TODO: verify return values of wait_for()
-    except TimeoutError:
-      # The process is still running, the timeout expired
-      return False, None
-    except Exception as e:
-      # it can also throw an exception if there is no job to wait for
-      print(e)
-      return False, None
+    def __init__(self, launcher='flux'):
+        super(FLUX, self).__init__(launcher=launcher)
+        # connect to the running Flux instance
+        try:
+            self.flux = flux.Flux()
+        except:
+            raise ImportError(
+                'Error importing flux, ensure that the flux daemon is running.'
+            )
 
-    if success == False:
-        print(f'flux job {proc} failed: {errstr}')
-    return True, success
+    def waitonprocess(self, proc, timeout=None):
+        try:
+            future = flux.job.wait_async(self.flux, proc)
+            if timeout is None:
+                (jobid, success, errstr) = future.get_status()
+            else:
+                (jobid, success, errstr) = future.wait_for(int(timeout))
+                # TODO: verify return values of wait_for()
+        except TimeoutError:
+            # The process is still running, the timeout expired
+            return False, None
+        except Exception as e:
+            # it can also throw an exception if there is no job to wait for
+            print(e)
+            return False, None
 
-  def launchruncmd(self, up_nodes='', down_nodes='', launcher_args=[]):
-    if type(launcher_args) is str:
-      launcher_args = launcher_args.split(' ')
-    if len(launcher_args) == 0:
-      return None, None
-    argv = [self.launcher]
-    argv.extend(launcher_args)
+        if success == False:
+            print(f'flux job {proc} failed: {errstr}')
+        return True, success
 
-    ### TODO: figure out how to exclude down_nodes
+    def launchruncmd(self, up_nodes='', down_nodes='', launcher_args=[]):
+        if type(launcher_args) is str:
+            launcher_args = launcher_args.split(' ')
+        if len(launcher_args) == 0:
+            return None, None
+        argv = [self.launcher]
+        argv.extend(launcher_args)
 
-    # A jobspec is a yaml description of job and its resource requirements.
-    # Building one lets us submit the job and get back the assigned jobid.
-    argv.insert(2, '--dry-run')
-    compute_jobreq, exitcode = runproc(argv=argv, getstdout=True)
-    if compute_jobreq == None:
-        return None, None
+        ### TODO: figure out how to exclude down_nodes
 
-    # waitable=True is required by the call to wait_async() in waitonprocess()
-    jobid = flux.job.submit(self.flux,
-                          compute_jobreq,
-                          waitable=True)
-    return jobid, jobid
+        # A jobspec is a yaml description of job and its resource requirements.
+        # Building one lets us submit the job and get back the assigned jobid.
+        argv.insert(2, '--dry-run')
+        compute_jobreq, exitcode = runproc(argv=argv, getstdout=True)
+        if compute_jobreq == None:
+            return None, None
 
-  def parallel_exec(self, argv=[], runnodes=''):
-    if type(argv) is str:
-      argv = argv.split(' ')
-    nnodes, ntasks, ncores, argv = self.parsefluxargs(argv)
-    ### Need to determine number of nodes to set nnodes and nntasks to N
-    ### without specifying it is set above to just launch 1 task on 1 cpu on 1 node
-    ### glob_hosts defaults to scr_hostlist.expand(hosts)
-    ###  passing in the resmgr would allow use of ClusterShell.NodeSet
-    ### The size is the number of ranks flux start was launched with
-    resp = RPC(self.flux, 'resource.status').get()
-    rset = ResourceSet(resp['R'])
-    nnodes = rset.nnodes
-    ntasks = nnodes
-    compute_jobreq = JobspecV1.from_command(
-        command=argv, num_tasks=ntasks, num_nodes=nnodes, cores_per_task=ncores)
-    ### create a yaml 'file' stream from a string to get JobspecV1.from_yaml_stream()
-    #   This may allow to explicitly specify the nodes to run on
-    # string = 'yaml spec'
-    # stream = io.StringIO(string)
-    # compute_jobreq = JobspecV1.from_yaml_stream(stream)
-    compute_jobreq.cwd = os.getcwd()
-    compute_jobreq.environment = dict(os.environ)
-    compute_jobreq.setattr_shell_option("output.stdout.label", True)
-    compute_jobreq.setattr_shell_option("output.stderr.label", True)
-    prefix = scr_prefix()
-    timestamp = str(time())
-    # time will return posix timestamp like -> '1628179160.1724932'
-    # some unique filename to send stdout/stderr to
-    ### the script prepends the rank to stdout, not stderr.
-    outfilename = 'out' + timestamp
-    errfilename = 'err' + timestamp
-    outfilename = os.path.join(prefix, outfilename)
-    errfilename = os.path.join(prefix, errfilename)
-    # all tasks will write their stdout to this file
-    compute_jobreq.stdout = outfilename
-    compute_jobreq.stderr = errfilename
-    job = flux.job.submit(self.flux,
-                          compute_jobreq,
-                          waitable=True)
-    # get the hostlist to swap ranks for hosts
-    nodelist = rset.nodelist
-    future = flux.job.wait_async(self.flux, job)
-    status = future.get_status()
-    ret = [['', ''], 0]
-    # don't fail if can't open a file, just leave output blank
-    try:
-      with open(outfilename,'r') as infile:
-        lines = infile.readlines()
-        for line in lines:
-          try:
-            rank = re.search('\d', line)
-            host = nodelist[int(rank[0])]
-            line = host + line[line.find(':'):]
-          except:
+        # waitable=True is required by the call to wait_async() in waitonprocess()
+        jobid = flux.job.submit(self.flux, compute_jobreq, waitable=True)
+        return jobid, jobid
+
+    def parallel_exec(self, argv=[], runnodes=''):
+        if type(argv) is str:
+            argv = argv.split(' ')
+        nnodes, ntasks, ncores, argv = self.parsefluxargs(argv)
+        ### Need to determine number of nodes to set nnodes and nntasks to N
+        ### without specifying it is set above to just launch 1 task on 1 cpu on 1 node
+        ### glob_hosts defaults to scr_hostlist.expand(hosts)
+        ###  passing in the resmgr would allow use of ClusterShell.NodeSet
+        ### The size is the number of ranks flux start was launched with
+        resp = RPC(self.flux, 'resource.status').get()
+        rset = ResourceSet(resp['R'])
+        nnodes = rset.nnodes
+        ntasks = nnodes
+        compute_jobreq = JobspecV1.from_command(command=argv,
+                                                num_tasks=ntasks,
+                                                num_nodes=nnodes,
+                                                cores_per_task=ncores)
+        ### create a yaml 'file' stream from a string to get JobspecV1.from_yaml_stream()
+        #   This may allow to explicitly specify the nodes to run on
+        # string = 'yaml spec'
+        # stream = io.StringIO(string)
+        # compute_jobreq = JobspecV1.from_yaml_stream(stream)
+        compute_jobreq.cwd = os.getcwd()
+        compute_jobreq.environment = dict(os.environ)
+        compute_jobreq.setattr_shell_option("output.stdout.label", True)
+        compute_jobreq.setattr_shell_option("output.stderr.label", True)
+        prefix = scr_prefix()
+        timestamp = str(time())
+        # time will return posix timestamp like -> '1628179160.1724932'
+        # some unique filename to send stdout/stderr to
+        ### the script prepends the rank to stdout, not stderr.
+        outfilename = 'out' + timestamp
+        errfilename = 'err' + timestamp
+        outfilename = os.path.join(prefix, outfilename)
+        errfilename = os.path.join(prefix, errfilename)
+        # all tasks will write their stdout to this file
+        compute_jobreq.stdout = outfilename
+        compute_jobreq.stderr = errfilename
+        job = flux.job.submit(self.flux, compute_jobreq, waitable=True)
+        # get the hostlist to swap ranks for hosts
+        nodelist = rset.nodelist
+        future = flux.job.wait_async(self.flux, job)
+        status = future.get_status()
+        ret = [['', ''], 0]
+        # don't fail if can't open a file, just leave output blank
+        try:
+            with open(outfilename, 'r') as infile:
+                lines = infile.readlines()
+                for line in lines:
+                    try:
+                        rank = re.search('\d', line)
+                        host = nodelist[int(rank[0])]
+                        line = host + line[line.find(':'):]
+                    except:
+                        pass
+                    ret[0][0] += line
+            os.remove(outfilename)
+        except:
             pass
-          ret[0][0] += line
-      os.remove(outfilename)
-    except:
-      pass
-    try:
-      with open(errfilename,'r') as infile:
-        lines = infile.readlines()
-        for line in lines:
-          try:
-            rank = re.search('\d', line)
-            host = nodelist[int(rank[0])]
-            line = host + line[line.find(':'):]
-          except:
+        try:
+            with open(errfilename, 'r') as infile:
+                lines = infile.readlines()
+                for line in lines:
+                    try:
+                        rank = re.search('\d', line)
+                        host = nodelist[int(rank[0])]
+                        line = host + line[line.find(':'):]
+                    except:
+                        pass
+                    ret[0][1] += line
+        except:
+            try:
+                ret[0][1] = status.errstr.decode('UTF-8')
+            except:
+                pass
+        # stderr set in a nested try, remove the errfile here
+        try:
+            os.remove(errfilename)
+        except:
             pass
-          ret[0][1] += line
-    except:
-      try:
-        ret[0][1] = status.errstr.decode('UTF-8')
-      except:
-        pass
-    # stderr set in a nested try, remove the errfile here
-    try:
-      os.remove(errfilename)
-    except:
-      pass
-    ret[1] = 0 if status.success == True else 1
-    return ret
+        ret[1] = 0 if status.success == True else 1
+        return ret
 
-  def scr_kill_jobstep(self, jobstep=None):
-    if jobstep is not None:
-      try:
-        flux.job.cancel(self.flux, jobstep)
-        flux.job.wait_async(self.flux, jobstep)
-      except Exception:
-        # we could get 'invalid jobstep id' when the job has already terminated
-        pass
+    def scr_kill_jobstep(self, jobstep=None):
+        if jobstep is not None:
+            try:
+                flux.job.cancel(self.flux, jobstep)
+                flux.job.wait_async(self.flux, jobstep)
+            except Exception:
+                # we could get 'invalid jobstep id' when the job has already terminated
+                pass

--- a/scripts/python/scrjob/launchers/joblauncher.py
+++ b/scripts/python/scrjob/launchers/joblauncher.py
@@ -4,8 +4,9 @@ from subprocess import TimeoutExpired
 from scrjob import scr_const
 from scrjob.scr_common import interpolate_variables
 
+
 class JobLauncher(object):
-  """JobLauncher is the super class for the job launcher family
+    """JobLauncher is the super class for the job launcher family
 
   Methods
   -------
@@ -43,23 +44,23 @@ class JobLauncher(object):
                       a launcher can use clustershell_exec() rather than parallel_exec().
   """
 
-  def __init__(self, launcher=''):
-    """Base class initialization
+    def __init__(self, launcher=''):
+        """Base class initialization
 
     Call super().__init__() in derived launchers.
     """
-    self.launcher = launcher
-    self.hostfile = ''
-    self.clustershell_task = False
-    if scr_const.USE_CLUSTERSHELL != '0':
-      try:
-        import ClusterShell.Task as MyCSTask
-        self.clustershell_task = MyCSTask
-      except:
-        pass
+        self.launcher = launcher
+        self.hostfile = ''
+        self.clustershell_task = False
+        if scr_const.USE_CLUSTERSHELL != '0':
+            try:
+                import ClusterShell.Task as MyCSTask
+                self.clustershell_task = MyCSTask
+            except:
+                pass
 
-  def waitonprocess(self, proc=None, timeout=None):
-    """This method is called after a jobstep is launched with the return values of launchruncmd
+    def waitonprocess(self, proc=None, timeout=None):
+        """This method is called after a jobstep is launched with the return values of launchruncmd
 
     The base class method may be used when launchruncmd returns runproc(argv=argv,wait=False).
     Override this implementation in any base class whose launchruncmd returns a different value,
@@ -79,27 +80,28 @@ class JobLauncher(object):
            True -  the process exited 0
            False - the process failed (exit code nonzero)
     """
-    if proc is not None:
-      try:
-        proc.communicate(timeout=timeout)
-      except TimeoutExpired:
-        return (False, None)
-      except e:
-        print(f'waitonprocess for proc {proc} failed with exception {e}')
-        return (None, None)
+        if proc is not None:
+            try:
+                proc.communicate(timeout=timeout)
+            except TimeoutExpired:
+                return (False, None)
+            except e:
+                print(
+                    f'waitonprocess for proc {proc} failed with exception {e}')
+                return (None, None)
 
-    return (True, proc.returncode)
+        return (True, proc.returncode)
 
-  def prepareforprerun(self):
-    """This method is called (without arguments) before scr_prerun.py
+    def prepareforprerun(self):
+        """This method is called (without arguments) before scr_prerun.py
 
     Any necessary preamble work can be inserted into this method.
     This method does nothing by default and may be overridden as needed.
     """
-    pass
+        pass
 
-  def launchruncmd(self, up_nodes='', down_nodes='', launcher_args=[]):
-    """This method is called to launch a jobstep
+    def launchruncmd(self, up_nodes='', down_nodes='', launcher_args=[]):
+        """This method is called to launch a jobstep
 
     This method must be overridden.
     Launch a jobstep specified by launcher_args using up_nodes and down_nodes.
@@ -113,15 +115,15 @@ class JobLauncher(object):
         The first return value is used as the argument for waiting on the process in launcher.waitonprocess().
         The second return value is used as the argument to kill a jobstep in launcher.scr_kill_jobstep().
     """
-    return None, None
+        return None, None
 
-  #####
-  # https://clustershell.readthedocs.io/en/latest/api/Task.html
-  # clustershell exec can be called from any sub-resource manager
-  # the sub-resource manager is responsible for ensuring clustershell is available
-  ### TODO: different ssh programs may need different parameters added to remove the 'tput: ' from the output
-  def clustershell_exec(self, argv=[], runnodes=''):
-    """This method implements the functionality of parallel_exec using clustershell
+    #####
+    # https://clustershell.readthedocs.io/en/latest/api/Task.html
+    # clustershell exec can be called from any sub-resource manager
+    # the sub-resource manager is responsible for ensuring clustershell is available
+    ### TODO: different ssh programs may need different parameters added to remove the 'tput: ' from the output
+    def clustershell_exec(self, argv=[], runnodes=''):
+        """This method implements the functionality of parallel_exec using clustershell
 
     This method may be called from a launcher's parallel_exec if self.clustershell_task is not False.
     if self.clustershell_task is not False:
@@ -139,32 +141,32 @@ class JobLauncher(object):
       where output is a list: [stdout, stderr],
       so the full return value is then: [[stdout, stderr], returncode].
     """
-    task = self.clustershell_task.task_self()
-    # launch the task
-    task.run(' '.join(argv), nodes=runnodes)
-    ret = [['', ''], 0]
-    # ensure all of the tasks have completed
-    self.clustershell_task.task_wait()
-    # iterate through the task.iter_retcodes() to get (return code, [nodes])
-    # to get msg objects, output must be retrieved by individual node using task.node_buffer or .key_error
-    # retrieved outputs are bytes, convert with .decode('utf-8')
-    for rc, keys in task.iter_retcodes():
-      if rc != 0:
-        ret[1] = 1
-      for host in keys:
-        output = task.node_buffer(host).decode('utf-8')
-        for line in output.split('\n'):
-          if line != '' and line != 'tput: No value for $TERM and no -T specified':
-            ret[0][0] += host + ': ' + line + '\n'
-        output = task.key_error(host).decode('utf-8')
-        for line in output.split('\n'):
-          if line != '' and line != 'tput: No value for $TERM and no -T specified':
-            ret[0][1] += host + ': ' + line + '\n'
-    return ret
+        task = self.clustershell_task.task_self()
+        # launch the task
+        task.run(' '.join(argv), nodes=runnodes)
+        ret = [['', ''], 0]
+        # ensure all of the tasks have completed
+        self.clustershell_task.task_wait()
+        # iterate through the task.iter_retcodes() to get (return code, [nodes])
+        # to get msg objects, output must be retrieved by individual node using task.node_buffer or .key_error
+        # retrieved outputs are bytes, convert with .decode('utf-8')
+        for rc, keys in task.iter_retcodes():
+            if rc != 0:
+                ret[1] = 1
+            for host in keys:
+                output = task.node_buffer(host).decode('utf-8')
+                for line in output.split('\n'):
+                    if line != '' and line != 'tput: No value for $TERM and no -T specified':
+                        ret[0][0] += host + ': ' + line + '\n'
+                output = task.key_error(host).decode('utf-8')
+                for line in output.split('\n'):
+                    if line != '' and line != 'tput: No value for $TERM and no -T specified':
+                        ret[0][1] += host + ': ' + line + '\n'
+        return ret
 
-  # perform a generic pdsh / clustershell command
-  def parallel_exec(self, argv=[], runnodes=''):
-    """Job launchers should override this method to run the command in the manner of pdsh
+    # perform a generic pdsh / clustershell command
+    def parallel_exec(self, argv=[], runnodes=''):
+        """Job launchers should override this method to run the command in the manner of pdsh
 
     argv is a list of arguments representing the command.
     runnodes is a comma separated string of nodes which will execute the command.
@@ -176,23 +178,23 @@ class JobLauncher(object):
       Format pdshcmd as a list using scr_const.PDSH_EXE, the argv, and runnodes.
       return runproc(argv=pdshcmd, getstdout=True, getstderr=True).
     """
-    if self.clustershell_task is not False:
-      return self.clustershell_exec(argv=argv, runnodes=runnodes)
-    return [['', ''], 0]
+        if self.clustershell_task is not False:
+            return self.clustershell_exec(argv=argv, runnodes=runnodes)
+        return [['', ''], 0]
 
-  # generate the argv to perform the scavenge files operation for scr_scavenge
-  # command format depends on resource manager in use
-  # returns a list -> [ 'stdout', 'stderr' ]
-  def scavenge_files(self,
-                     prog='',
-                     upnodes='',
-                     downnodes_spaced='',
-                     cntldir='',
-                     dataset_id='',
-                     prefixdir='',
-                     buf_size='',
-                     crc_flag=''):
-    """Job launchers may override this method to change the scavenge command
+    # generate the argv to perform the scavenge files operation for scr_scavenge
+    # command format depends on resource manager in use
+    # returns a list -> [ 'stdout', 'stderr' ]
+    def scavenge_files(self,
+                       prog='',
+                       upnodes='',
+                       downnodes_spaced='',
+                       cntldir='',
+                       dataset_id='',
+                       prefixdir='',
+                       buf_size='',
+                       crc_flag=''):
+        """Job launchers may override this method to change the scavenge command
 
     The scavenge argv is formed in this method and launched with launcher.parallel_exec().
 
@@ -219,25 +221,25 @@ class JobLauncher(object):
           The text output (first element of the list) of launcher.parallel_exec()
           ['stdout', 'stderr']
     """
-    argv = [
-        prog, '--cntldir', cntldir, '--id', dataset_id, '--prefix', prefixdir,
-        '--buf', buf_size, crc_flag, downnodes_spaced
-    ]
-    output = self.parallel_exec(argv=argv, runnodes=upnodes)[0]
-    return output
+        argv = [
+            prog, '--cntldir', cntldir, '--id', dataset_id, '--prefix',
+            prefixdir, '--buf', buf_size, crc_flag, downnodes_spaced
+        ]
+        output = self.parallel_exec(argv=argv, runnodes=upnodes)[0]
+        return output
 
-  def scr_kill_jobstep(self, jobstep=None):
-    """Kills task identified by jobstep parameter.
+    def scr_kill_jobstep(self, jobstep=None):
+        """Kills task identified by jobstep parameter.
 
     When launcher.launchruncmd() returns scr_common.runproc(argv, wait=False),
     then this method may be used to send the terminate signal through the Popen object.
     """
-    if jobstep is not None:
-      try:
-        # if jobstep.returncode is None:
-        # send the SIGTERM message to the subprocess.Popen object
-        jobstep.terminate()
-        # ensure complete
-        jobstep.communicate()
-      except:
-        pass
+        if jobstep is not None:
+            try:
+                # if jobstep.returncode is None:
+                # send the SIGTERM message to the subprocess.Popen object
+                jobstep.terminate()
+                # ensure complete
+                jobstep.communicate()
+            except:
+                pass

--- a/scripts/python/scrjob/launchers/jsrun.py
+++ b/scripts/python/scrjob/launchers/jsrun.py
@@ -11,64 +11,67 @@ from scrjob.scr_common import runproc, pipeproc
 
 
 class JSRUN(JobLauncher):
-  def __init__(self, launcher='jsrun'):
-    super(JSRUN, self).__init__(launcher=launcher)
 
-  # returns the subprocess.Popen object as left and right elements of a tuple,
-  # as returned by runproc(argv=argv, wait=False)
-  def launchruncmd(self, up_nodes='', down_nodes='', launcher_args=[]):
-    if type(launcher_args) is str:
-      launcher_args = launcher_args.split()
-    if len(launcher_args) == 0:
-      return None, None
-    argv = [self.launcher]
-    if down_nodes != '':
-      argv.append('--exclude_hosts ' + down_nodes)
-    argv.extend(launcher_args)
-    # it looks like the Popen.terminate is working with jsrun
-    if scr_const.USE_JOBLAUNCHER_KILL != '1':
-      return runproc(argv=argv, wait=False)
-    proc = runproc(argv=argv, wait=False)[0]
-    jobstepid = self.get_jobstep_id()
-    if jobstepid != '-1':
-      return proc, jobstepid
-    else:
-      return proc, proc
+    def __init__(self, launcher='jsrun'):
+        super(JSRUN, self).__init__(launcher=launcher)
 
-  # perform a generic pdsh / clustershell command
-  # returns [ [ stdout, stderr ] , returncode ]
-  def parallel_exec(self, argv=[], runnodes=''):
-    if len(argv) == 0:
-      return [['', ''], 0]
-    if self.clustershell_task != False:
-      return self.clustershell_exec(argv=argv,runnodes=runnodes)
-    pdshcmd = [scr_const.PDSH_EXE, '-Rexec', '-f', '256', '-S', '-w', runnodes]
-    pdshcmd.extend(argv)
-    return runproc(argv=pdshcmd, getstdout=True, getstderr=True)
+    # returns the subprocess.Popen object as left and right elements of a tuple,
+    # as returned by runproc(argv=argv, wait=False)
+    def launchruncmd(self, up_nodes='', down_nodes='', launcher_args=[]):
+        if type(launcher_args) is str:
+            launcher_args = launcher_args.split()
+        if len(launcher_args) == 0:
+            return None, None
+        argv = [self.launcher]
+        if down_nodes != '':
+            argv.append('--exclude_hosts ' + down_nodes)
+        argv.extend(launcher_args)
+        # it looks like the Popen.terminate is working with jsrun
+        if scr_const.USE_JOBLAUNCHER_KILL != '1':
+            return runproc(argv=argv, wait=False)
+        proc = runproc(argv=argv, wait=False)[0]
+        jobstepid = self.get_jobstep_id()
+        if jobstepid != '-1':
+            return proc, jobstepid
+        else:
+            return proc, proc
 
-  # query jslist for the most recent jobstep in current allocation
-  def get_jobstep_id(self):
-    # allow launched job to show in jslist
-    sleep(10)
-    # track the highest number running job
-    jobstepid = -1
-    # get the output of 'jslist'
-    output = runproc(['jslist'], getstdout=True)[0]
-    for line in output.split('\n'):
-      if 'Running' not in line:
-        continue
-      line = line.split()
-      # Format:
-      # ID ParentID nrs CPUs/rs GPUs/rs ExitStatus Status
-      #  2        0   2       1       0          0  Running
-      if int(line[0]) > jobstepid:
-        jobstepid = int(line[0])
-    return str(jobstepid)
+    # perform a generic pdsh / clustershell command
+    # returns [ [ stdout, stderr ] , returncode ]
+    def parallel_exec(self, argv=[], runnodes=''):
+        if len(argv) == 0:
+            return [['', ''], 0]
+        if self.clustershell_task != False:
+            return self.clustershell_exec(argv=argv, runnodes=runnodes)
+        pdshcmd = [
+            scr_const.PDSH_EXE, '-Rexec', '-f', '256', '-S', '-w', runnodes
+        ]
+        pdshcmd.extend(argv)
+        return runproc(argv=pdshcmd, getstdout=True, getstderr=True)
 
-  # Only use jskill to kill the jobstep if desired and get_jobstep_id was successful
-  def scr_kill_jobstep(self, jobstep=None):
-    # it looks like the Popen.terminate is working with jsrun
-    if type(jobstep) is str:
-      runproc(argv=['jskill', jobstep])
-    else:
-      super().scr_kill_jobstep(jobstep)
+    # query jslist for the most recent jobstep in current allocation
+    def get_jobstep_id(self):
+        # allow launched job to show in jslist
+        sleep(10)
+        # track the highest number running job
+        jobstepid = -1
+        # get the output of 'jslist'
+        output = runproc(['jslist'], getstdout=True)[0]
+        for line in output.split('\n'):
+            if 'Running' not in line:
+                continue
+            line = line.split()
+            # Format:
+            # ID ParentID nrs CPUs/rs GPUs/rs ExitStatus Status
+            #  2        0   2       1       0          0  Running
+            if int(line[0]) > jobstepid:
+                jobstepid = int(line[0])
+        return str(jobstepid)
+
+    # Only use jskill to kill the jobstep if desired and get_jobstep_id was successful
+    def scr_kill_jobstep(self, jobstep=None):
+        # it looks like the Popen.terminate is working with jsrun
+        if type(jobstep) is str:
+            runproc(argv=['jskill', jobstep])
+        else:
+            super().scr_kill_jobstep(jobstep)

--- a/scripts/python/scrjob/launchers/lrun.py
+++ b/scripts/python/scrjob/launchers/lrun.py
@@ -9,29 +9,32 @@ from scrjob.scr_common import runproc, pipeproc
 
 
 class LRUN(JobLauncher):
-  def __init__(self, launcher='lrun'):
-    super(LRUN, self).__init__(launcher=launcher)
 
-  # returns the subprocess.Popen object as left and right elements of a tuple,
-  # as returned by runproc(argv=argv, wait=False)
-  def launchruncmd(self, up_nodes='', down_nodes='', launcher_args=[]):
-    if type(launcher_args) is str:
-      launcher_args = launcher_args.split()
-    if len(launcher_args) == 0:
-      return None, None
-    argv = [self.launcher]
-    if len(down_nodes) > 0:
-      argv.append('--exclude_hosts=' + down_nodes)
-    argv.extend(launcher_args)
-    return runproc(argv=argv, wait=False)
+    def __init__(self, launcher='lrun'):
+        super(LRUN, self).__init__(launcher=launcher)
 
-  # perform a generic pdsh / clustershell command
-  # returns [ [ stdout, stderr ] , returncode ]
-  def parallel_exec(self, argv=[], runnodes=''):
-    if len(argv) == 0:
-      return [['', ''], 0]
-    if self.clustershell_task != False:
-      return self.clustershell_exec(argv=argv, runnodes=runnodes)
-    pdshcmd = [scr_const.PDSH_EXE, '-Rexec', '-f', '256', '-S', '-w', runnodes]
-    pdshcmd.extend(argv)
-    return runproc(argv=pdshcmd, getstdout=True, getstderr=True)
+    # returns the subprocess.Popen object as left and right elements of a tuple,
+    # as returned by runproc(argv=argv, wait=False)
+    def launchruncmd(self, up_nodes='', down_nodes='', launcher_args=[]):
+        if type(launcher_args) is str:
+            launcher_args = launcher_args.split()
+        if len(launcher_args) == 0:
+            return None, None
+        argv = [self.launcher]
+        if len(down_nodes) > 0:
+            argv.append('--exclude_hosts=' + down_nodes)
+        argv.extend(launcher_args)
+        return runproc(argv=argv, wait=False)
+
+    # perform a generic pdsh / clustershell command
+    # returns [ [ stdout, stderr ] , returncode ]
+    def parallel_exec(self, argv=[], runnodes=''):
+        if len(argv) == 0:
+            return [['', ''], 0]
+        if self.clustershell_task != False:
+            return self.clustershell_exec(argv=argv, runnodes=runnodes)
+        pdshcmd = [
+            scr_const.PDSH_EXE, '-Rexec', '-f', '256', '-S', '-w', runnodes
+        ]
+        pdshcmd.extend(argv)
+        return runproc(argv=pdshcmd, getstdout=True, getstderr=True)

--- a/scripts/python/scrjob/launchers/mpirun.py
+++ b/scripts/python/scrjob/launchers/mpirun.py
@@ -10,40 +10,45 @@ from scrjob.scr_common import runproc, pipeproc
 
 
 class MPIRUN(JobLauncher):
-  def __init__(self, launcher='mpirun'):
-    super(MPIRUN, self).__init__(launcher=launcher)
 
-  # returns the subprocess.Popen object as left and right elements of a tuple,
-  # as returned by runproc(argv=argv, wait=False)
-  def launchruncmd(self, up_nodes='', down_nodes='', launcher_args=[]):
-    if type(launcher_args) is str:
-      launcher_args = launcher_args.split()
-    if len(launcher_args) == 0:
-      return None, None
-    # split the node string into a node per line
-    up_nodes = '/n'.join(up_nodes.split(','))
-    try:
-      # need to first ensure the directory exists
-      basepath = '/'.join(self.hostfile.split('/')[:-1])
-      os.makedirs(basepath, exist_ok=True)
-      with open(self.hostfile, 'w') as usehostfile:
-        usehostfile.write(up_nodes)
-      argv = [self.launcher, '--hostfile', self.hostfile]
-      argv.extend(launcher_args)
-      return runproc(argv=argv, wait=False)
-    except Exception as e:
-      print(e)
-      print('scr_mpirun: Error writing hostfile and creating launcher command')
-      print('launcher file: \"' + self.hostfile + '\"')
-      return None, None
+    def __init__(self, launcher='mpirun'):
+        super(MPIRUN, self).__init__(launcher=launcher)
 
-  # perform a generic pdsh / clustershell command
-  # returns [ [ stdout, stderr ] , returncode ]
-  def parallel_exec(self, argv=[], runnodes=''):
-    if len(argv) == 0:
-      return [['', ''], 0]
-    if self.clustershell_task != False:
-      return self.clustershell_exec(argv=argv,runnodes=runnodes)
-    pdshcmd = [scr_const.PDSH_EXE, '-Rexec', '-f', '256', '-S', '-w', runnodes]
-    pdshcmd.extend(argv)
-    return runproc(argv=pdshcmd, getstdout=True, getstderr=True)
+    # returns the subprocess.Popen object as left and right elements of a tuple,
+    # as returned by runproc(argv=argv, wait=False)
+    def launchruncmd(self, up_nodes='', down_nodes='', launcher_args=[]):
+        if type(launcher_args) is str:
+            launcher_args = launcher_args.split()
+        if len(launcher_args) == 0:
+            return None, None
+        # split the node string into a node per line
+        up_nodes = '/n'.join(up_nodes.split(','))
+        try:
+            # need to first ensure the directory exists
+            basepath = '/'.join(self.hostfile.split('/')[:-1])
+            os.makedirs(basepath, exist_ok=True)
+            with open(self.hostfile, 'w') as usehostfile:
+                usehostfile.write(up_nodes)
+            argv = [self.launcher, '--hostfile', self.hostfile]
+            argv.extend(launcher_args)
+            return runproc(argv=argv, wait=False)
+        except Exception as e:
+            print(e)
+            print(
+                'scr_mpirun: Error writing hostfile and creating launcher command'
+            )
+            print('launcher file: \"' + self.hostfile + '\"')
+            return None, None
+
+    # perform a generic pdsh / clustershell command
+    # returns [ [ stdout, stderr ] , returncode ]
+    def parallel_exec(self, argv=[], runnodes=''):
+        if len(argv) == 0:
+            return [['', ''], 0]
+        if self.clustershell_task != False:
+            return self.clustershell_exec(argv=argv, runnodes=runnodes)
+        pdshcmd = [
+            scr_const.PDSH_EXE, '-Rexec', '-f', '256', '-S', '-w', runnodes
+        ]
+        pdshcmd.extend(argv)
+        return runproc(argv=pdshcmd, getstdout=True, getstderr=True)

--- a/scripts/python/scrjob/launchers/srun.py
+++ b/scripts/python/scrjob/launchers/srun.py
@@ -12,80 +12,83 @@ from scrjob.launchers import JobLauncher
 
 
 class SRUN(JobLauncher):
-  def __init__(self, launcher='srun'):
-    super(SRUN, self).__init__(launcher=launcher)
 
-  # a command to run immediately before prerun is ran
-  # NOP srun to force every node to run prolog to delete files from cache
-  # TODO: remove this if admins find a better place to clear cache
-  def prepareforprerun(self):
+    def __init__(self, launcher='srun'):
+        super(SRUN, self).__init__(launcher=launcher)
+
+    # a command to run immediately before prerun is ran
     # NOP srun to force every node to run prolog to delete files from cache
     # TODO: remove this if admins find a better place to clear cache
-    argv = ['srun', '/bin/hostname']  # ,'>','/dev/null']
-    runproc(argv=argv)
+    def prepareforprerun(self):
+        # NOP srun to force every node to run prolog to delete files from cache
+        # TODO: remove this if admins find a better place to clear cache
+        argv = ['srun', '/bin/hostname']  # ,'>','/dev/null']
+        runproc(argv=argv)
 
-  # returns the process and PID of the launched process
-  # as returned by runproc(argv=argv, wait=False)
-  def launchruncmd(self, up_nodes='', down_nodes='', launcher_args=[]):
-    if type(launcher_args) is str:
-      launcher_args = launcher_args.split()
-    if len(launcher_args) == 0:
-      return None, None
-    argv = [self.launcher]
-    if len(down_nodes) > 0:
-      argv.extend(['--exclude', down_nodes])
-    argv.extend(launcher_args)
-    # The Popen.terminate() seems to work for srun
-    if scr_const.USE_JOBLAUNCHER_KILL != '1':
-      return runproc(argv=argv, wait=False)
-    proc = runproc(argv=argv, wait=False)[0]
-    ### TODO: If we allow this to be toggled, we have to get the user and allocid below!
-    jobstepid = self.get_jobstep_id(pid = proc.pid)
-    if jobstepid is not None:
-      return proc, jobstepid
-    else:
-      return proc, proc
+    # returns the process and PID of the launched process
+    # as returned by runproc(argv=argv, wait=False)
+    def launchruncmd(self, up_nodes='', down_nodes='', launcher_args=[]):
+        if type(launcher_args) is str:
+            launcher_args = launcher_args.split()
+        if len(launcher_args) == 0:
+            return None, None
+        argv = [self.launcher]
+        if len(down_nodes) > 0:
+            argv.extend(['--exclude', down_nodes])
+        argv.extend(launcher_args)
+        # The Popen.terminate() seems to work for srun
+        if scr_const.USE_JOBLAUNCHER_KILL != '1':
+            return runproc(argv=argv, wait=False)
+        proc = runproc(argv=argv, wait=False)[0]
+        ### TODO: If we allow this to be toggled, we have to get the user and allocid below!
+        jobstepid = self.get_jobstep_id(pid=proc.pid)
+        if jobstepid is not None:
+            return proc, jobstepid
+        else:
+            return proc, proc
 
-  # perform a generic pdsh / clustershell command
-  # returns [ [ stdout, stderr ] , returncode ]
-  def parallel_exec(self, argv=[], runnodes=''):
-    if len(argv) == 0:
-      return [['', ''], 0]
-    if self.clustershell_task != False:
-      return self.clustershell_exec(argv=argv,runnodes=runnodes)
-    pdshcmd = [scr_const.PDSH_EXE, '-Rexec', '-f', '256', '-S', '-w', runnodes]
-    pdshcmd.extend(argv)
-    return runproc(argv=pdshcmd, getstdout=True, getstderr=True)
+    # perform a generic pdsh / clustershell command
+    # returns [ [ stdout, stderr ] , returncode ]
+    def parallel_exec(self, argv=[], runnodes=''):
+        if len(argv) == 0:
+            return [['', ''], 0]
+        if self.clustershell_task != False:
+            return self.clustershell_exec(argv=argv, runnodes=runnodes)
+        pdshcmd = [
+            scr_const.PDSH_EXE, '-Rexec', '-f', '256', '-S', '-w', runnodes
+        ]
+        pdshcmd.extend(argv)
+        return runproc(argv=pdshcmd, getstdout=True, getstderr=True)
 
-  # query SLURM for the most recent jobstep in current allocation
-  def get_jobstep_id(self, pid):
-    ### TODO: If we allow this to be toggled, we have to get the user and allocid!
-    ### Or, the command ran could possibly be changed . . .
-    user = os.environ.get('USER')
-    allocid = os.environ.get('SLURM_JOBID')
-    if user == '' or allocid == '':
-      return None
-    # allow launched job to show in squeue
-    sleep(10)
+    # query SLURM for the most recent jobstep in current allocation
+    def get_jobstep_id(self, pid):
+        ### TODO: If we allow this to be toggled, we have to get the user and allocid!
+        ### Or, the command ran could possibly be changed . . .
+        user = os.environ.get('USER')
+        allocid = os.environ.get('SLURM_JOBID')
+        if user == '' or allocid == '':
+            return None
+        # allow launched job to show in squeue
+        sleep(10)
 
-    # get job steps for this user and job, order by decreasing job step
-    # so first one should be the one we are looking for
-    #   squeue -h -s -u $user -j $jobid -S "-i"
-    # -h means print no header, so just the data in this order:
-    # STEPID         NAME PARTITION     USER      TIME NODELIST
-    cmd = "squeue -h -s -u " + user + " -j " + allocid + " -S \"-i\""
-    output = runproc(cmd, getstdout=True)[0]
-    output = re.search('\d+', output)
-    try:
-      jobstepid = output[0]
-      return jobstepid
-    except:
-      return None
+        # get job steps for this user and job, order by decreasing job step
+        # so first one should be the one we are looking for
+        #   squeue -h -s -u $user -j $jobid -S "-i"
+        # -h means print no header, so just the data in this order:
+        # STEPID         NAME PARTITION     USER      TIME NODELIST
+        cmd = "squeue -h -s -u " + user + " -j " + allocid + " -S \"-i\""
+        output = runproc(cmd, getstdout=True)[0]
+        output = re.search('\d+', output)
+        try:
+            jobstepid = output[0]
+            return jobstepid
+        except:
+            return None
 
-  # Only use scancel to kill the jobstep if desired and get_jobstep_id was successful
-  def scr_kill_jobstep(self, jobstep=None):
-    # it looks like the Popen.terminate is working with srun
-    if type(jobstep) is str:
-      runproc(argv=['scancel', jobstep])
-    else:
-      super().scr_kill_jobstep(jobstep)
+    # Only use scancel to kill the jobstep if desired and get_jobstep_id was successful
+    def scr_kill_jobstep(self, jobstep=None):
+        # it looks like the Popen.terminate is working with srun
+        if type(jobstep) is str:
+            runproc(argv=['scancel', jobstep])
+        else:
+            super().scr_kill_jobstep(jobstep)

--- a/scripts/python/scrjob/list_dir.py
+++ b/scripts/python/scrjob/list_dir.py
@@ -9,7 +9,7 @@ def list_dir(user=None,
              runcmd=None,
              scr_env=None,
              bindir=''):
-  """This method returns info on the SCR control/cache/prefix directories
+    """This method returns info on the SCR control/cache/prefix directories
   for the current user and jobid
 
   Required Parameters
@@ -29,69 +29,69 @@ def list_dir(user=None,
     string representing the error.
     The method will then return the integer 1
   """
-  # check that user specified "control" or "cache"
-  if runcmd != 'control' and runcmd != 'cache':
-    print('list_dir: INVALID: \'control\' or \'cache\' must be specified.')
-    return 1
+    # check that user specified "control" or "cache"
+    if runcmd != 'control' and runcmd != 'cache':
+        print('list_dir: INVALID: \'control\' or \'cache\' must be specified.')
+        return 1
 
-  # TODO: read cache directory from config file
-  bindir = scr_const.X_BINDIR
+    # TODO: read cache directory from config file
+    bindir = scr_const.X_BINDIR
 
-  # ensure scr_env is set
-  if scr_env is None or scr_env.resmgr is None or scr_env.param is None:
-    print('list_dir: INVALID: Unknown environment.')
-    return 1
+    # ensure scr_env is set
+    if scr_env is None or scr_env.resmgr is None or scr_env.param is None:
+        print('list_dir: INVALID: Unknown environment.')
+        return 1
 
-  # get the base directory
-  bases = []
-  if runcmd == 'cache':
-    # lookup cache base
-    cachedesc = scr_env.param.get_hash('CACHE')
-    if type(cachedesc) is dict:
-      bases = list(cachedesc.keys())
-      #foreach my $index (keys %$cachedesc) {
-      #  push @bases, $index;
-    elif cachedesc is not None:
-      bases = [cachedesc]
+    # get the base directory
+    bases = []
+    if runcmd == 'cache':
+        # lookup cache base
+        cachedesc = scr_env.param.get_hash('CACHE')
+        if type(cachedesc) is dict:
+            bases = list(cachedesc.keys())
+            #foreach my $index (keys %$cachedesc) {
+            #  push @bases, $index;
+        elif cachedesc is not None:
+            bases = [cachedesc]
+        else:
+            print('list_dir: INVALID: Unable to get parameter CACHE.')
+            return 1
     else:
-      print('list_dir: INVALID: Unable to get parameter CACHE.')
-      return 1
-  else:
-    # lookup cntl base
-    bases = scr_env.param.get('SCR_CNTL_BASE')
-    if type(bases) is dict:
-      bases = list(bases.keys())
-    elif type(bases) is not None:
-      bases = [bases]
-    else:
-      print('list_dir: INVALID: Unable to get parameter SCR_CNTL_BASE.')
-      return 1
-  if len(bases) == 0:
-    print('list_dir: INVALID: Length of bases [] is zero.')
-    return 1
+        # lookup cntl base
+        bases = scr_env.param.get('SCR_CNTL_BASE')
+        if type(bases) is dict:
+            bases = list(bases.keys())
+        elif type(bases) is not None:
+            bases = [bases]
+        else:
+            print('list_dir: INVALID: Unable to get parameter SCR_CNTL_BASE.')
+            return 1
+    if len(bases) == 0:
+        print('list_dir: INVALID: Length of bases [] is zero.')
+        return 1
 
-  # get the user/job directory
-  suffix = ''
-  if base == False:
-    # if not specified, read username from environment
-    if user is None:
-      user = scr_env.get_user()
-    # if not specified, read jobid from environment
-    if jobid is None:
-      jobid = scr_env.resmgr.getjobid()
-    # check that the required environment variables are set
-    if user is None or jobid is None:
-      # something is missing, print invalid dir and exit with error
-      print('list_dir: INVALID: Unable to determine user or jobid.')
-      return 1
-    suffix = user + '/scr.' + jobid
+    # get the user/job directory
+    suffix = ''
+    if base == False:
+        # if not specified, read username from environment
+        if user is None:
+            user = scr_env.get_user()
+        # if not specified, read jobid from environment
+        if jobid is None:
+            jobid = scr_env.resmgr.getjobid()
+        # check that the required environment variables are set
+        if user is None or jobid is None:
+            # something is missing, print invalid dir and exit with error
+            print('list_dir: INVALID: Unable to determine user or jobid.')
+            return 1
+        suffix = user + '/scr.' + jobid
 
-  # ok, all values are here, print out the directory name and exit with success
-  dirs = []
-  for abase in bases:
-    if suffix != '':
-      dirs.append(abase + '/' + suffix)
-    else:
-      dirs.append(abase)
-  dirs = ' '.join(dirs)
-  return dirs
+    # ok, all values are here, print out the directory name and exit with success
+    dirs = []
+    for abase in bases:
+        if suffix != '':
+            dirs.append(abase + '/' + suffix)
+        else:
+            dirs.append(abase)
+    dirs = ' '.join(dirs)
+    return dirs

--- a/scripts/python/scrjob/list_down_nodes.py
+++ b/scripts/python/scrjob/list_down_nodes.py
@@ -8,12 +8,12 @@ from scrjob.list_dir import list_dir
 
 # mark any nodes specified on the command line
 def remove_argument_excluded_nodes(nodes=[], nodeset_down=[]):
-  #unavailable = {}
-  for node in nodeset_down:
-    if node in nodes:
-      nodes.remove(node)
-      #unavailable[node] = 'Specified on command line'
-  #return unavailable
+    #unavailable = {}
+    for node in nodeset_down:
+        if node in nodes:
+            nodes.remove(node)
+            #unavailable[node] = 'Specified on command line'
+    #return unavailable
 
 
 # The main scr_list_down_nodes method.
@@ -25,65 +25,65 @@ def list_down_nodes(reason=False,
                     nodeset=None,
                     scr_env=None,
                     log=None):
-  if scr_env is None or scr_env.resmgr is None or scr_env.param is None:
-    return 1
-  bindir = scr_const.X_BINDIR
+    if scr_env is None or scr_env.resmgr is None or scr_env.param is None:
+        return 1
+    bindir = scr_const.X_BINDIR
 
-  # check that we have a nodeset before going any further
-  resourcemgr = scr_env.resmgr
-  if type(nodeset) is list:
-    nodeset = ','.join(nodeset)
-  if not nodeset:
-    nodeset = scr_env.get_scr_nodelist()
-    if nodeset is None:
-      nodeset = resourcemgr.get_job_nodes()
-  if nodeset is None or nodeset == '':
-    print(
-        'scr_list_down_nodes: ERROR: Nodeset must be specified or script must be run from within a job allocation.'
-    )
-    return 1
+    # check that we have a nodeset before going any further
+    resourcemgr = scr_env.resmgr
+    if type(nodeset) is list:
+        nodeset = ','.join(nodeset)
+    if not nodeset:
+        nodeset = scr_env.get_scr_nodelist()
+        if nodeset is None:
+            nodeset = resourcemgr.get_job_nodes()
+    if nodeset is None or nodeset == '':
+        print(
+            'scr_list_down_nodes: ERROR: Nodeset must be specified or script must be run from within a job allocation.'
+        )
+        return 1
 
-  param = scr_env.param
+    param = scr_env.param
 
-  # get list of nodes from nodeset
-  nodes = scr_env.resmgr.expand_hosts(nodeset)
+    # get list of nodes from nodeset
+    nodes = scr_env.resmgr.expand_hosts(nodeset)
 
-  ### In each of the scr_list_down_nodes.in
-  ### these nodes are marked as unavailable, and also removed from the list to log
-  ### There is no use to keep track of them in the unavailable dictionary
-  #unavailable = list_argument_excluded_nodes(nodes=nodes,nodeset_down=nodeset_down)
-  if nodeset_down != '':
-    remove_argument_excluded_nodes(nodes=nodes,
-                                   nodeset_down=scr_env.resmgr.expand_hosts(nodeset_down))
+    ### In each of the scr_list_down_nodes.in
+    ### these nodes are marked as unavailable, and also removed from the list to log
+    ### There is no use to keep track of them in the unavailable dictionary
+    #unavailable = list_argument_excluded_nodes(nodes=nodes,nodeset_down=nodeset_down)
+    if nodeset_down != '':
+        remove_argument_excluded_nodes(
+            nodes=nodes,
+            nodeset_down=scr_env.resmgr.expand_hosts(nodeset_down))
 
-  # get a hash of all unavailable (down or excluded) nodes and reason
-  # keys are nodes and the values are the reasons
-  unavailable = resourcemgr.list_down_nodes_with_reason(
-      nodes=nodes,
-      scr_env=scr_env)
-  # TODO: read exclude list from a file, as well?
+    # get a hash of all unavailable (down or excluded) nodes and reason
+    # keys are nodes and the values are the reasons
+    unavailable = resourcemgr.list_down_nodes_with_reason(nodes=nodes,
+                                                          scr_env=scr_env)
+    # TODO: read exclude list from a file, as well?
 
-  # print any failed nodes to stdout and exit with non-zero
-  if len(unavailable) > 0:
-    # log each newly failed node, along with the reason
-    if log:
-      for node in unavailable:
-        note = node + ": " + unavailable[node]
-        log.event('NODE_FAIL', note=note, secs=runtime_secs)
+    # print any failed nodes to stdout and exit with non-zero
+    if len(unavailable) > 0:
+        # log each newly failed node, along with the reason
+        if log:
+            for node in unavailable:
+                note = node + ": " + unavailable[node]
+                log.event('NODE_FAIL', note=note, secs=runtime_secs)
 
-    # now output info to the user
-    if reason:
-      # list each node and the reason each is down
-      reasons = []
-      for node in unavailable:
-        reasons.append(node + ': ' + unavailable[node])
-      return "\n".join(reasons)
-    else:
-      # simply print the list of down node in range syntax
-      # cast unavailable to a list to get only the keys of the dictionary
-      return scr_env.resmgr.compress_hosts(list(unavailable))
-  # if we are returning a print string, just return a blank string if no down nodes
-  elif reason:
-    return ''
-  # otherwise, don't print anything and exit with 0
-  return 0
+        # now output info to the user
+        if reason:
+            # list each node and the reason each is down
+            reasons = []
+            for node in unavailable:
+                reasons.append(node + ': ' + unavailable[node])
+            return "\n".join(reasons)
+        else:
+            # simply print the list of down node in range syntax
+            # cast unavailable to a list to get only the keys of the dictionary
+            return scr_env.resmgr.compress_hosts(list(unavailable))
+    # if we are returning a print string, just return a blank string if no down nodes
+    elif reason:
+        return ''
+    # otherwise, don't print anything and exit with 0
+    return 0

--- a/scripts/python/scrjob/parsetime.py
+++ b/scripts/python/scrjob/parsetime.py
@@ -8,53 +8,55 @@ import re, sys
 
 
 def print_usage(prog):
-  """this method prints a description of usage of the parsetime method of this script"""
+    """this method prints a description of usage of the parsetime method of this script"""
 
-  print('Time parser')
-  print('Returns the time between now and the argument.')
-  print('Argument time should be within one year (don\'t specify the year)')
-  print(
-      'Month and day can be written as \'Month Day\', \'MM/DD\', or \'m/DD\'')
-  print('Colon separated time values are interpreted as:')
-  print(
-      '\'HH:MM\', \'HH:MM:SS\', \'DD:HH:MM:SS\' (leading zeroes not required)')
-  print('Hours may be specified in 12- or 24- hour format')
-  print(
-      'Use pm is required when using the 12-hour format to set a time, use of am is optional'
-  )
-  print('Enter a \'+\' symbol to specify the argument time is a duration')
-  print('Separate different arguments with spaces')
-  print('usage: ' + prog + ' time')
-  print('examples:')
-  print(prog + ' 3pm')
-  print(prog + ' 1500 tomorrow')
-  print(prog + ' 1500:30 today')
-  print(prog + ' 3:00 pm Monday')
-  print(prog + ' tues 3:00:30pm')
-  print(prog + ' December 11th 03:00am')
-  print(prog + ' 3pm 12/11')
-  print(prog + ' 42:10:36:30')
+    print('Time parser')
+    print('Returns the time between now and the argument.')
+    print('Argument time should be within one year (don\'t specify the year)')
+    print(
+        'Month and day can be written as \'Month Day\', \'MM/DD\', or \'m/DD\''
+    )
+    print('Colon separated time values are interpreted as:')
+    print(
+        '\'HH:MM\', \'HH:MM:SS\', \'DD:HH:MM:SS\' (leading zeroes not required)'
+    )
+    print('Hours may be specified in 12- or 24- hour format')
+    print(
+        'Use pm is required when using the 12-hour format to set a time, use of am is optional'
+    )
+    print('Enter a \'+\' symbol to specify the argument time is a duration')
+    print('Separate different arguments with spaces')
+    print('usage: ' + prog + ' time')
+    print('examples:')
+    print(prog + ' 3pm')
+    print(prog + ' 1500 tomorrow')
+    print(prog + ' 1500:30 today')
+    print(prog + ' 3:00 pm Monday')
+    print(prog + ' tues 3:00:30pm')
+    print(prog + ' December 11th 03:00am')
+    print(prog + ' 3pm 12/11')
+    print(prog + ' 42:10:36:30')
 
 
 def isleapyear(year):
-  """returns true if a given year is a leap year"""
-  if year % 400 == 0 or (year % 4 == 0 and year % 100 != 0):
-    return True
-  return False
+    """returns true if a given year is a leap year"""
+    if year % 400 == 0 or (year % 4 == 0 and year % 100 != 0):
+        return True
+    return False
 
 
 def numdays(current, future):
-  """returns a number of days in the future one weekday is from another"""
-  # Wednesday to Tuesday
-  if future < current:
-    # 7 - Wednesday + Tuesday
-    return 7 - current + future
-  # Tuesday to Wednesday is Wednesday - Tuesday
-  return future - current
+    """returns a number of days in the future one weekday is from another"""
+    # Wednesday to Tuesday
+    if future < current:
+        # 7 - Wednesday + Tuesday
+        return 7 - current + future
+    # Tuesday to Wednesday is Wednesday - Tuesday
+    return future - current
 
 
 def parsetime(timestr):
-  """returns an int( posix time ) from a provided input string
+    """returns an int( posix time ) from a provided input string
   
   Interpreted strings can have relative offsets from the current time.
 
@@ -63,196 +65,196 @@ def parsetime(timestr):
 
   An invalid input will likely return a timedelta of about 24 hours in the future.
   """
-  weekdays = {
-      'mon': 0,
-      'tue': 1,
-      'wed': 2,
-      'thu': 3,
-      'fri': 4,
-      'sat': 5,
-      'sun': 6
-  }
-  months = {
-      'jan': 1,
-      'feb': 2,
-      'mar': 3,
-      'apr': 4,
-      'may': 5,
-      'jun': 6,
-      'jul': 7,
-      'aug': 8,
-      'sep': 9,
-      'oct': 10,
-      'nov': 11,
-      'dec': 12
-  }
-  # track whether the same day was given (it is monday and monday was given)
-  # if the time would otherwise be in the past we can advance to next week
-  now = datetime.now()
-  # the future time, based off of now
-  shouldbeinpast = False
-  jumpweek = False
-  ispm = False
-  isduration = False
-  second = now.second
-  minute = now.minute
-  hour = now.hour
-  day = now.day
-  month = now.month
-  year = now.year
-  plusdays = 0
-  timestr = timestr.lower()
-  if 'pm' in timestr:
-    ispm = True
-    timestr = re.sub('pm', ' ', timestr)
-  elif 'am' in timestr:
-    timestr = re.sub('am', ' ', timestr)
-  timestr = re.sub(',', ' ', timestr)
-  if timestr.find('+') >= 0:
-    timestr = re.sub('+', '', timestr)
-    isduration = True
-  parts = timestr.split(' ')
-  for part in parts:
-    if part == '':
-      pass
-    elif part.isnumeric():
-      if len(part) == 4:
-        hour = int(part) // 100
-        minute = int(part) % 100
-      else:
-        hour = int(part)
-        minute = 0
-      second = 0
-    elif part == 'noon':  # 12pm
-      hour = 12
-      minute = 0
-      second = 0
-    elif 'yester' in part:  # yesterday
-      plusdays = -1
-      shouldbeinpast = True
-    elif 'tom' in part:  # tomorrow
-      plusdays = 1
-    elif 'tod' in part:  # today
-      pass
-    elif ':' in part:
-      pieces = part.split(':')
-      # 42:10:3:12 <- specify to run for 42 days, 10 hours, ...,
-      if len(pieces) == 4:
-        plusdays = int(pieces[0])
-        hour += int(pieces[1])
-        minute += int(pieces[2])
-        second += int(pieces[3])
-      # 1720:30 <- 17 hours, 20 minutes, 30 seconds
-      elif len(pieces) == 2 and len(pieces[0]) > 2:
-        if isduration == True:
-          hour += int(pieces[0]) // 100
-          minute += int(pieces[0]) % 100
-          second += int(pieces[1])
-        else:
-          hour = int(pieces[0]) // 100
-          minute = int(pieces[0]) % 100
-          second = int(pieces[1])
-      # '+' symbol present, use additive duration
-      elif isduration == True:
-        hour += int(pieces[0])
-        minute += int(pieces[1])
-        if len(pieces) == 3:
-          second += int(pieces[2])
-      # not a duration, set the time
-      else:
-        hour = int(pieces[0])
-        minute = int(pieces[1])
-        if len(pieces) == 3:
-          second = int(pieces[2])
-        else:
-          second = 0
-    elif '/' in part:
-      pieces = part.split('/')
-      month = pieces[0]
-      day = pieces[1]
-      jumpweek = False
-    elif (part.endswith('st') or part.endswith('th') or part.endswith('nd')
-          or part.endswith('rd')) and part[:-2].isnumeric():
-      day = int(part[:-2])
-    elif any(key in part for key in weekdays.keys()):
-      for key in weekdays:
-        if key in part:
-          plusdays = numdays(now.weekday(), weekdays[key])
-          break
-      if plusdays == 0:
-        jumpweek = True  # jump to next week if the time would otherwise be in the past
-    elif any(key in part for key in months.keys()):
-      for key in months:
-        if key in part:
-          if months[key] < month:
-            year += 1
-          month = months[key]
-          break
-      jumpweek = False
-  if ispm == True:
-    hour += 12
-  while second > 59:
-    second -= 60
-    minute += 1
-  while minute > 59:
-    minute -= 60
-    hour += 1
-  while hour > 23:
-    hour -= 24
-    plusdays += 1
-  day += plusdays
-  # the time is in the past, bring it to the future
-  # (if hour/min/sec not specified this can still end up being slightly in the past, e.g., ~1 minute in the past)
-  if month <= now.month and year <= now.year:
-    while day < now.day or (day == now.day and
-                            (hour < now.hour or
-                             (hour == now.hour and minute < now.minute))):
-      if shouldbeinpast:
-        break
-      # the day of the week was specified, move to next week
-      if jumpweek == True:
-        day += 7
-      # no day was specified, move to tomorrow
-      else:
-        day += 1
-  maxday = 31
-  if month == 2:
-    if isleapyear(month):
-      maxday = 29
-    else:
-      maxday = 28
-  elif month % 2 == 0:
-    maxday = 30
-  # we have day = 37, maxday = 31, do day-=31 ( == 6 ) and month +=1
-  while day > maxday:
-    day -= maxday
-    month += 1
-    if month > 12:
-      month = 1
-      year += 1
+    weekdays = {
+        'mon': 0,
+        'tue': 1,
+        'wed': 2,
+        'thu': 3,
+        'fri': 4,
+        'sat': 5,
+        'sun': 6
+    }
+    months = {
+        'jan': 1,
+        'feb': 2,
+        'mar': 3,
+        'apr': 4,
+        'may': 5,
+        'jun': 6,
+        'jul': 7,
+        'aug': 8,
+        'sep': 9,
+        'oct': 10,
+        'nov': 11,
+        'dec': 12
+    }
+    # track whether the same day was given (it is monday and monday was given)
+    # if the time would otherwise be in the past we can advance to next week
+    now = datetime.now()
+    # the future time, based off of now
+    shouldbeinpast = False
+    jumpweek = False
+    ispm = False
+    isduration = False
+    second = now.second
+    minute = now.minute
+    hour = now.hour
+    day = now.day
+    month = now.month
+    year = now.year
+    plusdays = 0
+    timestr = timestr.lower()
+    if 'pm' in timestr:
+        ispm = True
+        timestr = re.sub('pm', ' ', timestr)
+    elif 'am' in timestr:
+        timestr = re.sub('am', ' ', timestr)
+    timestr = re.sub(',', ' ', timestr)
+    if timestr.find('+') >= 0:
+        timestr = re.sub('+', '', timestr)
+        isduration = True
+    parts = timestr.split(' ')
+    for part in parts:
+        if part == '':
+            pass
+        elif part.isnumeric():
+            if len(part) == 4:
+                hour = int(part) // 100
+                minute = int(part) % 100
+            else:
+                hour = int(part)
+                minute = 0
+            second = 0
+        elif part == 'noon':  # 12pm
+            hour = 12
+            minute = 0
+            second = 0
+        elif 'yester' in part:  # yesterday
+            plusdays = -1
+            shouldbeinpast = True
+        elif 'tom' in part:  # tomorrow
+            plusdays = 1
+        elif 'tod' in part:  # today
+            pass
+        elif ':' in part:
+            pieces = part.split(':')
+            # 42:10:3:12 <- specify to run for 42 days, 10 hours, ...,
+            if len(pieces) == 4:
+                plusdays = int(pieces[0])
+                hour += int(pieces[1])
+                minute += int(pieces[2])
+                second += int(pieces[3])
+            # 1720:30 <- 17 hours, 20 minutes, 30 seconds
+            elif len(pieces) == 2 and len(pieces[0]) > 2:
+                if isduration == True:
+                    hour += int(pieces[0]) // 100
+                    minute += int(pieces[0]) % 100
+                    second += int(pieces[1])
+                else:
+                    hour = int(pieces[0]) // 100
+                    minute = int(pieces[0]) % 100
+                    second = int(pieces[1])
+            # '+' symbol present, use additive duration
+            elif isduration == True:
+                hour += int(pieces[0])
+                minute += int(pieces[1])
+                if len(pieces) == 3:
+                    second += int(pieces[2])
+            # not a duration, set the time
+            else:
+                hour = int(pieces[0])
+                minute = int(pieces[1])
+                if len(pieces) == 3:
+                    second = int(pieces[2])
+                else:
+                    second = 0
+        elif '/' in part:
+            pieces = part.split('/')
+            month = pieces[0]
+            day = pieces[1]
+            jumpweek = False
+        elif (part.endswith('st') or part.endswith('th') or part.endswith('nd')
+              or part.endswith('rd')) and part[:-2].isnumeric():
+            day = int(part[:-2])
+        elif any(key in part for key in weekdays.keys()):
+            for key in weekdays:
+                if key in part:
+                    plusdays = numdays(now.weekday(), weekdays[key])
+                    break
+            if plusdays == 0:
+                jumpweek = True  # jump to next week if the time would otherwise be in the past
+        elif any(key in part for key in months.keys()):
+            for key in months:
+                if key in part:
+                    if months[key] < month:
+                        year += 1
+                    month = months[key]
+                    break
+            jumpweek = False
+    if ispm == True:
+        hour += 12
+    while second > 59:
+        second -= 60
+        minute += 1
+    while minute > 59:
+        minute -= 60
+        hour += 1
+    while hour > 23:
+        hour -= 24
+        plusdays += 1
+    day += plusdays
+    # the time is in the past, bring it to the future
+    # (if hour/min/sec not specified this can still end up being slightly in the past, e.g., ~1 minute in the past)
+    if month <= now.month and year <= now.year:
+        while day < now.day or (day == now.day and
+                                (hour < now.hour or
+                                 (hour == now.hour and minute < now.minute))):
+            if shouldbeinpast:
+                break
+            # the day of the week was specified, move to next week
+            if jumpweek == True:
+                day += 7
+            # no day was specified, move to tomorrow
+            else:
+                day += 1
     maxday = 31
     if month == 2:
-      if isleapyear(month):
-        maxday = 29
-      else:
-        maxday = 28
+        if isleapyear(month):
+            maxday = 29
+        else:
+            maxday = 28
     elif month % 2 == 0:
-      maxday = 30
-  while month > 12:
-    month -= 12
-    year += 1
-  # datetime(year, month, day, hour=0, minute=0, second=0, microsecond=0, tzinfo=None, *, fold=0)
-  # timestamp to convert it to a POSIX timestamp
-  # int cast to remove the trailing decimal
-  return int(datetime(year, month, day, hour, minute, second).timestamp())
+        maxday = 30
+    # we have day = 37, maxday = 31, do day-=31 ( == 6 ) and month +=1
+    while day > maxday:
+        day -= maxday
+        month += 1
+        if month > 12:
+            month = 1
+            year += 1
+        maxday = 31
+        if month == 2:
+            if isleapyear(month):
+                maxday = 29
+            else:
+                maxday = 28
+        elif month % 2 == 0:
+            maxday = 30
+    while month > 12:
+        month -= 12
+        year += 1
+    # datetime(year, month, day, hour=0, minute=0, second=0, microsecond=0, tzinfo=None, *, fold=0)
+    # timestamp to convert it to a POSIX timestamp
+    # int cast to remove the trailing decimal
+    return int(datetime(year, month, day, hour, minute, second).timestamp())
 
 
 if __name__ == '__main__':
-  """this script may be called as main to test output"""
+    """this script may be called as main to test output"""
 
-  now = datetime.now()
-  #print(now)
-  if len(sys.argv) < 2:
-    print_usage(sys.argv[0])
-  else:
-    print(parsetime(' '.join(sys.argv[1:])))
+    now = datetime.now()
+    #print(now)
+    if len(sys.argv) < 2:
+        print_usage(sys.argv[0])
+    else:
+        print(parsetime(' '.join(sys.argv[1:])))

--- a/scripts/python/scrjob/postrun.py
+++ b/scripts/python/scrjob/postrun.py
@@ -17,7 +17,7 @@ from scrjob.cli import SCRIndex, SCRFlushFile
 
 
 def postrun(prefix_dir=None, scr_env=None, verbose=False, log=None):
-  """this method is called after all runs has completed, before scr_run.py exits
+    """this method is called after all runs has completed, before scr_run.py exits
 
   Determine whether there are datasets to scavenge, and perform scavenge operations
 
@@ -26,237 +26,252 @@ def postrun(prefix_dir=None, scr_env=None, verbose=False, log=None):
   int     0 on success
           1 on error
   """
-  if scr_env is None or scr_env.resmgr is None:
-    return 1
+    if scr_env is None or scr_env.resmgr is None:
+        return 1
 
-  # if SCR is disabled, immediately exit
-  val = os.environ.get('SCR_ENABLE')
-  if val is not None and val == '0':
-    return 0
+    # if SCR is disabled, immediately exit
+    val = os.environ.get('SCR_ENABLE')
+    if val is not None and val == '0':
+        return 0
 
-  # record the start time for timing purposes
-  start_time = datetime.now()
-  start_secs = int(time())
+    # record the start time for timing purposes
+    start_time = datetime.now()
+    start_secs = int(time())
 
-  bindir = scr_const.X_BINDIR
+    bindir = scr_const.X_BINDIR
 
-  pardir = ''
-  # pass prefix via command line
-  if prefix_dir is not None:
-    pardir = prefix_dir
-  if not pardir:
-    pardir = scr_env.get_prefix()
+    pardir = ''
+    # pass prefix via command line
+    if prefix_dir is not None:
+        pardir = prefix_dir
+    if not pardir:
+        pardir = scr_env.get_prefix()
 
-  # check that we have the parallel file system prefix
-  if pardir == '':
-    return 1
+    # check that we have the parallel file system prefix
+    if pardir == '':
+        return 1
 
-  scr_index = SCRIndex(pardir)
-  scr_flush_file = SCRFlushFile(pardir)
+    scr_index = SCRIndex(pardir)
+    scr_flush_file = SCRFlushFile(pardir)
 
-  # all parameters checked out, start normal output
-  print('scr_postrun: Started: ' + str(datetime.now()))
+    # all parameters checked out, start normal output
+    print('scr_postrun: Started: ' + str(datetime.now()))
 
-  # get our nodeset for this job
-  scr_nodelist = scr_env.get_scr_nodelist()
-  if scr_nodelist is None:
-    scr_nodelist = scr_env.resmgr.get_job_nodes()
+    # get our nodeset for this job
+    scr_nodelist = scr_env.get_scr_nodelist()
     if scr_nodelist is None:
-      print('scr_postrun: ERROR: Could not identify nodeset')
-      return 1
-    os.environ['SCR_NODELIST'] = scr_nodelist
+        scr_nodelist = scr_env.resmgr.get_job_nodes()
+        if scr_nodelist is None:
+            print('scr_postrun: ERROR: Could not identify nodeset')
+            return 1
+        os.environ['SCR_NODELIST'] = scr_nodelist
 
-  # identify what nodes are still up
-  upnodes = ','.join(scr_env.resmgr.expand_hosts(scr_nodelist))
-  downnodes = list_down_nodes(nodeset=upnodes, scr_env=scr_env)
+    # identify what nodes are still up
+    upnodes = ','.join(scr_env.resmgr.expand_hosts(scr_nodelist))
+    downnodes = list_down_nodes(nodeset=upnodes, scr_env=scr_env)
 
-  if verbose:
-    print('scr_postrun: upnodes:   ' + str(upnodes))
-    print('scr_postrun: downnodes: ' + str(downnodes))
+    if verbose:
+        print('scr_postrun: upnodes:   ' + str(upnodes))
+        print('scr_postrun: downnodes: ' + str(downnodes))
 
-  # list_down_nodes returns 0 for none, 1 for error
-  if type(downnodes) is int:
-    downnodes = ''
-    #if downnodes==1: # returned error
-    #  return 1 # should we return an error here (?)
-    #else: #returned 0, there were no down nodes
-    #  downnodes = ''
-  # otherwise a comma separated string of downnodes was returned
-  else:
-    # subtract the downnodes from the upnodes
-    upnodes = scr_glob_hosts(minus=upnodes + ':' + downnodes,
-                             resmgr=scr_env.resmgr)
-  print('scr_postrun: UPNODES:   ' + upnodes)
-
-  # if there is at least one remaining up node, attempt to scavenge
-  ret = 1
-  ### TODO : the default return value is 1, indicating failure.
-  ### Should this be changed to zero, and conditionally set the return value to 1 ?
-  ### This has no affect on anything else, as this is called as the script is ending.
-  if upnodes != '':
-    cntldir = list_dir(runcmd='control', scr_env=scr_env, bindir=bindir)
-    # list_dir returns 1 or a space separated list of directories
-    if cntldir == 1:
-      print('scr_postrun: Unable to determine a control directory')
-      return 1
-
-    # TODODSET: avoid scavenging things unless it's in this list
-    # get list of possible datasets
-    #  dataset_list=`$bindir/scr_inspect --up $UPNODES --from $cntldir`
-    #  if [ $? -eq 0 ] ; then
-    #  else
-    #    echo "$prog: Failed to inspect cache or cannot scavenge any datasets"
-    #  fi
-
-    # array to track which datasets we tried to get
-    attempted = []
-
-    # array to track datasets we got
-    succeeded = []
-
-    # track the id of the first one we fail to get
-    # this will be used to list dsets --before "failed_dataset"
-    # if there is no failure, we pass --before "0"
-    failed_dataset = '0'
-
-    # scavenge all output sets in ascending order
-    print('scr_postrun: Looking for output sets')
-    dsets_output = scr_flush_file.list_dsets_output()
-    if not dsets_output:
-      print('scr_postrun: Found no output set to scavenge')
+    # list_down_nodes returns 0 for none, 1 for error
+    if type(downnodes) is int:
+        downnodes = ''
+        #if downnodes==1: # returned error
+        #  return 1 # should we return an error here (?)
+        #else: #returned 0, there were no down nodes
+        #  downnodes = ''
+    # otherwise a comma separated string of downnodes was returned
     else:
-      for d in dsets_output:
-        # determine whether this dataset needs to be flushed
-        if not scr_flush_file.need_flush(d):
-          # dataset has already been flushed, go to the next one
-          print('scr_postrun: Dataset ' + d + ' has already been flushed')
-          continue
-        print('scr_postrun: Attempting to scavenge dataset ' + d)
+        # subtract the downnodes from the upnodes
+        upnodes = scr_glob_hosts(minus=upnodes + ':' + downnodes,
+                                 resmgr=scr_env.resmgr)
+    print('scr_postrun: UPNODES:   ' + upnodes)
 
-        # add $d to ATTEMPTED list
-        attempted.append(d)
+    # if there is at least one remaining up node, attempt to scavenge
+    ret = 1
+    ### TODO : the default return value is 1, indicating failure.
+    ### Should this be changed to zero, and conditionally set the return value to 1 ?
+    ### This has no affect on anything else, as this is called as the script is ending.
+    if upnodes != '':
+        cntldir = list_dir(runcmd='control', scr_env=scr_env, bindir=bindir)
+        # list_dir returns 1 or a space separated list of directories
+        if cntldir == 1:
+            print('scr_postrun: Unable to determine a control directory')
+            return 1
 
-        # get dataset name
-        dsetname = scr_flush_file.name(d)
-        if not dsetname:
-          # got a dataset to flush, but failed to get name
-          print('scr_postrun: Failed to read name of dataset ' + d)
-          failed_dataset = d
-          break
+        # TODODSET: avoid scavenging things unless it's in this list
+        # get list of possible datasets
+        #  dataset_list=`$bindir/scr_inspect --up $UPNODES --from $cntldir`
+        #  if [ $? -eq 0 ] ; then
+        #  else
+        #    echo "$prog: Failed to inspect cache or cannot scavenge any datasets"
+        #  fi
 
-        # build full path to dataset directory
-        datadir = scr_env.dir_dset(d)
-        os.makedirs(datadir, exist_ok=True)
+        # array to track which datasets we tried to get
+        attempted = []
 
-        # Gather files from cache to parallel file system
-        print('scr_postrun: Scavenging files from cache for ' + dsetname +
-              ' to ' + datadir)
-        if scr_scavenge(nodeset_job=scr_nodelist,
-                        nodeset_up=upnodes,
-                        dataset_id=d,
-                        cntldir=cntldir,
-                        prefixdir=pardir,
-                        verbose=verbose,
-                        scr_env=scr_env,
-                        log=log) != 1:
-          print('scr_postrun: Done scavenging files from cache for ' +
-                dsetname + ' to ' + datadir)
+        # array to track datasets we got
+        succeeded = []
+
+        # track the id of the first one we fail to get
+        # this will be used to list dsets --before "failed_dataset"
+        # if there is no failure, we pass --before "0"
+        failed_dataset = '0'
+
+        # scavenge all output sets in ascending order
+        print('scr_postrun: Looking for output sets')
+        dsets_output = scr_flush_file.list_dsets_output()
+        if not dsets_output:
+            print('scr_postrun: Found no output set to scavenge')
         else:
-          print('scr_postrun: ERROR: Scavenge files from cache for ' +
-                dsetname + ' to ' + datadir)
+            for d in dsets_output:
+                # determine whether this dataset needs to be flushed
+                if not scr_flush_file.need_flush(d):
+                    # dataset has already been flushed, go to the next one
+                    print('scr_postrun: Dataset ' + d +
+                          ' has already been flushed')
+                    continue
+                print('scr_postrun: Attempting to scavenge dataset ' + d)
 
-        # check that gathered set is complete,
-        # if not, don't update current marker
-        #update_current=1
-        print('scr_postrun: Checking that dataset is complete')
-        if not scr_index.build(d):
-          # failed to get dataset, stop trying for later sets
-          failed_dataset = d
-          break
+                # add $d to ATTEMPTED list
+                attempted.append(d)
 
-        # remember that we scavenged this dataset in case we try again below
-        succeeded.append(d)
-        print('scr_postrun: Scavenged dataset ' + dsetname + ' successfully')
+                # get dataset name
+                dsetname = scr_flush_file.name(d)
+                if not dsetname:
+                    # got a dataset to flush, but failed to get name
+                    print('scr_postrun: Failed to read name of dataset ' + d)
+                    failed_dataset = d
+                    break
 
-    # check whether we have a dataset set to flush
-    print('scr_postrun: Looking for most recent checkpoint')
-    dsets_ckpt = scr_flush_file.list_dsets_ckpt(before=failed_dataset)
-    if not dsets_ckpt:
-      print('scr_postrun: Found no checkpoint to scavenge')
-    else:
-      for d in dsets_ckpt:
-        if d in attempted:
-          if d in succeeded:
-            # already got this one above, update current, and finish
-            dsetname = scr_flush_file.name(d)
-            if dsetname:
-              print('scr_postrun: Already scavenged checkpoint dataset ' + d)
-              print('scr_postrun: Updating current marker in index to ' +
-                    dsetname)
-              scr_index.current(dsetname)
-              ret = 0
-              break
-          else:
-            # already tried and failed, skip this dataset
-            print('scr_postrun: Skipping checkpoint dataset ' + d +
-                  ', since already failed to scavenge')
-            continue
+                # build full path to dataset directory
+                datadir = scr_env.dir_dset(d)
+                os.makedirs(datadir, exist_ok=True)
 
-        # we have a dataset, check whether it still needs to be flushed
+                # Gather files from cache to parallel file system
+                print('scr_postrun: Scavenging files from cache for ' +
+                      dsetname + ' to ' + datadir)
+                if scr_scavenge(nodeset_job=scr_nodelist,
+                                nodeset_up=upnodes,
+                                dataset_id=d,
+                                cntldir=cntldir,
+                                prefixdir=pardir,
+                                verbose=verbose,
+                                scr_env=scr_env,
+                                log=log) != 1:
+                    print(
+                        'scr_postrun: Done scavenging files from cache for ' +
+                        dsetname + ' to ' + datadir)
+                else:
+                    print(
+                        'scr_postrun: ERROR: Scavenge files from cache for ' +
+                        dsetname + ' to ' + datadir)
 
-        if not scr_flush_file.need_flush(d):
-          # found a dataset that has already been flushed, we can quit
-          print('scr_postrun: Checkpoint dataset ' + d +
-                ' has already been flushed')
-          ret = 0
-          break
-        print('scr_postrun: Attempting to scavenge checkpoint dataset ' + d)
+                # check that gathered set is complete,
+                # if not, don't update current marker
+                #update_current=1
+                print('scr_postrun: Checking that dataset is complete')
+                if not scr_index.build(d):
+                    # failed to get dataset, stop trying for later sets
+                    failed_dataset = d
+                    break
 
-        # get dataset name
-        dsetname = scr_flush_file.name(d)
-        if not dsetname:
-          # got a dataset to flush, but failed to get name
-          print('scr_postrun: Failed to read name of checkpoint dataset ' + d)
-          continue
+                # remember that we scavenged this dataset in case we try again below
+                succeeded.append(d)
+                print('scr_postrun: Scavenged dataset ' + dsetname +
+                      ' successfully')
 
-        # build full path to dataset directory
-        datadir = scr_env.dir_dset(d)
-        os.makedirs(datadir, exist_ok=True)
-
-        # Gather files from cache to parallel file system
-        print('scr_postrun: Scavenging files from cache for checkpoint ' +
-              dsetname + ' to ' + datadir)
-        if scr_scavenge(nodeset_job=scr_nodelist,
-                        nodeset_up=upnodes,
-                        dataset_id=d,
-                        cntldir=cntldir,
-                        prefixdir=pardir,
-                        verbose=verbose,
-                        scr_env=scr_env,
-                        log=log) != 1:
-          print('scr_postrun: Done scavenging files from cache for ' +
-                dsetname + ' to ' + datadir)
+        # check whether we have a dataset set to flush
+        print('scr_postrun: Looking for most recent checkpoint')
+        dsets_ckpt = scr_flush_file.list_dsets_ckpt(before=failed_dataset)
+        if not dsets_ckpt:
+            print('scr_postrun: Found no checkpoint to scavenge')
         else:
-          print('scr_postrun: ERROR: Scavenge files from cache for ' +
-                dsetname + ' to ' + datadir)
+            for d in dsets_ckpt:
+                if d in attempted:
+                    if d in succeeded:
+                        # already got this one above, update current, and finish
+                        dsetname = scr_flush_file.name(d)
+                        if dsetname:
+                            print(
+                                'scr_postrun: Already scavenged checkpoint dataset '
+                                + d)
+                            print(
+                                'scr_postrun: Updating current marker in index to '
+                                + dsetname)
+                            scr_index.current(dsetname)
+                            ret = 0
+                            break
+                    else:
+                        # already tried and failed, skip this dataset
+                        print('scr_postrun: Skipping checkpoint dataset ' + d +
+                              ', since already failed to scavenge')
+                        continue
 
-        # check that gathered set is complete,
-        print('scr_postrun: Checking that dataset is complete')
-        if scr_index.build(d):
-          # make the new current
-          # just completed scavenging this dataset, so quit
-          print('scr_postrun: Updating current marker in index to ' + dsetname)
-          scr_index.current(dsetname)
-          ret = 0
-          break
+                # we have a dataset, check whether it still needs to be flushed
 
-  # print the timing info
-  end_time = datetime.now()
-  end_secs = int(time())
-  run_secs = end_secs - start_secs
-  print('scr_postrun: Ended: ' + str(end_time))
-  print('scr_postrun: secs: ' + str(run_secs))
+                if not scr_flush_file.need_flush(d):
+                    # found a dataset that has already been flushed, we can quit
+                    print('scr_postrun: Checkpoint dataset ' + d +
+                          ' has already been flushed')
+                    ret = 0
+                    break
+                print(
+                    'scr_postrun: Attempting to scavenge checkpoint dataset ' +
+                    d)
 
-  # print the exit code and exit
-  print('scr_postrun: exit code: ' + str(ret))
-  return ret
+                # get dataset name
+                dsetname = scr_flush_file.name(d)
+                if not dsetname:
+                    # got a dataset to flush, but failed to get name
+                    print(
+                        'scr_postrun: Failed to read name of checkpoint dataset '
+                        + d)
+                    continue
+
+                # build full path to dataset directory
+                datadir = scr_env.dir_dset(d)
+                os.makedirs(datadir, exist_ok=True)
+
+                # Gather files from cache to parallel file system
+                print(
+                    'scr_postrun: Scavenging files from cache for checkpoint '
+                    + dsetname + ' to ' + datadir)
+                if scr_scavenge(nodeset_job=scr_nodelist,
+                                nodeset_up=upnodes,
+                                dataset_id=d,
+                                cntldir=cntldir,
+                                prefixdir=pardir,
+                                verbose=verbose,
+                                scr_env=scr_env,
+                                log=log) != 1:
+                    print(
+                        'scr_postrun: Done scavenging files from cache for ' +
+                        dsetname + ' to ' + datadir)
+                else:
+                    print(
+                        'scr_postrun: ERROR: Scavenge files from cache for ' +
+                        dsetname + ' to ' + datadir)
+
+                # check that gathered set is complete,
+                print('scr_postrun: Checking that dataset is complete')
+                if scr_index.build(d):
+                    # make the new current
+                    # just completed scavenging this dataset, so quit
+                    print('scr_postrun: Updating current marker in index to ' +
+                          dsetname)
+                    scr_index.current(dsetname)
+                    ret = 0
+                    break
+
+    # print the timing info
+    end_time = datetime.now()
+    end_secs = int(time())
+    run_secs = end_secs - start_secs
+    print('scr_postrun: Ended: ' + str(end_time))
+    print('scr_postrun: secs: ' + str(run_secs))
+
+    # print the exit code and exit
+    print('scr_postrun: exit code: ' + str(ret))
+    return ret

--- a/scripts/python/scrjob/resmgrs/auto.py
+++ b/scripts/python/scrjob/resmgrs/auto.py
@@ -24,27 +24,28 @@ from scrjob.resmgrs import (
 
 
 class AutoResourceManager:
-  def __new__(cls, resmgr=None):
-    # see if we are in a flux instance
-    try:
-      fluxresmgr = FLUX()
-      return fluxresmgr
-    # not in a flux instance, just continue
-    except:
-      pass
-    if resmgr is None:
-      resmgr = scr_const.SCR_RESOURCE_MANAGER
-    if resmgr == 'SLURM':
-      return SLURM()
-    if resmgr == 'LSF':
-      return LSF()
-    if resmgr == 'APRUN':
-      return APRUN()
-    #if resmgr=='PMIX':
-    #  return PMIX()
-    return ResourceManager()
+
+    def __new__(cls, resmgr=None):
+        # see if we are in a flux instance
+        try:
+            fluxresmgr = FLUX()
+            return fluxresmgr
+        # not in a flux instance, just continue
+        except:
+            pass
+        if resmgr is None:
+            resmgr = scr_const.SCR_RESOURCE_MANAGER
+        if resmgr == 'SLURM':
+            return SLURM()
+        if resmgr == 'LSF':
+            return LSF()
+        if resmgr == 'APRUN':
+            return APRUN()
+        #if resmgr=='PMIX':
+        #  return PMIX()
+        return ResourceManager()
 
 
 if __name__ == '__main__':
-  resourcemgr = AutoResourceManager()
-  print(type(resourcemgr))
+    resourcemgr = AutoResourceManager()
+    print(type(resourcemgr))

--- a/scripts/python/scrjob/resmgrs/flux.py
+++ b/scripts/python/scrjob/resmgrs/flux.py
@@ -11,73 +11,77 @@ from scrjob.resmgrs import nodetests, ResourceManager
 
 # flux imports
 try:
-  import flux
-  from flux.hostlist import Hostlist
-  from flux.resource import ResourceSet
-  from flux.rpc import RPC
-  from flux.job import JobID, JobInfo, JobList
+    import flux
+    from flux.hostlist import Hostlist
+    from flux.resource import ResourceSet
+    from flux.rpc import RPC
+    from flux.job import JobID, JobInfo, JobList
 except:
-  pass
+    pass
+
 
 class FLUX(ResourceManager):
-  # init initializes vars from the environment
-  def __init__(self):
-    try:
-      self.flux = flux.Flux()
-    except:
-      raise ImportError('Error importing flux, ensure that the flux daemon is running.')
-    # the super.init() calls resmgr.get_job_nodes, we must set self.flux first
-    super(FLUX, self).__init__(resmgr='FLUX')
-    ### set the jobid once at init
-    self.jobid = None
-    self.jobid = self.getjobid()
+    # init initializes vars from the environment
+    def __init__(self):
+        try:
+            self.flux = flux.Flux()
+        except:
+            raise ImportError(
+                'Error importing flux, ensure that the flux daemon is running.'
+            )
+        # the super.init() calls resmgr.get_job_nodes, we must set self.flux first
+        super(FLUX, self).__init__(resmgr='FLUX')
+        ### set the jobid once at init
+        self.jobid = None
+        self.jobid = self.getjobid()
 
-  ####
-  # the job id of the allocation is needed in postrun/list_dir
-  # the job id is a component of the path.
-  # We can either copy methods from existing resource managers . . .
-  # or we can use the POSIX timestamp and set the value at __init__
-  def getjobid(self):
-    if self.jobid is not None:
-      return self.jobid
+    ####
+    # the job id of the allocation is needed in postrun/list_dir
+    # the job id is a component of the path.
+    # We can either copy methods from existing resource managers . . .
+    # or we can use the POSIX timestamp and set the value at __init__
+    def getjobid(self):
+        if self.jobid is not None:
+            return self.jobid
 
-    jobid_str = os.environ.get('FLUX_JOB_ID')
-    if jobid_str is None:
-      jobid = JobID(self.flux.attr_get("jobid"))
-    else:
-      jobid = self.flux.job.JobID.id_parse(jobid_str)
+        jobid_str = os.environ.get('FLUX_JOB_ID')
+        if jobid_str is None:
+            jobid = JobID(self.flux.attr_get("jobid"))
+        else:
+            jobid = self.flux.job.JobID.id_parse(jobid_str)
 
-    return str(jobid)
+        return str(jobid)
 
-  # get node list
-  def get_job_nodes(self):
-    resp = RPC(self.flux, "resource.status").get()
-    rset = ResourceSet(resp["R"])
-    return str(rset.nodelist)
+    # get node list
+    def get_job_nodes(self):
+        resp = RPC(self.flux, "resource.status").get()
+        rset = ResourceSet(resp["R"])
+        return str(rset.nodelist)
 
-  def get_downnodes(self):
-    downnodes = {}
-    resp = RPC(self.flux, "resource.status").get()
-    rset = ResourceSet(resp["R"])
-    offline = str(resp['offline'])
-    exclude = str(resp['exclude'])
-    offline = self.expand_hosts(offline)
-    exclude = self.expand_hosts(offline)
-    for node in offline:
-      if node != '' and node not in downnodes:
-        downnodes[node] = 'Reported down by resource manager'
-    for node in exclude:
-      if node != '' and node not in downnodes:
-        downnodes[node] = 'Excluded by resource manager'
-    return downnodes
+    def get_downnodes(self):
+        downnodes = {}
+        resp = RPC(self.flux, "resource.status").get()
+        rset = ResourceSet(resp["R"])
+        offline = str(resp['offline'])
+        exclude = str(resp['exclude'])
+        offline = self.expand_hosts(offline)
+        exclude = self.expand_hosts(offline)
+        for node in offline:
+            if node != '' and node not in downnodes:
+                downnodes[node] = 'Reported down by resource manager'
+        for node in exclude:
+            if node != '' and node not in downnodes:
+                downnodes[node] = 'Excluded by resource manager'
+        return downnodes
 
-  def get_scr_end_time(self):
-    jobid_str = os.environ.get('FLUX_JOB_ID')
-    if jobid_str is None:
-      parent = flux.Flux(self.flux.attr_get("parent-uri"))
-      info = JobList(parent, ids=[self.jobid]).fetch_jobs().get_jobs()[0]
-    else:
-      info = JobList(self.flux, ids=[self.jobid]).fetch_jobs().get_jobs()[0]
-    endtime = info["expiration"]
+    def get_scr_end_time(self):
+        jobid_str = os.environ.get('FLUX_JOB_ID')
+        if jobid_str is None:
+            parent = flux.Flux(self.flux.attr_get("parent-uri"))
+            info = JobList(parent, ids=[self.jobid]).fetch_jobs().get_jobs()[0]
+        else:
+            info = JobList(self.flux,
+                           ids=[self.jobid]).fetch_jobs().get_jobs()[0]
+        endtime = info["expiration"]
 
-    return endtime
+        return endtime

--- a/scripts/python/scrjob/resmgrs/lsf.py
+++ b/scripts/python/scrjob/resmgrs/lsf.py
@@ -12,97 +12,97 @@ from scrjob.resmgrs import nodetests, ResourceManager
 
 
 class LSF(ResourceManager):
-  # init initializes vars from the environment
-  def __init__(self):
-    super(LSF, self).__init__(resmgr='LSF')
-    if 'pdsh_echo' not in self.nodetests.tests:
-      self.nodetests.tests.append('pdsh_echo')
+    # init initializes vars from the environment
+    def __init__(self):
+        super(LSF, self).__init__(resmgr='LSF')
+        if 'pdsh_echo' not in self.nodetests.tests:
+            self.nodetests.tests.append('pdsh_echo')
 
-  # get LSF jobid
-  def getjobid(self):
-    return os.environ.get('LSB_JOBID')
+    # get LSF jobid
+    def getjobid(self):
+        return os.environ.get('LSB_JOBID')
 
-  # get node list
-  def get_job_nodes(self):
-    hostfile = os.environ.get('LSB_DJOB_HOSTFILE')
-    if hostfile is not None:
-      try:
-        # make a list from the set -> make a set from the list -> file.readlines().rstrip('\n')
-        # get a list of lines without newlines and skip the first line
-        lines = []
-        with open(hostfile, 'r') as f:
-          lines = [line.strip() for line in f.readlines()]
-        if len(lines) == 0:
-          raise ValueError('Hostfile empty')
+    # get node list
+    def get_job_nodes(self):
+        hostfile = os.environ.get('LSB_DJOB_HOSTFILE')
+        if hostfile is not None:
+            try:
+                # make a list from the set -> make a set from the list -> file.readlines().rstrip('\n')
+                # get a list of lines without newlines and skip the first line
+                lines = []
+                with open(hostfile, 'r') as f:
+                    lines = [line.strip() for line in f.readlines()]
+                if len(lines) == 0:
+                    raise ValueError('Hostfile empty')
 
-        # get a set of unique hostnames, convert list to set and back
-        hostlist = list(set(lines[1:]))
-        hostlist = self.compress_hosts(hostlist)
-        return hostlist
-      except Exception as e:
-        # failed to read file
-        print('ERROR: LSF.get_job_nodes')
-        print(e)
-    return None
+                # get a set of unique hostnames, convert list to set and back
+                hostlist = list(set(lines[1:]))
+                hostlist = self.compress_hosts(hostlist)
+                return hostlist
+            except Exception as e:
+                # failed to read file
+                print('ERROR: LSF.get_job_nodes')
+                print(e)
+        return None
 
-    # fall back to try LSB_HOSTS
-    hosts = os.environ.get('LSB_HOSTS')
-    if hosts is not None:
-      hosts = hosts.split(' ')
-      hosts = list(set(hosts[1:]))
-      hosts = self.compress_hosts(hosts)
-    return hosts
+        # fall back to try LSB_HOSTS
+        hosts = os.environ.get('LSB_HOSTS')
+        if hosts is not None:
+            hosts = hosts.split(' ')
+            hosts = list(set(hosts[1:]))
+            hosts = self.compress_hosts(hosts)
+        return hosts
 
-  def get_downnodes(self):
-    # TODO : any way to get list of down nodes in LSF?
-    return {}
+    def get_downnodes(self):
+        # TODO : any way to get list of down nodes in LSF?
+        return {}
 
-  def get_scr_end_time(self):
-    # run bjobs to get time remaining in current allocation
-    bjobs, rc = runproc("bjobs -o time_left", getstdout=True)
-    if rc != 0:
-      return 0
+    def get_scr_end_time(self):
+        # run bjobs to get time remaining in current allocation
+        bjobs, rc = runproc("bjobs -o time_left", getstdout=True)
+        if rc != 0:
+            return 0
 
-    # parse bjobs output
-    lines = bjobs.split('\n')
-    for line in lines:
-      line = line.strip()
+        # parse bjobs output
+        lines = bjobs.split('\n')
+        for line in lines:
+            line = line.strip()
 
-      # skip empty lines
-      if len(line) == 0:
-        continue
+            # skip empty lines
+            if len(line) == 0:
+                continue
 
-      # the following is printed if there is no limit
-      #   bjobs -o 'time_left'
-      #   TIME_LEFT
-      #   -
-      # look for the "-", in this case,
-      # return -1 to indicate there is no limit
-      if line.startswith('-'):
-        # no limit
-        return -1
+            # the following is printed if there is no limit
+            #   bjobs -o 'time_left'
+            #   TIME_LEFT
+            #   -
+            # look for the "-", in this case,
+            # return -1 to indicate there is no limit
+            if line.startswith('-'):
+                # no limit
+                return -1
 
-      # the following is printed if there is a limit
-      #   bjobs -o 'time_left'
-      #   TIME_LEFT
-      #   0:12 L
-      # look for a line like "0:12 L",
-      # avoid matching the "L" since other characters can show up there
-      pieces = re.split(r'(^\s*)(\d+):(\d+)\s+', line)
-      if len(pieces) < 3:
-        continue
-      #print(line)
+            # the following is printed if there is a limit
+            #   bjobs -o 'time_left'
+            #   TIME_LEFT
+            #   0:12 L
+            # look for a line like "0:12 L",
+            # avoid matching the "L" since other characters can show up there
+            pieces = re.split(r'(^\s*)(\d+):(\d+)\s+', line)
+            if len(pieces) < 3:
+                continue
+            #print(line)
 
-      # get current secs since epoch
-      secs_now = int(time())
+            # get current secs since epoch
+            secs_now = int(time())
 
-      # compute seconds left in job
-      hours = int(pieces[2])
-      mins = int(pieces[3])
-      secs_remaining = ((hours * 60) + mins) * 60
+            # compute seconds left in job
+            hours = int(pieces[2])
+            mins = int(pieces[3])
+            secs_remaining = ((hours * 60) + mins) * 60
 
-      secs = secs_now + secs_remaining
-      return secs
+            secs = secs_now + secs_remaining
+            return secs
 
-    # had a problem executing bjobs command
-    return 0
+        # had a problem executing bjobs command
+        return 0

--- a/scripts/python/scrjob/resmgrs/nodetests.py
+++ b/scripts/python/scrjob/resmgrs/nodetests.py
@@ -5,211 +5,213 @@ from scrjob import scr_const
 from scrjob.scr_common import runproc
 from scrjob.list_dir import list_dir
 
+
 class Nodetests:
-  def __init__(self):
-    # The list_dir() method uses a free flag iff it is the first run
-    # other tests could perform alternate behavior during first/subsequent runs
-    self.firstrun = True
-    # the ping executable
-    self.pingexe = 'ping'
-    # First try to read the environment variable
-    self.tests = os.environ.get('SCR_NODE_TESTS')
-    if self.tests is not None:
-      self.tests = self.tests.split(',')
-    elif scr_const.SCR_NODE_TESTS != '':
-      self.tests = scr_const.SCR_NODE_TESTS.split(',')
-    elif scr_const.SCR_NODE_TESTS_FILE != '':
-      try:
-        self.tests = []
-        with open(scr_const.SCR_NODE_TESTS_FILE,'r') as infile:
-          for line in infile.readlines():
-            line = line.strip()
-            if line != '':
-              self.tests.extend(line.split(','))
-      except:
-        print('nodetests.py: ERROR: Unable to open file ' + scr_const.SCR_NODE_TESTS_FILE)
-    else:
-      self.tests = []
 
-  def __call__(self,
-               nodes=[],
-               scr_env=None):
-    if type(nodes) is str:
-      nodes = nodes.split(',')
-    # This method returns a dictionary of unavailable nodes
-    #   keyed on node with the reason as the value
-    unavailable = {}
-    # mark any nodes to explicitly exclude via SCR_EXCLUDE_NODES
-    nodelist = scr_env.resmgr.expand_hosts(scr_env.param.get('SCR_EXCLUDE_NODES'))
-    for node in nodelist:
-      if node == '':
-        continue
-      if node in nodes:
-        nodes.remove(node)
-      unavailable[node] = 'User excluded via SCR_EXCLUDE_NODES'
-    # mark the set of nodes the resource manager thinks is down
-    nodelist = scr_env.resmgr.get_downnodes()
-    for node in nodelist:
-      if node == '':
-        continue
-      if node in nodes:
-        nodes.remove(node)
-      unavailable[node] = nodelist[node]
-    # iterate through user selected tests
-    for test in self.tests:
-      # if all of the nodes have failed discontinue the tests
-      if nodes == []:
-        break
-      try:
-        testmethod = getattr(self, test)
-        if callable(testmethod):
-          nextunavailable = testmethod(nodes=nodes,scr_env=scr_env)
-          unavailable.update(nextunavailable)
+    def __init__(self):
+        # The list_dir() method uses a free flag iff it is the first run
+        # other tests could perform alternate behavior during first/subsequent runs
+        self.firstrun = True
+        # the ping executable
+        self.pingexe = 'ping'
+        # First try to read the environment variable
+        self.tests = os.environ.get('SCR_NODE_TESTS')
+        if self.tests is not None:
+            self.tests = self.tests.split(',')
+        elif scr_const.SCR_NODE_TESTS != '':
+            self.tests = scr_const.SCR_NODE_TESTS.split(',')
+        elif scr_const.SCR_NODE_TESTS_FILE != '':
+            try:
+                self.tests = []
+                with open(scr_const.SCR_NODE_TESTS_FILE, 'r') as infile:
+                    for line in infile.readlines():
+                        line = line.strip()
+                        if line != '':
+                            self.tests.extend(line.split(','))
+            except:
+                print('nodetests.py: ERROR: Unable to open file ' +
+                      scr_const.SCR_NODE_TESTS_FILE)
         else:
-          print('Nodetests: ERROR: ' + test + ' is defined but is not a test method.')
-      except AttributeError as e:
-        print('Nodetests: ERROR: ' + test + ' is not defined.')
-        print('dir(self)='+str(dir(self)))
-      except Exception as e:
-        print('Nodetests: ERROR: Unable to perform the ' + test + ' test.')
-        print(e)
-    # allow alternate behavior on subsequent runs
-    self.firstrun = False
-    return unavailable
+            self.tests = []
 
-  # mark any nodes that fail to respond to (up to 2) ping(s)
-  def ping(self,
-           nodes=[],
-           scr_env=None):
-    unavailable = {}
-    # `$ping -c 1 -w 1 $node 2>&1 || $ping -c 1 -w 1 $node 2>&1`;
-    argv = [self.pingexe, '-c', '1', '-w', '1', '']
-    for node in nodes:
-      argv[5] = node
-      returncode = runproc(argv=argv)[1]
-      if returncode != 0:
-        returncode = runproc(argv=argv)[1]
-        if returncode != 0:
-          unavailable[node] = 'Failed to ping'
-    for node in unavailable:
-      if node in nodes:
-        nodes.remove(node)
-    return unavailable
+    def __call__(self, nodes=[], scr_env=None):
+        if type(nodes) is str:
+            nodes = nodes.split(',')
+        # This method returns a dictionary of unavailable nodes
+        #   keyed on node with the reason as the value
+        unavailable = {}
+        # mark any nodes to explicitly exclude via SCR_EXCLUDE_NODES
+        nodelist = scr_env.resmgr.expand_hosts(
+            scr_env.param.get('SCR_EXCLUDE_NODES'))
+        for node in nodelist:
+            if node == '':
+                continue
+            if node in nodes:
+                nodes.remove(node)
+            unavailable[node] = 'User excluded via SCR_EXCLUDE_NODES'
+        # mark the set of nodes the resource manager thinks is down
+        nodelist = scr_env.resmgr.get_downnodes()
+        for node in nodelist:
+            if node == '':
+                continue
+            if node in nodes:
+                nodes.remove(node)
+            unavailable[node] = nodelist[node]
+        # iterate through user selected tests
+        for test in self.tests:
+            # if all of the nodes have failed discontinue the tests
+            if nodes == []:
+                break
+            try:
+                testmethod = getattr(self, test)
+                if callable(testmethod):
+                    nextunavailable = testmethod(nodes=nodes, scr_env=scr_env)
+                    unavailable.update(nextunavailable)
+                else:
+                    print('Nodetests: ERROR: ' + test +
+                          ' is defined but is not a test method.')
+            except AttributeError as e:
+                print('Nodetests: ERROR: ' + test + ' is not defined.')
+                print('dir(self)=' + str(dir(self)))
+            except Exception as e:
+                print('Nodetests: ERROR: Unable to perform the ' + test +
+                      ' test.')
+                print(e)
+        # allow alternate behavior on subsequent runs
+        self.firstrun = False
+        return unavailable
 
-  # mark any nodes that don't respond to pdsh echo up
-  def pdsh_echo(self,
-                nodes=[],
-                scr_env=None):
-    unavailable = {}
-    pdsh_assumed_down = nodes.copy()
-    # only run this against set of nodes known to be responding
-    # run an "echo UP" on each node to check whether it works
-    output = scr_env.launcher.parallel_exec(argv=['echo', 'UP'],
-                                            runnodes=','.join(nodes))[0][0]
-    for line in output.split('\n'):
-      if len(line) == 0:
-        continue
-      if 'UP' in line:
-        uphost = line.split(':')[0]
-        if uphost in pdsh_assumed_down:
-          pdsh_assumed_down.remove(uphost)
-  
-    # if we still have any nodes assumed down, update our available/unavailable lists
-    for node in pdsh_assumed_down:
-      nodes.remove(node)
-      unavailable[node] = 'Failed to pdsh echo UP'
-    return unavailable
+    # mark any nodes that fail to respond to (up to 2) ping(s)
+    def ping(self, nodes=[], scr_env=None):
+        unavailable = {}
+        # `$ping -c 1 -w 1 $node 2>&1 || $ping -c 1 -w 1 $node 2>&1`;
+        argv = [self.pingexe, '-c', '1', '-w', '1', '']
+        for node in nodes:
+            argv[5] = node
+            returncode = runproc(argv=argv)[1]
+            if returncode != 0:
+                returncode = runproc(argv=argv)[1]
+                if returncode != 0:
+                    unavailable[node] = 'Failed to ping'
+        for node in unavailable:
+            if node in nodes:
+                nodes.remove(node)
+        return unavailable
 
-  # mark nodes that fail the capacity check
-  def dir_capacity(self,
-                   nodes=[],
-                   #free=False, ###free is only true during the _first_ run
-                   scr_env=None):
-    cntldir_string = list_dir(base=True,
-                              runcmd='control',
-                              scr_env=scr_env,
-                              bindir=scr_const.X_BINDIR)
-    cachedir_string = list_dir(base=True,
-                               runcmd='cache',
-                               scr_env=scr_env,
-                               bindir=scr_const.X_BINDIR)
-    unavailable = {}
-    param = scr_env.param
-    # specify whether to check total or free capacity in directories
-    #if free: free_flag = '--free'
+    # mark any nodes that don't respond to pdsh echo up
+    def pdsh_echo(self, nodes=[], scr_env=None):
+        unavailable = {}
+        pdsh_assumed_down = nodes.copy()
+        # only run this against set of nodes known to be responding
+        # run an "echo UP" on each node to check whether it works
+        output = scr_env.launcher.parallel_exec(argv=['echo', 'UP'],
+                                                runnodes=','.join(nodes))[0][0]
+        for line in output.split('\n'):
+            if len(line) == 0:
+                continue
+            if 'UP' in line:
+                uphost = line.split(':')[0]
+                if uphost in pdsh_assumed_down:
+                    pdsh_assumed_down.remove(uphost)
 
-    # check that control and cache directories on each node work and are of proper size
-    # get the control directory the job will use
-    cntldir_vals = []
-    # cntldir_string = `$bindir/scr_list_dir --base control`;
-    if type(cntldir_string) is str and len(cntldir_string) != 0:
-      dirs = cntldir_string.split(' ')
-      cntldirs = param.get_hash('CNTLDIR')
-      for base in dirs:
-        if len(base) < 1:
-          continue
-        val = base
-        if cntldirs is not None and base in cntldirs and 'BYTES' in cntldirs[
-            base]:
-          if len(cntldirs[base]['BYTES'].keys()) > 0:
-            size = list(cntldirs[base]['BYTES'].keys())[
-                0]  #(keys %{$$cntldirs{$base}{"BYTES"}})[0];
-            #if (defined $size) {
-            size = param.abtoull(size)
-            #  $size = $param->abtoull($size);
-            val += ':' + str(size)
-            #  $val = "$base:$size";
-        cntldir_vals.append(val)
+        # if we still have any nodes assumed down, update our available/unavailable lists
+        for node in pdsh_assumed_down:
+            nodes.remove(node)
+            unavailable[node] = 'Failed to pdsh echo UP'
+        return unavailable
 
-    cntldir_flag = []
-    if len(cntldir_vals) > 0:
-      cntldir_flag = ['--cntl', ','.join(cntldir_vals)]
+    # mark nodes that fail the capacity check
+    def dir_capacity(
+            self,
+            nodes=[],
+            #free=False, ###free is only true during the _first_ run
+            scr_env=None):
+        cntldir_string = list_dir(base=True,
+                                  runcmd='control',
+                                  scr_env=scr_env,
+                                  bindir=scr_const.X_BINDIR)
+        cachedir_string = list_dir(base=True,
+                                   runcmd='cache',
+                                   scr_env=scr_env,
+                                   bindir=scr_const.X_BINDIR)
+        unavailable = {}
+        param = scr_env.param
+        # specify whether to check total or free capacity in directories
+        #if free: free_flag = '--free'
 
-    # get the cache directory the job will use
-    cachedir_vals = []
-    #`$bindir/scr_list_dir --base cache`;
-    if type(cachedir_string) is str and len(cachedir_string) != 0:
-      dirs = cachedir_string.split(' ')
-      cachedirs = param.get_hash('CACHEDIR')
-      for base in dirs:
-        if len(base) < 1:
-          continue
-        val = base
-        if cachedirs is not None and base in cachedirs and 'BYTES' in cachedirs[
-            base]:
-          if len(cachedirs[base]['BYTES'].keys()) > 0:
-            size = list(cachedirs[base]['BYTES'].keys())[0]
-            #my $size = (keys %{$$cachedirs{$base}{"BYTES"}})[0];
-            #if (defined $size) {
-            size = param.abtoull(size)
-            #  $size = $param->abtoull($size);
-            val += ':' + str(size)
-            #  $val = "$base:$size";
-        cachedir_vals.append(val)
+        # check that control and cache directories on each node work and are of proper size
+        # get the control directory the job will use
+        cntldir_vals = []
+        # cntldir_string = `$bindir/scr_list_dir --base control`;
+        if type(cntldir_string) is str and len(cntldir_string) != 0:
+            dirs = cntldir_string.split(' ')
+            cntldirs = param.get_hash('CNTLDIR')
+            for base in dirs:
+                if len(base) < 1:
+                    continue
+                val = base
+                if cntldirs is not None and base in cntldirs and 'BYTES' in cntldirs[
+                        base]:
+                    if len(cntldirs[base]['BYTES'].keys()) > 0:
+                        size = list(cntldirs[base]['BYTES'].keys())[
+                            0]  #(keys %{$$cntldirs{$base}{"BYTES"}})[0];
+                        #if (defined $size) {
+                        size = param.abtoull(size)
+                        #  $size = $param->abtoull($size);
+                        val += ':' + str(size)
+                        #  $val = "$base:$size";
+                cntldir_vals.append(val)
 
-    cachedir_flag = []
-    if len(cachedir_vals) > 0:
-      cachedir_flag = ['--cache', ','.join(cachedir_vals)]
+        cntldir_flag = []
+        if len(cntldir_vals) > 0:
+            cntldir_flag = ['--cntl', ','.join(cntldir_vals)]
 
-    # only run this against set of nodes known to be responding
-    upnodes = scr_env.resmgr.compress_hosts(nodes)
+        # get the cache directory the job will use
+        cachedir_vals = []
+        #`$bindir/scr_list_dir --base cache`;
+        if type(cachedir_string) is str and len(cachedir_string) != 0:
+            dirs = cachedir_string.split(' ')
+            cachedirs = param.get_hash('CACHEDIR')
+            for base in dirs:
+                if len(base) < 1:
+                    continue
+                val = base
+                if cachedirs is not None and base in cachedirs and 'BYTES' in cachedirs[
+                        base]:
+                    if len(cachedirs[base]['BYTES'].keys()) > 0:
+                        size = list(cachedirs[base]['BYTES'].keys())[0]
+                        #my $size = (keys %{$$cachedirs{$base}{"BYTES"}})[0];
+                        #if (defined $size) {
+                        size = param.abtoull(size)
+                        #  $size = $param->abtoull($size);
+                        val += ':' + str(size)
+                        #  $val = "$base:$size";
+                cachedir_vals.append(val)
 
-    # run scr_check_node on each node specifying control and cache directories to check
-    argv = [scr_const.X_BINDIR + '/scrpy/scrjob/scr_check_node.py']
-    if self.firstrun:
-      argv.append('--free')
-    argv.extend(cntldir_flag)
-    argv.extend(cachedir_flag)
-    output = scr_env.launcher.parallel_exec(argv=argv, runnodes=upnodes)[0][0]
-    action = 0  # tracking action to use range iterator and follow original line <- shift flow
-    nodeset = ''
-    for line in output.split('\n'):
-      if line == '':
-        continue
-      if 'FAIL' in line:
-        parts = line.split(':')
-        node = parts[0]
-        if node in nodes:
-          nodes.remove(node)
-          unavailable[node] = parts[1][1:]
-    return unavailable
+        cachedir_flag = []
+        if len(cachedir_vals) > 0:
+            cachedir_flag = ['--cache', ','.join(cachedir_vals)]
+
+        # only run this against set of nodes known to be responding
+        upnodes = scr_env.resmgr.compress_hosts(nodes)
+
+        # run scr_check_node on each node specifying control and cache directories to check
+        argv = [scr_const.X_BINDIR + '/scrpy/scrjob/scr_check_node.py']
+        if self.firstrun:
+            argv.append('--free')
+        argv.extend(cntldir_flag)
+        argv.extend(cachedir_flag)
+        output = scr_env.launcher.parallel_exec(argv=argv,
+                                                runnodes=upnodes)[0][0]
+        action = 0  # tracking action to use range iterator and follow original line <- shift flow
+        nodeset = ''
+        for line in output.split('\n'):
+            if line == '':
+                continue
+            if 'FAIL' in line:
+                parts = line.split(':')
+                node = parts[0]
+                if node in nodes:
+                    nodes.remove(node)
+                    unavailable[node] = parts[1][1:]
+        return unavailable

--- a/scripts/python/scrjob/resmgrs/pbsalps.py
+++ b/scripts/python/scrjob/resmgrs/pbsalps.py
@@ -11,49 +11,50 @@ from scrjob.resmgrs import nodetests, ResourceManager
 
 
 class PBSALPS(ResourceManager):
-  # init initializes vars from the environment
-  def __init__(self, env=None):
-    super(PBSALPS, self).__init__(resmgr='PBSALPS')
-    if 'ping' not in self.nodetests.tests:
-      self.nodetests.tests.append('ping')
-    if 'dir_capacity' not in self.nodetests.tests:
-      self.nodetests.tests.append('dir_capacity')
+    # init initializes vars from the environment
+    def __init__(self, env=None):
+        super(PBSALPS, self).__init__(resmgr='PBSALPS')
+        if 'ping' not in self.nodetests.tests:
+            self.nodetests.tests.append('ping')
+        if 'dir_capacity' not in self.nodetests.tests:
+            self.nodetests.tests.append('dir_capacity')
 
-  # get job id, setting environment flag here
-  def getjobid(self):
-    if self.jobid is not None:
-      return self.jobid
-    # val may be None
-    return os.environ.get('PBS_JOBID')
+    # get job id, setting environment flag here
+    def getjobid(self):
+        if self.jobid is not None:
+            return self.jobid
+        # val may be None
+        return os.environ.get('PBS_JOBID')
 
-  # get node list
-  def get_job_nodes(self):
-    val = os.environ.get('PBS_NUM_NODES')
-    if val is not None:
-      cmd = "aprun -n " + val + " -N 1 cat /proc/cray_xt/nid"  # $nidfile
-      out = runproc(cmd, getstdout=True)[0]
-      nodearray = out.split('\n')
-      if len(nodearray) > 0:
-        if nodearray[-1] == '\n':
-          nodearray = nodearray[:-1]
-        if len(nodearray) > 0:
-          if nodearray[-1].startswith('Application'):
-            nodearray = nodearray[:-1]
-          shortnodes = self.compress_hosts(nodearray)
-          return shortnodes
-    return None
+    # get node list
+    def get_job_nodes(self):
+        val = os.environ.get('PBS_NUM_NODES')
+        if val is not None:
+            cmd = "aprun -n " + val + " -N 1 cat /proc/cray_xt/nid"  # $nidfile
+            out = runproc(cmd, getstdout=True)[0]
+            nodearray = out.split('\n')
+            if len(nodearray) > 0:
+                if nodearray[-1] == '\n':
+                    nodearray = nodearray[:-1]
+                if len(nodearray) > 0:
+                    if nodearray[-1].startswith('Application'):
+                        nodearray = nodearray[:-1]
+                    shortnodes = self.compress_hosts(nodearray)
+                    return shortnodes
+        return None
 
-  def get_downnodes(self):
-    downnodes = {}
-    snodes = self.get_job_nodes()
-    if snodes is not None:
-      snodes = self.expand_hosts(snodes)
-      for node in snodes:
-        out, returncode = runproc("xtprocadmin -n " + node, getstdout=True)
-        #if returncode==0:
-        resarray = out.split('\n')
-        answerarray = resarray[1].split(' ')
-        answer = answerarray[4]
-        if 'down' in answer:
-          downnodes[node] = 'Reported down by resource manager'
-    return downnodes
+    def get_downnodes(self):
+        downnodes = {}
+        snodes = self.get_job_nodes()
+        if snodes is not None:
+            snodes = self.expand_hosts(snodes)
+            for node in snodes:
+                out, returncode = runproc("xtprocadmin -n " + node,
+                                          getstdout=True)
+                #if returncode==0:
+                resarray = out.split('\n')
+                answerarray = resarray[1].split(' ')
+                answer = answerarray[4]
+                if 'down' in answer:
+                    downnodes[node] = 'Reported down by resource manager'
+        return downnodes

--- a/scripts/python/scrjob/resmgrs/resourcemanager.py
+++ b/scripts/python/scrjob/resmgrs/resourcemanager.py
@@ -5,8 +5,9 @@ from scrjob import scr_const, scr_hostlist
 from scrjob.scr_common import scr_prefix
 from scrjob.resmgrs import Nodetests
 
+
 class ResourceManager(object):
-  """ResourceManager is the super class for the resource manager family
+    """ResourceManager is the super class for the resource manager family
 
   Provided Default Methods
   ------------------------
@@ -42,21 +43,22 @@ class ResourceManager(object):
   use_watchdog         - A boolean indicating whether to use the watchdog method
   nodetests            - An instance of the Nodetests class
   """
-  def __init__(self, resmgr='unknown'):
-    self.clustershell_nodeset = False
-    if scr_const.USE_CLUSTERSHELL != '0':
-      try:
-        import ClusterShell.NodeSet as MyCSNodeSet
-        self.clustershell_nodeset = MyCSNodeSet
-      except:
-        self.clustershell_nodeset = False
-    self.prefix = scr_prefix()
-    self.resmgr = resmgr
-    self.use_watchdog = False
-    self.nodetests = Nodetests()
 
-  def get_prerun_tests(self):
-    """This method returns a list of tests to perform during scr_prerun
+    def __init__(self, resmgr='unknown'):
+        self.clustershell_nodeset = False
+        if scr_const.USE_CLUSTERSHELL != '0':
+            try:
+                import ClusterShell.NodeSet as MyCSNodeSet
+                self.clustershell_nodeset = MyCSNodeSet
+            except:
+                self.clustershell_nodeset = False
+        self.prefix = scr_prefix()
+        self.resmgr = resmgr
+        self.use_watchdog = False
+        self.nodetests = Nodetests()
+
+    def get_prerun_tests(self):
+        """This method returns a list of tests to perform during scr_prerun
 
     Test methods must be defined in the SCR_Test_Runtime class in scr_test_runtime.py.
     Tests ensure the environment will function with SCR and may vary between environments.
@@ -67,12 +69,12 @@ class ResourceManager(object):
     list
         A list of strings, where each string is a static method in the SCR_Test_Runtime class
     """
-    # The check_clustershell method only returns failure when ClusterShell is enabled yet
-    # we are unable to import the ClusterShell module, this is a safe test for all managers
-    return ['check_clustershell']
+        # The check_clustershell method only returns failure when ClusterShell is enabled yet
+        # we are unable to import the ClusterShell module, this is a safe test for all managers
+        return ['check_clustershell']
 
-  def usewatchdog(self, use_scr_watchdog=None):
-    """Set or get the use_scr_watchdog attribute
+    def usewatchdog(self, use_scr_watchdog=None):
+        """Set or get the use_scr_watchdog attribute
 
     When not using the SCR_Watchdog, a jobstep is launched and waited on.
 
@@ -90,12 +92,12 @@ class ResourceManager(object):
         use_scr_watchdog
         or None if parameter given and attribute was set
     """
-    if use_scr_watchdog is None:
-      return self.use_watchdog
-    self.use_watchdog = use_scr_watchdog
+        if use_scr_watchdog is None:
+            return self.use_watchdog
+        self.use_watchdog = use_scr_watchdog
 
-  def getjobid(self):
-    """Return current job allocation id
+    def getjobid(self):
+        """Return current job allocation id
 
     This value is used in logging and is used in building paths for output files.
 
@@ -105,10 +107,10 @@ class ResourceManager(object):
         job allocation id
         or None if unknown or error
     """
-    return None
+        return None
 
-  def get_job_nodes(self):
-    """Return compute nodes in the allocation
+    def get_job_nodes(self):
+        """Return compute nodes in the allocation
 
     Each node should be specified once and in order.
 
@@ -118,10 +120,10 @@ class ResourceManager(object):
         list of allocation compute nodes in string format
         or None if unknown or error
     """
-    return None
+        return None
 
-  def get_downnodes(self):
-    """Return allocation compute nodes the resource manager identifies as down
+    def get_downnodes(self):
+        """Return allocation compute nodes the resource manager identifies as down
 
     Some resource managers can report nodes it has determined to be down.
     The returned list should be a subset of the allocation nodes.
@@ -133,10 +135,10 @@ class ResourceManager(object):
         dict of down compute nodes, keyed by the node, reason is a description of
         why a node is down: 'Reported down by resource manager' or 'Excluded by resource manager'
     """
-    return {}
+        return {}
 
-  def get_scr_end_time(self):
-    """Return expected allocation end time
+    def get_scr_end_time(self):
+        """Return expected allocation end time
 
     The end time must be expressed as seconds since
     the Unix epoch.
@@ -148,10 +150,10 @@ class ResourceManager(object):
         If end time is unknown or error: 0
         If there is no end time:         -1
     """
-    return 0
+        return 0
 
-  def compress_hosts(self, hostnames=[]):
-    """Return hostlist string, where the hostlist is in a compressed form
+    def compress_hosts(self, hostnames=[]):
+        """Return hostlist string, where the hostlist is in a compressed form
 
     Input parameter, hostnames, is a list or a comma separated string.
 
@@ -160,18 +162,18 @@ class ResourceManager(object):
     str
         comma separated hostlist in compressed form, e.g., 'node[1-4],node7'
     """
-    if type(hostnames) is str:
-      hostnames = hostnames.split(',')
-    if hostnames is None or len(hostnames) == 0:
-      return ''
-    if self.clustershell_nodeset != False:
-      nodeset = self.clustershell_nodeset.NodeSet.fromlist(hostnames)
-      # the type is a ClusterShell NodeSet, convert to a string
-      return str(nodeset)
-    return scr_hostlist.compress_range(hostnames)
+        if type(hostnames) is str:
+            hostnames = hostnames.split(',')
+        if hostnames is None or len(hostnames) == 0:
+            return ''
+        if self.clustershell_nodeset != False:
+            nodeset = self.clustershell_nodeset.NodeSet.fromlist(hostnames)
+            # the type is a ClusterShell NodeSet, convert to a string
+            return str(nodeset)
+        return scr_hostlist.compress_range(hostnames)
 
-  def expand_hosts(self, hostnames=''):
-    """Return list of hosts, where each element is a single host.
+    def expand_hosts(self, hostnames=''):
+        """Return list of hosts, where each element is a single host.
 
     Input parameter, hostnames, is a comma separated string or a list.
 
@@ -180,19 +182,19 @@ class ResourceManager(object):
     list
         list of expanded hosts, e.g., ['node1','node2','node3']
     """
-    if type(hostnames) is list:
-      hostnames = ','.join(hostnames)
-    if hostnames is None or hostnames == '':
-      return []
-    if self.clustershell_nodeset != False:
-      nodeset = self.clustershell_nodeset.NodeSet(hostnames)
-      # the type is a ClusterShell NodeSet, convert to a list
-      nodeset = [node for node in nodeset]
-      return nodeset
-    return scr_hostlist.expand(hostnames)
+        if type(hostnames) is list:
+            hostnames = ','.join(hostnames)
+        if hostnames is None or hostnames == '':
+            return []
+        if self.clustershell_nodeset != False:
+            nodeset = self.clustershell_nodeset.NodeSet(hostnames)
+            # the type is a ClusterShell NodeSet, convert to a list
+            nodeset = [node for node in nodeset]
+            return nodeset
+        return scr_hostlist.expand(hostnames)
 
-  def diff_hosts(self, set1=[], set2=[]):
-    """Return the set difference from 2 host lists
+    def diff_hosts(self, set1=[], set2=[]):
+        """Return the set difference from 2 host lists
 
     Input parameters, set1 and set2, are lists or comma separated strings.
 
@@ -201,28 +203,28 @@ class ResourceManager(object):
     list
         elements of set1 that do not appear in set2
     """
-    if type(set1) is str:
-      set1 = set1.split(',')
-    if type(set2) is str:
-      set2 = set2.split(',')
-    if set1 is None or set1 == []:
-      return set2 if set2 is not None else []
-    if set2 is None or set2 == []:
-      return set1
-    if self.clustershell_nodeset != False:
-      set1 = self.clustershell_nodeset.NodeSet.fromlist(set1)
-      set2 = self.clustershell_nodeset.NodeSet.fromlist(set2)
-      # strict=False is default
-      # if strict true then raises error if something in set2 not in set1
-      set1.difference_update(set2, strict=False)
-      # ( this should also work like set1 -= set2 )
-      # the type is a ClusterShell NodeSet, convert to a list
-      set1 = [node for node in set1]
-      return set1
-    return scr_hostlist.diff(set1=set1, set2=set2)
+        if type(set1) is str:
+            set1 = set1.split(',')
+        if type(set2) is str:
+            set2 = set2.split(',')
+        if set1 is None or set1 == []:
+            return set2 if set2 is not None else []
+        if set2 is None or set2 == []:
+            return set1
+        if self.clustershell_nodeset != False:
+            set1 = self.clustershell_nodeset.NodeSet.fromlist(set1)
+            set2 = self.clustershell_nodeset.NodeSet.fromlist(set2)
+            # strict=False is default
+            # if strict true then raises error if something in set2 not in set1
+            set1.difference_update(set2, strict=False)
+            # ( this should also work like set1 -= set2 )
+            # the type is a ClusterShell NodeSet, convert to a list
+            set1 = [node for node in set1]
+            return set1
+        return scr_hostlist.diff(set1=set1, set2=set2)
 
-  def intersect_hosts(self, set1=[], set2=[]):
-    """Return the set intersection of 2 host lists
+    def intersect_hosts(self, set1=[], set2=[]):
+        """Return the set intersection of 2 host lists
 
     Input parameters, set1 and set2, are lists or comma separated strings.
 
@@ -231,28 +233,26 @@ class ResourceManager(object):
     list
         elements of set1 that also appear in set2
     """
-    if type(set1) is str:
-      set1 = set1.split(',')
-    if type(set2) is str:
-      set2 = set2.split(',')
-    if set1 is None or set1 == []:
-      return []
-    if set2 is None or set2 == []:
-      return []
-    if self.clustershell_nodeset != False:
-      set1 = self.clustershell_nodeset.NodeSet.fromlist(set1)
-      set2 = self.clustershell_nodeset.NodeSet.fromlist(set2)
-      set1.intersection_update(set2)
-      # the type is a ClusterShell NodeSet, convert to a list
-      set1 = [node for node in set1]
-      return set1
-    return scr_hostlist.intersect(set1, set2)
+        if type(set1) is str:
+            set1 = set1.split(',')
+        if type(set2) is str:
+            set2 = set2.split(',')
+        if set1 is None or set1 == []:
+            return []
+        if set2 is None or set2 == []:
+            return []
+        if self.clustershell_nodeset != False:
+            set1 = self.clustershell_nodeset.NodeSet.fromlist(set1)
+            set2 = self.clustershell_nodeset.NodeSet.fromlist(set2)
+            set1.intersection_update(set2)
+            # the type is a ClusterShell NodeSet, convert to a list
+            set1 = [node for node in set1]
+            return set1
+        return scr_hostlist.intersect(set1, set2)
 
-  # return a hash to define all unavailable (down or excluded) nodes and reason
-  def list_down_nodes_with_reason(self,
-                                  nodes=[],
-                                  scr_env=None):
-    """Return down nodes with the reason they are down
+    # return a hash to define all unavailable (down or excluded) nodes and reason
+    def list_down_nodes_with_reason(self, nodes=[], scr_env=None):
+        """Return down nodes with the reason they are down
 
     Parameters
     ----------
@@ -272,12 +272,12 @@ class ResourceManager(object):
     dict
         dictionary of reported down nodes, keyed by node with reasons as values
     """
-    unavailable = self.nodetests(nodes=nodes, scr_env=scr_env)
-    return unavailable
+        unavailable = self.nodetests(nodes=nodes, scr_env=scr_env)
+        return unavailable
 
-  # each scavenge operation needs upnodes and downnodes_spaced
-  def get_scavenge_nodelists(self, upnodes='', downnodes=''):
-    """Return formatted upnodes and downnodes for joblaunchers' scavenge operation
+    # each scavenge operation needs upnodes and downnodes_spaced
+    def get_scavenge_nodelists(self, upnodes='', downnodes=''):
+        """Return formatted upnodes and downnodes for joblaunchers' scavenge operation
 
     Input parameters upnodes and downnodes are comma separated strings or lists.
 
@@ -286,28 +286,28 @@ class ResourceManager(object):
     upnodes     string, a comma separated list of up nodes
     downnodes   string, a space separated list of down nodes
     """
-    if type(upnodes) is list:
-      upnodes = ','.join(upnodes)
-    if type(downnodes) is list:
-      downnodes = ','.join(downnodes)
-    # get nodesets
-    jobnodes = self.get_job_nodes()
-    if jobnodes is None:
-      ### error handling
-      print('scr_scavenge: ERROR: Could not determine nodeset.')
-      return '', ''
-    jobnodes = self.expand_hosts(jobnodes)
-    if downnodes != '':
-      downnodes = self.expand_hosts(downnodes)
-      upnodes = self.diff_hosts(jobnodes, downnodes)
-    elif upnodes != '':
-      upnodes = self.expand_hosts(upnodes)
-      downnodes = self.diff_hosts(jobnodes, upnodes)
-    else:
-      upnodes = jobnodes
-    ##############################
-    # format up and down node sets for scavenge command
-    #################
-    upnodes = ','.join(self.expand_hosts(upnodes))
-    downnodes_spaced = ' '.join(self.expand_hosts(downnodes))
-    return upnodes, downnodes_spaced
+        if type(upnodes) is list:
+            upnodes = ','.join(upnodes)
+        if type(downnodes) is list:
+            downnodes = ','.join(downnodes)
+        # get nodesets
+        jobnodes = self.get_job_nodes()
+        if jobnodes is None:
+            ### error handling
+            print('scr_scavenge: ERROR: Could not determine nodeset.')
+            return '', ''
+        jobnodes = self.expand_hosts(jobnodes)
+        if downnodes != '':
+            downnodes = self.expand_hosts(downnodes)
+            upnodes = self.diff_hosts(jobnodes, downnodes)
+        elif upnodes != '':
+            upnodes = self.expand_hosts(upnodes)
+            downnodes = self.diff_hosts(jobnodes, upnodes)
+        else:
+            upnodes = jobnodes
+        ##############################
+        # format up and down node sets for scavenge command
+        #################
+        upnodes = ','.join(self.expand_hosts(upnodes))
+        downnodes_spaced = ' '.join(self.expand_hosts(downnodes))
+        return upnodes, downnodes_spaced

--- a/scripts/python/scrjob/resmgrs/slurm.py
+++ b/scripts/python/scrjob/resmgrs/slurm.py
@@ -9,66 +9,68 @@ from scrjob import scr_const
 from scrjob.scr_common import runproc, pipeproc
 from scrjob.resmgrs import ResourceManager
 
+
 class SLURM(ResourceManager):
-  def __init__(self):
-    super(SLURM, self).__init__(resmgr='SLURM')
-    ### need default configs.
-    if 'ping' not in self.nodetests.tests:
-      self.nodetests.tests.append('ping')
-    if 'dir_capacity' not in self.nodetests.tests:
-      self.nodetests.tests.append('dir_capacity')
 
-  # get a list of tests, methods that exist in the class SCR_Test_Runtime
-  # these tests will be ran during scr_prerun
-  def get_prerun_tests(self):
-    return ['check_clustershell','check_pdsh']
+    def __init__(self):
+        super(SLURM, self).__init__(resmgr='SLURM')
+        ### need default configs.
+        if 'ping' not in self.nodetests.tests:
+            self.nodetests.tests.append('ping')
+        if 'dir_capacity' not in self.nodetests.tests:
+            self.nodetests.tests.append('dir_capacity')
 
-  # get SLURM jobid of current allocation
-  def getjobid(self):
-    return os.environ.get('SLURM_JOBID')
+    # get a list of tests, methods that exist in the class SCR_Test_Runtime
+    # these tests will be ran during scr_prerun
+    def get_prerun_tests(self):
+        return ['check_clustershell', 'check_pdsh']
 
-  # get node list
-  def get_job_nodes(self):
-    return os.environ.get('SLURM_NODELIST')
+    # get SLURM jobid of current allocation
+    def getjobid(self):
+        return os.environ.get('SLURM_JOBID')
 
-  # use sinfo to query SLURM for the list of nodes it thinks to be down
-  def get_downnodes(self):
-    downnodes = {}
-    nodelist = self.get_job_nodes()
-    if nodelist is not None:
-      down, returncode = runproc("sinfo -ho %N -t down -n " + nodelist,
-                                 getstdout=True)
-      if returncode == 0:
-        down = down.strip()
-        #### verify this format, comma separated list
-        ### if nodes may be duplicated convert list to set then to list again
-        nodelist = list(set(down.split(',')))
-        for node in nodelist:
-          if node != '':
-            downnodes[node] = 'Reported down by resource manager'
-    return downnodes
+    # get node list
+    def get_job_nodes(self):
+        return os.environ.get('SLURM_NODELIST')
 
-  # query SLURM for allocation endtime, expressed as secs since epoch
-  def get_scr_end_time(self):
-    # get jobid
-    jobid = self.getjobid()
-    if jobid is None:
-      return 0
+    # use sinfo to query SLURM for the list of nodes it thinks to be down
+    def get_downnodes(self):
+        downnodes = {}
+        nodelist = self.get_job_nodes()
+        if nodelist is not None:
+            down, returncode = runproc("sinfo -ho %N -t down -n " + nodelist,
+                                       getstdout=True)
+            if returncode == 0:
+                down = down.strip()
+                #### verify this format, comma separated list
+                ### if nodes may be duplicated convert list to set then to list again
+                nodelist = list(set(down.split(',')))
+                for node in nodelist:
+                    if node != '':
+                        downnodes[node] = 'Reported down by resource manager'
+        return downnodes
 
-    # ask scontrol for endtime of this job
-    output = runproc("scontrol --oneliner show job " + jobid,
-                     getstdout=True)[0]
-    m = re.search('EndTime=(\\S*)', output)
-    if not m:
-      return 0
+    # query SLURM for allocation endtime, expressed as secs since epoch
+    def get_scr_end_time(self):
+        # get jobid
+        jobid = self.getjobid()
+        if jobid is None:
+            return 0
 
-    # 'Unknown' is returned when no time limit was set
-    timestr = m.group(1)
-    if timestr == 'Unknown':
-      return 0
+        # ask scontrol for endtime of this job
+        output = runproc("scontrol --oneliner show job " + jobid,
+                         getstdout=True)[0]
+        m = re.search('EndTime=(\\S*)', output)
+        if not m:
+            return 0
 
-    # TODO: we can probably get this from a library to avoid fork/exec/parsing
-    # parse time string like "2021-07-16T14:05:12" into secs since epoch
-    dt = datetime.datetime.strptime(timestr, "%Y-%m-%dT%H:%M:%S")
-    timestamp = int(dt.strftime("%s"))
-    return timestamp
+        # 'Unknown' is returned when no time limit was set
+        timestr = m.group(1)
+        if timestr == 'Unknown':
+            return 0
+
+        # TODO: we can probably get this from a library to avoid fork/exec/parsing
+        # parse time string like "2021-07-16T14:05:12" into secs since epoch
+        dt = datetime.datetime.strptime(timestr, "%Y-%m-%dT%H:%M:%S")
+        timestamp = int(dt.strftime("%s"))
+        return timestamp

--- a/scripts/python/scrjob/scr_check_node.py
+++ b/scripts/python/scrjob/scr_check_node.py
@@ -10,134 +10,140 @@
 import os, sys
 
 if 'scrjob' not in sys.path:
-  sys.path.insert(0, '/'.join(os.path.realpath(__file__).split('/')[:-2]))
-  import scrjob
+    sys.path.insert(0, '/'.join(os.path.realpath(__file__).split('/')[:-2]))
+    import scrjob
 
 import argparse
 
 
 def scr_check_node(free=False, cntl_list=None, cache_list=None):
-  types = ['cntl', 'cache']
-  # split up our lists of control directories / cache directories
-  checkdict = {}
-  for atype in types:
-    if (atype == 'cntl'
-        and cntl_list is None) or (atype == 'cache'
-                                       and cache_list is None):
-      types.remove(atype)
-      continue
-    checkdict[atype] = {}
-    dirs = []
-    if atype == 'cntl':
-      dirs = cntl_list.split(',')
-    else:
-      dirs = cache_list.split(',')
-    for adir in dirs:
-      if adir[-1] == '/':
-        adir = adir[:-1]
-      if ':' in adir:
-        parts = adir.split(':')
-        checkdict[atype][parts[0]] = {}
-        checkdict[atype][parts[0]]['bytes'] = parts[1]
-      else:
-        checkdict[atype][adir] = {}
-        checkdict[atype][adir]['bytes'] = None
+    types = ['cntl', 'cache']
+    # split up our lists of control directories / cache directories
+    checkdict = {}
+    for atype in types:
+        if (atype == 'cntl' and cntl_list is None) or (atype == 'cache'
+                                                       and cache_list is None):
+            types.remove(atype)
+            continue
+        checkdict[atype] = {}
+        dirs = []
+        if atype == 'cntl':
+            dirs = cntl_list.split(',')
+        else:
+            dirs = cache_list.split(',')
+        for adir in dirs:
+            if adir[-1] == '/':
+                adir = adir[:-1]
+            if ':' in adir:
+                parts = adir.split(':')
+                checkdict[atype][parts[0]] = {}
+                checkdict[atype][parts[0]]['bytes'] = parts[1]
+            else:
+                checkdict[atype][adir] = {}
+                checkdict[atype][adir]['bytes'] = None
 
-  # check that we can access the directory
-  for atype in checkdict:
-    dirs = list(checkdict[atype])
     # check that we can access the directory
-    # (perl code ran an ls)
-    # the docs suggest not to ask if access available, but to just try to access:
-    # https://docs.python.org/3/library/os.html?highlight=os%20access#os.access
+    for atype in checkdict:
+        dirs = list(checkdict[atype])
+        # check that we can access the directory
+        # (perl code ran an ls)
+        # the docs suggest not to ask if access available, but to just try to access:
+        # https://docs.python.org/3/library/os.html?highlight=os%20access#os.access
 
-    # if a size is defined, check that the total size is enough
-    for adir in dirs:
-      try:
-        if checkdict[atype][adir]['bytes'] is not None:
-          # TODO: need to know which unit df is using
-          # convert expected size from bytes to kilobytes
-          kb = int(checkdict[atype][adir]['bytes']) // 1024
+        # if a size is defined, check that the total size is enough
+        for adir in dirs:
+            try:
+                if checkdict[atype][adir]['bytes'] is not None:
+                    # TODO: need to know which unit df is using
+                    # convert expected size from bytes to kilobytes
+                    kb = int(checkdict[atype][adir]['bytes']) // 1024
 
-          # check total drive capacity, unless --free was given, then check free space on drive
-          # ok, now get drive capacity
-          statvfs = os.statvfs(adir)
-          df_kb = 0
-          if free:  # compare with usable free
-            df_kb = statvfs.f_frsize * statvfs.f_bavail // 1024
-          else:  # compare with total
-            df_kb = statvfs.f_frsize * statvfs.f_blocks // 1024
-          if df_kb < kb:
-            print('scr_check_node: FAIL: Insufficient space in directory: ' +
-                  adir + ', expected ' + str(kb) + ' KB, found ' + str(df_kb) +
-                  ' KB')
-            return 1
-      except Exception as e:
-        print('scr_check_node: FAIL: Could not access directory: ' + adir + str(e))
-        return 1
+                    # check total drive capacity, unless --free was given, then check free space on drive
+                    # ok, now get drive capacity
+                    statvfs = os.statvfs(adir)
+                    df_kb = 0
+                    if free:  # compare with usable free
+                        df_kb = statvfs.f_frsize * statvfs.f_bavail // 1024
+                    else:  # compare with total
+                        df_kb = statvfs.f_frsize * statvfs.f_blocks // 1024
+                    if df_kb < kb:
+                        print(
+                            'scr_check_node: FAIL: Insufficient space in directory: '
+                            + adir + ', expected ' + str(kb) + ' KB, found ' +
+                            str(df_kb) + ' KB')
+                        return 1
+            except Exception as e:
+                print('scr_check_node: FAIL: Could not access directory: ' +
+                      adir + str(e))
+                return 1
 
-    # attempt to write to directory
-    for adir in dirs:
-      testfile = adir + '/testfile.txt'
-      try:
-        os.makedirs(adir, exist_ok=True)
-        with open(testfile, 'w') as outfile:
-          outfile.write('test')
-      except PermissionError:
-        print('scr_check_node: FAIL: Lack permission to write test file: ' +
-              testfile)
-        return 1
-      except Exception as e:  # PermissionError or (other error)
-        print('scr_check_node: FAIL: Could not touch test file: ' + testfile + str(e))
-        # return 1 # for some other error it may be ok ?
-      try:
-        os.remove(testfile)
-      except PermissionError:
-        print('scr_check_node: FAIL: Lack permission to rm test file: ' + testfile)
-        return 1
-      except FileNotFoundError:
-        pass
-      except Exception as e:
-        print('scr_check_node: FAIL: Could not rm test file: ' + testfile + str(e))
-        return 1
-  print('PASS')
-  return 0
+        # attempt to write to directory
+        for adir in dirs:
+            testfile = adir + '/testfile.txt'
+            try:
+                os.makedirs(adir, exist_ok=True)
+                with open(testfile, 'w') as outfile:
+                    outfile.write('test')
+            except PermissionError:
+                print(
+                    'scr_check_node: FAIL: Lack permission to write test file: '
+                    + testfile)
+                return 1
+            except Exception as e:  # PermissionError or (other error)
+                print('scr_check_node: FAIL: Could not touch test file: ' +
+                      testfile + str(e))
+                # return 1 # for some other error it may be ok ?
+            try:
+                os.remove(testfile)
+            except PermissionError:
+                print(
+                    'scr_check_node: FAIL: Lack permission to rm test file: ' +
+                    testfile)
+                return 1
+            except FileNotFoundError:
+                pass
+            except Exception as e:
+                print('scr_check_node: FAIL: Could not rm test file: ' +
+                      testfile + str(e))
+                return 1
+    print('PASS')
+    return 0
 
 
 if __name__ == '__main__':
-  parser = argparse.ArgumentParser(
-      add_help=False,
-      argument_default=argparse.SUPPRESS,
-      prog='scr_check_node',
-      description='Checks that the current node is healthy')
-  # default=None, required=True, nargs='+'
-  parser.add_argument('-h',
-                      '--help',
-                      action='store_true',
-                      help='Show this help message and exit.')
-  parser.add_argument(
-      '--free',
-      action='store_true',
-      default=False,
-      help=
-      'Check that free capacity of drive meets limit, checks total capacity of drive otherwise.'
-  )
-  parser.add_argument('--cntl',
-                      metavar='<dir>',
-                      type=str,
-                      default=None,
-                      help='Specify the SCR control directory.')
-  parser.add_argument('--cache',
-                      metavar='<dir>',
-                      type=str,
-                      default=None,
-                      help='Specify the SCR cache directory.')
-  args = vars(parser.parse_args())
-  if 'help' in args:
-    parser.print_help()
-  else:
-    ret = scr_check_node(free=args['free'],
-                         cntl_list=args['cntl'],
-                         cache_list=args['cache'])
-    if ret == 0:
-      print('scr_check_node: PASS')
+    parser = argparse.ArgumentParser(
+        add_help=False,
+        argument_default=argparse.SUPPRESS,
+        prog='scr_check_node',
+        description='Checks that the current node is healthy')
+    # default=None, required=True, nargs='+'
+    parser.add_argument('-h',
+                        '--help',
+                        action='store_true',
+                        help='Show this help message and exit.')
+    parser.add_argument(
+        '--free',
+        action='store_true',
+        default=False,
+        help=
+        'Check that free capacity of drive meets limit, checks total capacity of drive otherwise.'
+    )
+    parser.add_argument('--cntl',
+                        metavar='<dir>',
+                        type=str,
+                        default=None,
+                        help='Specify the SCR control directory.')
+    parser.add_argument('--cache',
+                        metavar='<dir>',
+                        type=str,
+                        default=None,
+                        help='Specify the SCR cache directory.')
+    args = vars(parser.parse_args())
+    if 'help' in args:
+        parser.print_help()
+    else:
+        ret = scr_check_node(free=args['free'],
+                             cntl_list=args['cntl'],
+                             cache_list=args['cache'])
+        if ret == 0:
+            print('scr_check_node: PASS')

--- a/scripts/python/scrjob/scr_common.py
+++ b/scripts/python/scrjob/scr_common.py
@@ -6,8 +6,8 @@
 import os, sys
 
 if 'scrjob' not in sys.path:
-  sys.path.insert(0, '/'.join(os.path.realpath(__file__).split('/')[:-2]))
-  import scrjob
+    sys.path.insert(0, '/'.join(os.path.realpath(__file__).split('/')[:-2]))
+    import scrjob
 
 import argparse, inspect
 from subprocess import Popen, PIPE
@@ -16,7 +16,7 @@ from scrjob import scr_const
 
 
 def tracefunction(frame, event, arg):
-  """This method provides a hook for tracing python calls
+    """This method provides a hook for tracing python calls
 
   Usage:  sys.settrace(scr_common.tracefunction)
   Prints: filename:function:linenum -> event
@@ -28,19 +28,19 @@ def tracefunction(frame, event, arg):
   This output is very verbose. Filters could be added for event type,
   and print messages could be suppressed when the filename is not known.
   """
-  try:
-    print(
-        inspect.getfile(frame).split('/')[-1] + ':' +
-        str(frame.f_code.co_name) + '():' + str(frame.f_lineno) + ' -> ' +
-        str(event))
-  except:
-    print(
-        str(frame.f_code.co_name) + '():' + str(frame.f_lineno) + ' -> ' +
-        str(event))
+    try:
+        print(
+            inspect.getfile(frame).split('/')[-1] + ':' +
+            str(frame.f_code.co_name) + '():' + str(frame.f_lineno) + ' -> ' +
+            str(event))
+    except:
+        print(
+            str(frame.f_code.co_name) + '():' + str(frame.f_lineno) + ' -> ' +
+            str(event))
 
 
 def interpolate_variables(varstr):
-  """This method will expand a string, including paths
+    """This method will expand a string, including paths
 
   This method allows interpretation of path strings such as:
   ~ . ../ ../../
@@ -48,44 +48,49 @@ def interpolate_variables(varstr):
   Environment variables in the string will also be expanded.
   The input need not be a path.
   """
-  if varstr is None or len(varstr) == 0:
-    return ''
-  # replace ~ and . symbols from front of path
-  if varstr[0] == '~':
-    varstr = '$HOME' + varstr[1:]
-  elif varstr.startswith('..'):
-    topdir = '/'.join(os.getcwd().split('/')[:-1])
-    varstr = varstr[3:]
-    while varstr.startswith('..'):
-      topdir = '/'.join(topdir.split('/')[:-1])
-      varstr = varstr[3:]
-    varstr = topdir + '/' + varstr
-  elif varstr[0] == '.':
-    varstr = os.getcwd() + varstr[1:]
-  if varstr[-1] == '/' and len(varstr) > 1:
-    varstr = varstr[:-1]
-  return os.path.expandvars(varstr)
+    if varstr is None or len(varstr) == 0:
+        return ''
+    # replace ~ and . symbols from front of path
+    if varstr[0] == '~':
+        varstr = '$HOME' + varstr[1:]
+    elif varstr.startswith('..'):
+        topdir = '/'.join(os.getcwd().split('/')[:-1])
+        varstr = varstr[3:]
+        while varstr.startswith('..'):
+            topdir = '/'.join(topdir.split('/')[:-1])
+            varstr = varstr[3:]
+        varstr = topdir + '/' + varstr
+    elif varstr[0] == '.':
+        varstr = os.getcwd() + varstr[1:]
+    if varstr[-1] == '/' and len(varstr) > 1:
+        varstr = varstr[:-1]
+    return os.path.expandvars(varstr)
 
 
 def scr_prefix():
-  """This method will return the prefix for SCR
+    """This method will return the prefix for SCR
 
   If the environment variable is not set,
   it will return the current working directory.
   Allows the environment variable to contain relative paths by returning
   the string after passing through interpolate_variables
   """
-  prefix = os.environ.get('SCR_PREFIX')
-  if prefix is None:
-    return os.getcwd()
-  # tack on current working dir if needed
-  # don't resolve symlinks
-  # don't worry about missing parts, the calling script calling might create it
-  return interpolate_variables(prefix)
+    prefix = os.environ.get('SCR_PREFIX')
+    if prefix is None:
+        return os.getcwd()
+    # tack on current working dir if needed
+    # don't resolve symlinks
+    # don't worry about missing parts, the calling script calling might create it
+    return interpolate_variables(prefix)
 
 
-def runproc(argv, wait=True, getstdout=False, getstderr=False, verbose=False, shell=False):
-  """This method will execute a command using subprocess.Popen
+def runproc(argv,
+            wait=True,
+            getstdout=False,
+            getstderr=False,
+            verbose=False,
+            shell=False):
+    """This method will execute a command using subprocess.Popen
 
   Required argument
   -----------------
@@ -123,63 +128,63 @@ def runproc(argv, wait=True, getstdout=False, getstderr=False, verbose=False, sh
   The shell option is passed into the Popen call, and is supposed to prepend commands (?) with
     '/bin/sh -c', although when I tried simply using shell=True for 'which pdsh' I had errors.
   """
-  if shell:
-    if type(argv) is list:
-      argv = ' '.join(argv)
-    # following the security recommendation from subprocess.Popen:
-    # turn the command into a shlex quoted string
-    argv = 'bash -c ' + shlex.quote(argv)
-  # allow caller to pass command as a string, as in:
-  #   "ls -lt" rather than ["ls", "-lt"]
-  elif type(argv) is str:
-    argv = shlex.split(argv)
+    if shell:
+        if type(argv) is list:
+            argv = ' '.join(argv)
+        # following the security recommendation from subprocess.Popen:
+        # turn the command into a shlex quoted string
+        argv = 'bash -c ' + shlex.quote(argv)
+    # allow caller to pass command as a string, as in:
+    #   "ls -lt" rather than ["ls", "-lt"]
+    elif type(argv) is str:
+        argv = shlex.split(argv)
 
-  if len(argv) < 1:
-    return None, None
-  try:
-    # if verbose, print the command we will run to stdout
-    if verbose:
-      if type(argv) is list:
-        print(" ".join(argv))
-      else:
-        print(argv)
+    if len(argv) < 1:
+        return None, None
+    try:
+        # if verbose, print the command we will run to stdout
+        if verbose:
+            if type(argv) is list:
+                print(" ".join(argv))
+            else:
+                print(argv)
 
-    runproc = Popen(argv,
-                    bufsize=1,
-                    stdin=None,
-                    stdout=PIPE,
-                    stderr=PIPE,
-                    shell=shell,
-                    universal_newlines=True)
-    if wait == False:
-      return runproc, runproc
-    if getstdout == True and getstderr == True:
-      output = runproc.communicate()
-      return output, runproc.returncode
-    if getstdout == True:
-      output = runproc.communicate()[0]
-      return output, runproc.returncode
-    if getstderr == True:
-      output = runproc.communicate()[1]
-      return output, runproc.returncode
-    runproc.communicate()
-    return None, runproc.returncode
-  except Exception as e:
-    print('runproc: ERROR: ' + str(e))
-    if getstdout == True and getstderr == True:
-      return ['', str(e)], None
-    if getstdout == True:
-      return '', None
-    if getstderr == True:
-      return str(e), None
-    return None, None
+        runproc = Popen(argv,
+                        bufsize=1,
+                        stdin=None,
+                        stdout=PIPE,
+                        stderr=PIPE,
+                        shell=shell,
+                        universal_newlines=True)
+        if wait == False:
+            return runproc, runproc
+        if getstdout == True and getstderr == True:
+            output = runproc.communicate()
+            return output, runproc.returncode
+        if getstdout == True:
+            output = runproc.communicate()[0]
+            return output, runproc.returncode
+        if getstderr == True:
+            output = runproc.communicate()[1]
+            return output, runproc.returncode
+        runproc.communicate()
+        return None, runproc.returncode
+    except Exception as e:
+        print('runproc: ERROR: ' + str(e))
+        if getstdout == True and getstderr == True:
+            return ['', str(e)], None
+        if getstdout == True:
+            return '', None
+        if getstderr == True:
+            return str(e), None
+        return None, None
 
 
 # pipeproc works as runproc above, except argvs is a list of argv lists
 # the first subprocess is opened and from there stdout is chained to stdin
 # values returned (returncode/pid/stdout/stderr) will be from the final process
 def pipeproc(argvs, wait=True, getstdout=False, getstderr=False):
-  """This method is an extension of the above runproc method
+    """This method is an extension of the above runproc method
 
   This is essentially duplicated code from the runproc.
    ### TODO : This functionality could be put into runproc, increasing
@@ -189,62 +194,62 @@ def pipeproc(argvs, wait=True, getstdout=False, getstderr=False):
   The output of each previous 'runproc' will be piped to the next as stdin.
   Any return values will come from the result of the final Popen command
   """
-  if len(argvs) < 1:
-    return None, None
-  if len(argvs) == 1:
-    return runproc(argvs[0], wait, getstdout, getstderr)
-  try:
-    # split command into list if given as string
-    cmd = argvs[0]
-    if type(cmd) is str:
-      cmd = shlex.split(cmd)
+    if len(argvs) < 1:
+        return None, None
+    if len(argvs) == 1:
+        return runproc(argvs[0], wait, getstdout, getstderr)
+    try:
+        # split command into list if given as string
+        cmd = argvs[0]
+        if type(cmd) is str:
+            cmd = shlex.split(cmd)
 
-    nextprog = Popen(cmd,
-                     bufsize=1,
-                     stdin=None,
-                     stdout=PIPE,
-                     stderr=PIPE,
-                     universal_newlines=True)
+        nextprog = Popen(cmd,
+                         bufsize=1,
+                         stdin=None,
+                         stdout=PIPE,
+                         stderr=PIPE,
+                         universal_newlines=True)
 
-    for i in range(1, len(argvs)):
-      # split command into list if given as string
-      cmd = argvs[i]
-      if type(cmd) is str:
-        cmd = shlex.split(cmd)
+        for i in range(1, len(argvs)):
+            # split command into list if given as string
+            cmd = argvs[i]
+            if type(cmd) is str:
+                cmd = shlex.split(cmd)
 
-      pipeprog = Popen(cmd,
-                       stdin=nextprog.stdout,
-                       stdout=PIPE,
-                       stderr=PIPE,
-                       bufsize=1,
-                       universal_newlines=True)
-      nextprog.stdout.close()
-      nextprog = pipeprog
-    if wait == False:
-      return nextprog, nextprog.pid
-    if getstdout == True and getstderr == True:
-      output = nextprog.communicate()
-      return output, nextprog.returncode
-    if getstdout == True:
-      output = nextprog.communicate()[0]
-      return output, nextprog.returncode
-    if getstderr == True:
-      output = nextprog.communicate()[1]
-      return output, nextprog.returncode
-    return None, nextprog.returncode
-  except Exception as e:
-    print('pipeproc: ERROR: ' + str(e))
-    if getstdout == True and getstderr == True:
-      return ['', str(e)], 1
-    if getstdout == True:
-      return '', 1
-    if getstderr == True:
-      return str(e), 1
-    return None, 1
+            pipeprog = Popen(cmd,
+                             stdin=nextprog.stdout,
+                             stdout=PIPE,
+                             stderr=PIPE,
+                             bufsize=1,
+                             universal_newlines=True)
+            nextprog.stdout.close()
+            nextprog = pipeprog
+        if wait == False:
+            return nextprog, nextprog.pid
+        if getstdout == True and getstderr == True:
+            output = nextprog.communicate()
+            return output, nextprog.returncode
+        if getstdout == True:
+            output = nextprog.communicate()[0]
+            return output, nextprog.returncode
+        if getstderr == True:
+            output = nextprog.communicate()[1]
+            return output, nextprog.returncode
+        return None, nextprog.returncode
+    except Exception as e:
+        print('pipeproc: ERROR: ' + str(e))
+        if getstdout == True and getstderr == True:
+            return ['', str(e)], 1
+        if getstdout == True:
+            return '', 1
+        if getstderr == True:
+            return str(e), 1
+        return None, 1
 
 
 def choose_bindir():
-  """Determine appropriate location of binaries.
+    """Determine appropriate location of binaries.
 
   Testing using "make test" or "make check" must operate based on the contents
   of the build directory.
@@ -253,14 +258,15 @@ def choose_bindir():
   as defined by cmake so installed scripts use installed binaries.  Otherwise,
   determine the appropriate build directory.
   """
-  # Needed to find binaries in build dir when testing
-  parent_of_this_module = '/'.join(os.path.realpath(__file__).split('/')[:-1])
-  if scr_const.X_BINDIR in parent_of_this_module:
-      bindir = scr_const.X_BINDIR  # path to install bin directory
-  else:
-      bindir = os.path.join(scr_const.CMAKE_BINARY_DIR + "/src/")
+    # Needed to find binaries in build dir when testing
+    parent_of_this_module = '/'.join(
+        os.path.realpath(__file__).split('/')[:-1])
+    if scr_const.X_BINDIR in parent_of_this_module:
+        bindir = scr_const.X_BINDIR  # path to install bin directory
+    else:
+        bindir = os.path.join(scr_const.CMAKE_BINARY_DIR + "/src/")
 
-  return bindir
+    return bindir
 
 
 def log(bindir=None,
@@ -275,7 +281,7 @@ def log(bindir=None,
         event_name=None,
         event_start=None,
         event_secs=None):
-  """This method is a wrapper for commong logging operations
+    """This method is a wrapper for commong logging operations
 
   Logging operations call the scr_log_event program with formatted arguments.
 
@@ -290,167 +296,167 @@ def log(bindir=None,
                the remaining arguments are duplicated
                This allows several runproc calls without rebuilding argv each time
   """
-  if prefix is None:
-    prefix = scr_prefix()
-    #print('log: prefix is required')
-  if bindir is None:
-    bindir = scr_const.X_BINDIR
-  argv = [bindir + '/scr_log_event', '-p', prefix]
-  if username is not None:
-    argv.extend(['-u', username])
-  if jobname is not None:
-    argv.extend(['-j', jobname])
-  if jobid is not None:
-    argv.extend(['-i', jobid])
-  if start is not None:
-    argv.extend(['-s', start])
-  if event_type is not None:
-    argv.extend(['-T', event_type])
-  if event_dset is not None:
-    argv.extend(['-D', event_dset])
-  if event_name is not None:
-    argv.extend(['-n', event_name])
-  if event_start is not None:
-    argv.extend(['-S', event_start])
-  if event_secs is not None:
-    argv.extend(['-L', event_secs])
-  if type(event_note) is dict:
-    argv.extend(['-N', ''])
-    lastarg = len(argv) - 1
-    for key in event_note:
-      argv[lastarg] = key + ':' + event_note[key]
-      runproc(argv=argv)
-  else:
-    if event_note is not None:
-      argv.extend(['-N', event_note])
-    runproc(argv=argv)
+    if prefix is None:
+        prefix = scr_prefix()
+        #print('log: prefix is required')
+    if bindir is None:
+        bindir = scr_const.X_BINDIR
+    argv = [bindir + '/scr_log_event', '-p', prefix]
+    if username is not None:
+        argv.extend(['-u', username])
+    if jobname is not None:
+        argv.extend(['-j', jobname])
+    if jobid is not None:
+        argv.extend(['-i', jobid])
+    if start is not None:
+        argv.extend(['-s', start])
+    if event_type is not None:
+        argv.extend(['-T', event_type])
+    if event_dset is not None:
+        argv.extend(['-D', event_dset])
+    if event_name is not None:
+        argv.extend(['-n', event_name])
+    if event_start is not None:
+        argv.extend(['-S', event_start])
+    if event_secs is not None:
+        argv.extend(['-L', event_secs])
+    if type(event_note) is dict:
+        argv.extend(['-N', ''])
+        lastarg = len(argv) - 1
+        for key in event_note:
+            argv[lastarg] = key + ':' + event_note[key]
+            runproc(argv=argv)
+    else:
+        if event_note is not None:
+            argv.extend(['-N', event_note])
+        runproc(argv=argv)
 
 
 if __name__ == '__main__':
-  """This script allows being called as a standalone script
+    """This script allows being called as a standalone script
 
   This is meant for testing purposes, to directly call scr_common methods.
   """
-  parser = argparse.ArgumentParser(add_help=False,
-                                   argument_default=argparse.SUPPRESS,
-                                   prog='scr_common')
-  parser.add_argument('-h',
-                      '--help',
-                      action='store_true',
-                      help='Show this help message and exit.')
-  parser.add_argument('--interpolate',
-                      metavar='<variable>',
-                      type=str,
-                      help='Interpolate a variable string.')
-  parser.add_argument('--prefix',
-                      action='store_true',
-                      help='Print the SCR prefix.')
-  parser.add_argument('--runproc',
-                      nargs=argparse.REMAINDER,
-                      help='Launch process with arguments')
-  parser.add_argument(
-      '--pipeproc',
-      nargs=argparse.REMAINDER,
-      help=
-      'Launch processes and pipe output to other processes. (separate processes with a colon)'
-  )
-  parser.add_argument(
-      '--log',
-      nargs='+',
-      metavar='<option=value>',
-      help=
-      'Create a log entry, available options: bindir, prefix, username, jobname, jobid, start, event_type, event_note, event_dset, event_name, event_start, event_secs'
-  )
-  args = vars(parser.parse_args())
-  if 'help' in args:
-    parser.print_help()
-    sys.exit(1)
-  if 'interpolate' in args:
-    print('interpolate_variables(' + args['interpolate'] + ')')
-    print('  -> ' + str(interpolate_variables(args['interpolate'])))
-  if 'prefix' in args:
-    print('scr_prefix()')
-    print('  -> ' + str(scr_prefix()))
-  if 'runproc' in args:
-    print('runproc(' + ' '.join(args['runproc']) + ')')
-    out, returncode = runproc(argv=args['runproc'],
-                              getstdout=True,
-                              getstderr=True)
-    print('  process returned with code ' + str(returncode))
-    print('  stdout:')
-    print(out[0])
-    print('  stderr:')
-    print(out[1])
-  if 'pipeproc' in args:
-    printstr = 'pipeproc( '
-    argvs = []
-    argvs.append([])
-    i = 0
-    for arg in args['pipeproc']:
-      if arg == ':':
-        i += 1
+    parser = argparse.ArgumentParser(add_help=False,
+                                     argument_default=argparse.SUPPRESS,
+                                     prog='scr_common')
+    parser.add_argument('-h',
+                        '--help',
+                        action='store_true',
+                        help='Show this help message and exit.')
+    parser.add_argument('--interpolate',
+                        metavar='<variable>',
+                        type=str,
+                        help='Interpolate a variable string.')
+    parser.add_argument('--prefix',
+                        action='store_true',
+                        help='Print the SCR prefix.')
+    parser.add_argument('--runproc',
+                        nargs=argparse.REMAINDER,
+                        help='Launch process with arguments')
+    parser.add_argument(
+        '--pipeproc',
+        nargs=argparse.REMAINDER,
+        help=
+        'Launch processes and pipe output to other processes. (separate processes with a colon)'
+    )
+    parser.add_argument(
+        '--log',
+        nargs='+',
+        metavar='<option=value>',
+        help=
+        'Create a log entry, available options: bindir, prefix, username, jobname, jobid, start, event_type, event_note, event_dset, event_name, event_start, event_secs'
+    )
+    args = vars(parser.parse_args())
+    if 'help' in args:
+        parser.print_help()
+        sys.exit(1)
+    if 'interpolate' in args:
+        print('interpolate_variables(' + args['interpolate'] + ')')
+        print('  -> ' + str(interpolate_variables(args['interpolate'])))
+    if 'prefix' in args:
+        print('scr_prefix()')
+        print('  -> ' + str(scr_prefix()))
+    if 'runproc' in args:
+        print('runproc(' + ' '.join(args['runproc']) + ')')
+        out, returncode = runproc(argv=args['runproc'],
+                                  getstdout=True,
+                                  getstderr=True)
+        print('  process returned with code ' + str(returncode))
+        print('  stdout:')
+        print(out[0])
+        print('  stderr:')
+        print(out[1])
+    if 'pipeproc' in args:
+        printstr = 'pipeproc( '
+        argvs = []
         argvs.append([])
-        printstr += '| '
-      else:
-        argvs[i].append(arg)
-        printstr += arg + ' '
-    print(printstr + ')')
-    out, returncode = pipeproc(argvs=argvs, getstdout=True, getstderr=True)
-    print('  final process returned with code ' + str(returncode))
-    if out is not None:
-      print('  stdout:')
-      print(out[0])
-      print('  stderr:')
-      print(out[1])
-  if 'log' in args:
-    bindir, prefix, username, jobname = None, None, None, None
-    jobid, start, event_type, event_note = None, None, None, None
-    event_dset, event_name, event_start, event_secs = None, None, None, None
-    printstr = 'log('
-    for keyvalpair in args['log']:
-      if '=' not in keyvalpair:
-        continue
-      vals = keyvalpair.split('=')
-      if vals[0] == 'bindir':
-        bindir = vals[1]
-      elif vals[0] == 'prefix':
-        prefix = vals[1]
-      elif vals[0] == 'username':
-        username = vals[1]
-      elif vals[0] == 'jobname':
-        jobname = vals[1]
-      elif vals[0] == 'jobid':
-        jobid = vals[1]
-      elif vals[0] == 'start':
-        start = vals[1]
-      elif vals[0] == 'event_type':
-        event_type = vals[1]
-      elif vals[0] == 'event_note':
-        event_note = vals[1]
-      elif vals[0] == 'event_dset':
-        event_dset = vals[1]
-      elif vals[0] == 'event_name':
-        event_name = vals[1]
-      elif vals[0] == 'event_start':
-        event_start = vals[1]
-      elif vals[0] == 'event_secs':
-        event_secs = vals[1]
-      else:
-        continue
-      printstr += keyvalpair + ', '
-    if printstr[-1] == '(':
-      print('Nothing to log, see \'--help\' for available value pairs.')
-      sys.exit(1)
-    print(printstr[:-2] + ')')
-    log(bindir=bindir,
-        prefix=prefix,
-        username=username,
-        jobname=jobname,
-        jobid=jobid,
-        start=start,
-        event_type=event_type,
-        event_note=event_note,
-        event_dset=event_dset,
-        event_name=event_name,
-        event_start=event_start,
-        event_secs=event_secs)
+        i = 0
+        for arg in args['pipeproc']:
+            if arg == ':':
+                i += 1
+                argvs.append([])
+                printstr += '| '
+            else:
+                argvs[i].append(arg)
+                printstr += arg + ' '
+        print(printstr + ')')
+        out, returncode = pipeproc(argvs=argvs, getstdout=True, getstderr=True)
+        print('  final process returned with code ' + str(returncode))
+        if out is not None:
+            print('  stdout:')
+            print(out[0])
+            print('  stderr:')
+            print(out[1])
+    if 'log' in args:
+        bindir, prefix, username, jobname = None, None, None, None
+        jobid, start, event_type, event_note = None, None, None, None
+        event_dset, event_name, event_start, event_secs = None, None, None, None
+        printstr = 'log('
+        for keyvalpair in args['log']:
+            if '=' not in keyvalpair:
+                continue
+            vals = keyvalpair.split('=')
+            if vals[0] == 'bindir':
+                bindir = vals[1]
+            elif vals[0] == 'prefix':
+                prefix = vals[1]
+            elif vals[0] == 'username':
+                username = vals[1]
+            elif vals[0] == 'jobname':
+                jobname = vals[1]
+            elif vals[0] == 'jobid':
+                jobid = vals[1]
+            elif vals[0] == 'start':
+                start = vals[1]
+            elif vals[0] == 'event_type':
+                event_type = vals[1]
+            elif vals[0] == 'event_note':
+                event_note = vals[1]
+            elif vals[0] == 'event_dset':
+                event_dset = vals[1]
+            elif vals[0] == 'event_name':
+                event_name = vals[1]
+            elif vals[0] == 'event_start':
+                event_start = vals[1]
+            elif vals[0] == 'event_secs':
+                event_secs = vals[1]
+            else:
+                continue
+            printstr += keyvalpair + ', '
+        if printstr[-1] == '(':
+            print('Nothing to log, see \'--help\' for available value pairs.')
+            sys.exit(1)
+        print(printstr[:-2] + ')')
+        log(bindir=bindir,
+            prefix=prefix,
+            username=username,
+            jobname=jobname,
+            jobid=jobid,
+            start=start,
+            event_type=event_type,
+            event_note=event_note,
+            event_dset=event_dset,
+            event_name=event_name,
+            event_start=event_start,
+            event_secs=event_secs)

--- a/scripts/python/scrjob/scr_const.py.in
+++ b/scripts/python/scrjob/scr_const.py.in
@@ -1,7 +1,6 @@
 #! /usr/bin/env python3
 
 # scr_const.py
-
 """
 compile time constants
 """
@@ -51,23 +50,22 @@ Joblauncher scr_kill_jobstep strategy
 # Prefer to use job launcher's method to kill a jobstep, e.g., scancel, set to '1'
 USE_JOBLAUNCHER_KILL = '@USE_JOBLAUNCHER_KILL@'
 
-
 if __name__ == '__main__':
-  """running this script will print compiled values"""
+    """running this script will print compiled values"""
 
-  print('SCR_CNTL_BASE = \"' + SCR_CNTL_BASE + '\"')
-  print('SCR_CACHE_BASE = \"' + SCR_CACHE_BASE + '\"')
-  print('SCR_CACHE_SIZE = \"' + SCR_CACHE_SIZE + '\"')
-  print('SCR_CONFIG_FILE = \"' + SCR_CONFIG_FILE + '\"')
-  print('CMAKE_BINARY_DIR = \"' + CMAKE_BINARY_DIR + '\"')
-  print('X_BINDIR = \"' + X_BINDIR + '\"')
-  print('X_LIBDIR = \"' + X_LIBDIR + '\"')
-  print('PDSH_EXE = \"' + PDSH_EXE + '\"')
-  print('SCR_RESOURCE_MANAGER = \"' + SCR_RESOURCE_MANAGER + '\"')
-  print('CPPR_LDFLAGS = \"' + CPPR_LDFLAGS + '\"')
-  print('HAVE_LIBCPPR = \"' + HAVE_LIBCPPR + '\"')
-  print('SCR_NODE_TESTS = \"' + SCR_NODE_TESTS + '\"')
-  print('SCR_NODE_TESTS_FILE = \"' + SCR_NODE_TESTS_FILE + '\"')
-  print('USE_CLUSTERSHELL = \"' + USE_CLUSTERSHELL + '\"')
-  print('PYFE_TRACE_FUNC = \"' + PYFE_TRACE_FUNC + '\"')
-  print('USE_JOBLAUNCHER_KILL = \"' + USE_JOBLAUNCHER_KILL + '\"')
+    print('SCR_CNTL_BASE = \"' + SCR_CNTL_BASE + '\"')
+    print('SCR_CACHE_BASE = \"' + SCR_CACHE_BASE + '\"')
+    print('SCR_CACHE_SIZE = \"' + SCR_CACHE_SIZE + '\"')
+    print('SCR_CONFIG_FILE = \"' + SCR_CONFIG_FILE + '\"')
+    print('CMAKE_BINARY_DIR = \"' + CMAKE_BINARY_DIR + '\"')
+    print('X_BINDIR = \"' + X_BINDIR + '\"')
+    print('X_LIBDIR = \"' + X_LIBDIR + '\"')
+    print('PDSH_EXE = \"' + PDSH_EXE + '\"')
+    print('SCR_RESOURCE_MANAGER = \"' + SCR_RESOURCE_MANAGER + '\"')
+    print('CPPR_LDFLAGS = \"' + CPPR_LDFLAGS + '\"')
+    print('HAVE_LIBCPPR = \"' + HAVE_LIBCPPR + '\"')
+    print('SCR_NODE_TESTS = \"' + SCR_NODE_TESTS + '\"')
+    print('SCR_NODE_TESTS_FILE = \"' + SCR_NODE_TESTS_FILE + '\"')
+    print('USE_CLUSTERSHELL = \"' + USE_CLUSTERSHELL + '\"')
+    print('PYFE_TRACE_FUNC = \"' + PYFE_TRACE_FUNC + '\"')
+    print('USE_JOBLAUNCHER_KILL = \"' + USE_JOBLAUNCHER_KILL + '\"')

--- a/scripts/python/scrjob/scr_env.py
+++ b/scripts/python/scrjob/scr_env.py
@@ -7,8 +7,8 @@
 import os, sys
 
 if 'scrjob' not in sys.path:
-  sys.path.insert(0, '/'.join(os.path.realpath(__file__).split('/')[:-2]))
-  import scrjob
+    sys.path.insert(0, '/'.join(os.path.realpath(__file__).split('/')[:-2]))
+    import scrjob
 
 import argparse
 from scrjob.scr_environment import SCR_Env
@@ -18,86 +18,87 @@ from scrjob.launchers import AutoJobLauncher
 
 
 def printobject(obj, objname):
-  for attr in dir(obj):
-    if attr.startswith('__'):
-      continue
-    thing = getattr(obj, attr)
-    if thing is not None and (attr == 'resmgr' or attr == 'launcher'
-                              or attr == 'param'):
-      printobject(thing, objname + '.' + attr)
-    elif type(thing) is dict:
-      print(objname + '.' + attr + ' = {}')
-      for key in thing:
-        print(objname + '.' + attr + '[' + key + '] = ' + str(thing[key]))
-    else:
-      print(objname + '.' + attr + ' = ' + str(thing))
+    for attr in dir(obj):
+        if attr.startswith('__'):
+            continue
+        thing = getattr(obj, attr)
+        if thing is not None and (attr == 'resmgr' or attr == 'launcher'
+                                  or attr == 'param'):
+            printobject(thing, objname + '.' + attr)
+        elif type(thing) is dict:
+            print(objname + '.' + attr + ' = {}')
+            for key in thing:
+                print(objname + '.' + attr + '[' + key + '] = ' +
+                      str(thing[key]))
+        else:
+            print(objname + '.' + attr + ' = ' + str(thing))
 
 
 if __name__ == '__main__':
-  parser = argparse.ArgumentParser(add_help=False,
-                                   argument_default=argparse.SUPPRESS,
-                                   prog='scr_env')
-  parser.add_argument('-h',
-                      '--help',
-                      action='store_true',
-                      help='Show this help message and exit.')
-  parser.add_argument('-u',
-                      '--user',
-                      action='store_true',
-                      help='List the username of current job.')
-  parser.add_argument('-j',
-                      '--jobid',
-                      action='store_true',
-                      help='List the job id of the current job.')
-  parser.add_argument('-e',
-                      '--endtime',
-                      action='store_true',
-                      help='List the end time of the current job.')
-  parser.add_argument('-n',
-                      '--nodes',
-                      action='store_true',
-                      help='List the nodeset the current job is using.')
-  parser.add_argument(
-      '-d',
-      '--down',
-      action='store_true',
-      help=
-      'List any nodes of the job\'s nodeset that the resource manager knows to be down.'
-  )
-  parser.add_argument('-p',
-                      '--prefix',
-                      metavar='<dir>',
-                      type=str,
-                      default=None,
-                      help='Specify the prefix directory.')
-  parser.add_argument('-r',
-                      '--runnodes',
-                      action='store_true',
-                      help='List the number of nodes used in the last run.')
-  args = vars(parser.parse_args())
+    parser = argparse.ArgumentParser(add_help=False,
+                                     argument_default=argparse.SUPPRESS,
+                                     prog='scr_env')
+    parser.add_argument('-h',
+                        '--help',
+                        action='store_true',
+                        help='Show this help message and exit.')
+    parser.add_argument('-u',
+                        '--user',
+                        action='store_true',
+                        help='List the username of current job.')
+    parser.add_argument('-j',
+                        '--jobid',
+                        action='store_true',
+                        help='List the job id of the current job.')
+    parser.add_argument('-e',
+                        '--endtime',
+                        action='store_true',
+                        help='List the end time of the current job.')
+    parser.add_argument('-n',
+                        '--nodes',
+                        action='store_true',
+                        help='List the nodeset the current job is using.')
+    parser.add_argument(
+        '-d',
+        '--down',
+        action='store_true',
+        help=
+        'List any nodes of the job\'s nodeset that the resource manager knows to be down.'
+    )
+    parser.add_argument('-p',
+                        '--prefix',
+                        metavar='<dir>',
+                        type=str,
+                        default=None,
+                        help='Specify the prefix directory.')
+    parser.add_argument('-r',
+                        '--runnodes',
+                        action='store_true',
+                        help='List the number of nodes used in the last run.')
+    args = vars(parser.parse_args())
 
-  scr_env = SCR_Env(prefix=args['prefix'])
-  scr_env.resmgr = AutoResourceManager()
-  scr_env.launcher = AutoJobLauncher()
-  scr_env.param = SCR_Param()
+    scr_env = SCR_Env(prefix=args['prefix'])
+    scr_env.resmgr = AutoResourceManager()
+    scr_env.launcher = AutoJobLauncher()
+    scr_env.param = SCR_Param()
 
-  if len(args) == 0:
-    printobject(scr_env, 'scr_env')
-  elif 'help' in args:
-    parser.print_help()
-  else:
-    if 'user' in args:
-      print(str(scr_env.get_user()), end='')
-    if 'jobid' in args:
-      print(str(scr_env.resmgr.getjobid()), end='')
-    if 'endtime' in args:
-      print(str(scr_env.resmgr.get_scr_end_time()), end='')
-    if 'nodes' in args:
-      nodelist = scr_env.get_scr_nodelist()
-      if nodelist is None:
-        nodelist = scr_env.resmgr.get_job_nodes()
-      print(str(nodelist), end='')
-    if 'down' in args:
-      print(str(scr_env.resmgr.get_downnodes()), end='')
-    if 'runnodes' in args:
-      print(str(scr_env.get_runnode_count()), end='')
+    if len(args) == 0:
+        printobject(scr_env, 'scr_env')
+    elif 'help' in args:
+        parser.print_help()
+    else:
+        if 'user' in args:
+            print(str(scr_env.get_user()), end='')
+        if 'jobid' in args:
+            print(str(scr_env.resmgr.getjobid()), end='')
+        if 'endtime' in args:
+            print(str(scr_env.resmgr.get_scr_end_time()), end='')
+        if 'nodes' in args:
+            nodelist = scr_env.get_scr_nodelist()
+            if nodelist is None:
+                nodelist = scr_env.resmgr.get_job_nodes()
+            print(str(nodelist), end='')
+        if 'down' in args:
+            print(str(scr_env.resmgr.get_downnodes()), end='')
+        if 'runnodes' in args:
+            print(str(scr_env.get_runnode_count()), end='')

--- a/scripts/python/scrjob/scr_environment.py
+++ b/scripts/python/scrjob/scr_environment.py
@@ -6,8 +6,9 @@ import os
 from scrjob import scr_const
 from scrjob.scr_common import scr_prefix, runproc
 
+
 class SCR_Env:
-  """The SCR_Env class tracks information relating to the environment
+    """The SCR_Env class tracks information relating to the environment
 
   This class retrieves information from the environment.
   This class contains pointers to the active Joblauncher, ResourceManager, and SCR_Param.
@@ -23,47 +24,48 @@ class SCR_Env:
   bindir     - string, path to the scr bin directory, scr_const.X_BINDIR
   nodes_file - string, path to bindir/scr_nodes_file     ### Unused ?
   """
-  def __init__(self, prefix=None):
-    # we can keep a reference to the other objects
-    self.param = None
-    self.launcher = None
-    self.resmgr = None
 
-    # record SCR_PREFIX directory, default to scr_prefix if not provided
-    if prefix is None:
-      prefix = scr_prefix()
-    self.prefix = prefix
+    def __init__(self, prefix=None):
+        # we can keep a reference to the other objects
+        self.param = None
+        self.launcher = None
+        self.resmgr = None
 
-    # initialize paths
-    bindir = scr_const.X_BINDIR
-    self.nodes_file = os.path.join(bindir, 'scr_nodes_file')
+        # record SCR_PREFIX directory, default to scr_prefix if not provided
+        if prefix is None:
+            prefix = scr_prefix()
+        self.prefix = prefix
 
-  def get_user(self):
-    """Return the username from the environment"""
-    return os.environ.get('USER')
+        # initialize paths
+        bindir = scr_const.X_BINDIR
+        self.nodes_file = os.path.join(bindir, 'scr_nodes_file')
 
-  def get_scr_nodelist(self):
-    """Return the SCR_NODELIST, if set, or None"""
-    return os.environ.get('SCR_NODELIST')
+    def get_user(self):
+        """Return the username from the environment"""
+        return os.environ.get('USER')
 
-  def get_prefix(self):
-    """Return the scr prefix"""
-    return self.prefix
+    def get_scr_nodelist(self):
+        """Return the SCR_NODELIST, if set, or None"""
+        return os.environ.get('SCR_NODELIST')
 
-  def dir_scr(self):
-    """Return the prefix/.scr directory"""
-    return os.path.join(self.prefix, '.scr')
+    def get_prefix(self):
+        """Return the scr prefix"""
+        return self.prefix
 
-  def dir_dset(self, d):
-    """Given a dataset id, return the dataset directory within the prefix
+    def dir_scr(self):
+        """Return the prefix/.scr directory"""
+        return os.path.join(self.prefix, '.scr')
+
+    def dir_dset(self, d):
+        """Given a dataset id, return the dataset directory within the prefix
     prefix/.scr/scr.dataset.<id>
     """
-    return os.path.join(self.dir_scr(), 'scr.dataset.' + str(d))
+        return os.path.join(self.dir_scr(), 'scr.dataset.' + str(d))
 
-  def get_runnode_count(self):
-    """Return the number of nodes used in the last run, if known"""
-    argv = [self.nodes_file, '--dir', self.prefix]
-    out, returncode = runproc(argv=argv, getstdout=True)
-    if returncode == 0:
-      return int(out)
-    return 0
+    def get_runnode_count(self):
+        """Return the number of nodes used in the last run, if known"""
+        argv = [self.nodes_file, '--dir', self.prefix]
+        out, returncode = runproc(argv=argv, getstdout=True)
+        if returncode == 0:
+            return int(out)
+        return 0

--- a/scripts/python/scrjob/scr_flux.py
+++ b/scripts/python/scrjob/scr_flux.py
@@ -7,31 +7,31 @@
 import os, sys
 
 if 'scrjob' not in sys.path:
-  sys.path.insert(0, '/'.join(os.path.realpath(__file__).split('/')[:-2]))
+    sys.path.insert(0, '/'.join(os.path.realpath(__file__).split('/')[:-2]))
 
 from scrjob.scr_run import scr_run, parseargs, print_usage
 
 if __name__ == '__main__':
-  # just printing help, print the help and exit
-  if len(sys.argv) < 3 or '-h' in sys.argv[1:] or '--help' in sys.argv[1:]:
-    print_usage('flux')
-  elif not any(
-      arg.startswith('-rc') or arg.startswith('--run-cmd')
-      or arg.startswith('-rs') or arg.startswith('--restart-cmd')
-      for arg in sys.argv):
-    # then we were called with: scr_flux [launcher args]
-    scr_run(launcher='flux', launcher_args=sys.argv[1:])
-  else:
-    # remove prepended flux args which have no use for us
-    argv = sys.argv[1:]
-    if argv[0] == 'mini':
-      argv = argv[1:]
-    if argv[0] == 'run' or argv[0] == 'submit':
-      argv = argv[1:]
-    launcher, launcher_args, run_cmd, restart_cmd, restart_args = parseargs(
-        argv, launcher='flux')
-    scr_run(launcher='flux',
-            launcher_args=launcher_args,
-            run_cmd=run_cmd,
-            restart_cmd=restart_cmd,
-            restart_args=restart_args)
+    # just printing help, print the help and exit
+    if len(sys.argv) < 3 or '-h' in sys.argv[1:] or '--help' in sys.argv[1:]:
+        print_usage('flux')
+    elif not any(
+            arg.startswith('-rc') or arg.startswith('--run-cmd')
+            or arg.startswith('-rs') or arg.startswith('--restart-cmd')
+            for arg in sys.argv):
+        # then we were called with: scr_flux [launcher args]
+        scr_run(launcher='flux', launcher_args=sys.argv[1:])
+    else:
+        # remove prepended flux args which have no use for us
+        argv = sys.argv[1:]
+        if argv[0] == 'mini':
+            argv = argv[1:]
+        if argv[0] == 'run' or argv[0] == 'submit':
+            argv = argv[1:]
+        launcher, launcher_args, run_cmd, restart_cmd, restart_args = parseargs(
+            argv, launcher='flux')
+        scr_run(launcher='flux',
+                launcher_args=launcher_args,
+                run_cmd=run_cmd,
+                restart_cmd=restart_cmd,
+                restart_args=restart_args)

--- a/scripts/python/scrjob/scr_glob_hosts.py
+++ b/scripts/python/scrjob/scr_glob_hosts.py
@@ -5,8 +5,8 @@
 import os, sys
 
 if 'scrjob' not in sys.path:
-  sys.path.insert(0, '/'.join(os.path.realpath(__file__).split('/')[:-2]))
-  import scrjob
+    sys.path.insert(0, '/'.join(os.path.realpath(__file__).split('/')[:-2]))
+    import scrjob
 
 import argparse
 from scrjob import scr_hostlist
@@ -19,123 +19,124 @@ def scr_glob_hosts(count=False,
                    intersection=None,
                    compress=None,
                    resmgr=None):
-  hostset = []
-  if hosts is not None:
-    # resmgr can use ClusterShell.NodeSet, if available
+    hostset = []
+    if hosts is not None:
+        # resmgr can use ClusterShell.NodeSet, if available
+        if resmgr is not None:
+            hostset = resmgr.expand_hosts(hostnames=hosts)
+        else:
+            hostset = scr_hostlist.expand(hosts)
+    elif minus is not None and ':' in minus:
+        # subtract nodes in set2 from set1
+        pieces = minus.split(':')
+        if resmgr is not None:
+            set1 = resmgr.expand_hosts(pieces[0])
+            set2 = resmgr.expand_hosts(pieces[1])
+            hostset = resmgr.diff_hosts(set1, set2)
+        else:
+            set1 = scr_hostlist.expand(pieces[0])
+            set2 = scr_hostlist.expand(pieces[1])
+            hostset = scr_hostlist.diff(set1, set2)
+    elif intersection is not None and ':' in intersection:
+        # take the intersection of two nodesets
+        pieces = intersection.split(':')
+        if resmgr is not None:
+            set1 = resmgr.expand_hosts(pieces[0])
+            set2 = resmgr.expand_hosts(pieces[1])
+            hostset = resmgr.intersect_hosts(set1, set2)
+        else:
+            set1 = scr_hostlist.expand(pieces[0])
+            set2 = scr_hostlist.expand(pieces[1])
+            hostset = scr_hostlist.intersect(set1, set2)
+    elif compress is not None:
+        if resmgr is not None:
+            hostset = resmgr.compress_hosts(compress)
+        else:
+            hostset = compress.split(',')
+            return scr_hostlist.compress_range(hostset)
+    else:  #if not valid
+        return None
+    # ok, got our resulting nodeset, now print stuff to the screen
+    if nth is not None:
+        # print out the nth node of the nodelist
+        n = int(nth)
+        if n > len(hostset) or n < -len(hostset):
+            print('scr_glob_hosts: ERROR: Host index (' + str(n) +
+                  ') is out of range for the specified host list.')
+            return None
+        if n > 0:  # an initial n=0 or n=1 both return the same thing
+            n -= 1
+        # return the nth element
+        return hostset[n]
+    # return the number of nodes (length) in the nodelist
+    if count:
+        return len(hostset)
+    # return a csv string representation of the nodelist
     if resmgr is not None:
-      hostset = resmgr.expand_hosts(hostnames=hosts)
-    else:
-      hostset = scr_hostlist.expand(hosts)
-  elif minus is not None and ':' in minus:
-    # subtract nodes in set2 from set1
-    pieces = minus.split(':')
-    if resmgr is not None:
-      set1 = resmgr.expand_hosts(pieces[0])
-      set2 = resmgr.expand_hosts(pieces[1])
-      hostset = resmgr.diff_hosts(set1, set2)
-    else:
-      set1 = scr_hostlist.expand(pieces[0])
-      set2 = scr_hostlist.expand(pieces[1])
-      hostset = scr_hostlist.diff(set1, set2)
-  elif intersection is not None and ':' in intersection:
-    # take the intersection of two nodesets
-    pieces = intersection.split(':')
-    if resmgr is not None:
-      set1 = resmgr.expand_hosts(pieces[0])
-      set2 = resmgr.expand_hosts(pieces[1])
-      hostset = resmgr.intersect_hosts(set1, set2)
-    else:
-      set1 = scr_hostlist.expand(pieces[0])
-      set2 = scr_hostlist.expand(pieces[1])
-      hostset = scr_hostlist.intersect(set1, set2)
-  elif compress is not None:
-    if resmgr is not None:
-      hostset = resmgr.compress_hosts(compress)
-    else:
-      hostset = compress.split(',')
-      return scr_hostlist.compress_range(hostset)
-  else:  #if not valid
-    return None
-  # ok, got our resulting nodeset, now print stuff to the screen
-  if nth is not None:
-    # print out the nth node of the nodelist
-    n = int(nth)
-    if n > len(hostset) or n < -len(hostset):
-      print('scr_glob_hosts: ERROR: Host index (' + str(n) +
-            ') is out of range for the specified host list.')
-      return None
-    if n > 0:  # an initial n=0 or n=1 both return the same thing
-      n -= 1
-    # return the nth element
-    return hostset[n]
-  # return the number of nodes (length) in the nodelist
-  if count:
-    return len(hostset)
-  # return a csv string representation of the nodelist
-  if resmgr is not None:
-    hostset = resmgr.expand_hosts(hostset)
-    return ','.join(hostset)
-  return scr_hostlist.compress(hostset)
+        hostset = resmgr.expand_hosts(hostset)
+        return ','.join(hostset)
+    return scr_hostlist.compress(hostset)
 
 
 if __name__ == '__main__':
-  parser = argparse.ArgumentParser(add_help=False,
-                                   argument_default=argparse.SUPPRESS,
-                                   prog='scr_glob_hosts')
-  # default=None, required=True, nargs='+'
-  parser.add_argument('--help',
-                      action='store_true',
-                      help='Show this help message and exit.')
-  parser.add_argument('-c',
-                      '--count',
-                      action='store_true',
-                      default=False,
-                      help='Print the number of hosts.')
-  parser.add_argument('-n',
-                      '--nth',
-                      metavar='<num>',
-                      type=int,
-                      default=None,
-                      help='Output the Nth host (1=lo, -1=hi).')
-  group = parser.add_mutually_exclusive_group()
-  group.add_argument('-h',
-                     '--hosts',
-                     metavar='<hosts>',
-                     type=str,
-                     default=None,
-                     help='Use this hostlist.')
-  group.add_argument('-m',
-                     '--minus',
-                     metavar='<s1:s2>',
-                     type=str,
-                     default=None,
-                     help='Elements of s1 not in s2.')
-  group.add_argument('-i',
-                     '--intersection',
-                     metavar='<s1:s2>',
-                     type=str,
-                     default=None,
-                     help='Intersection of s1 and s2 hosts.')
-  group.add_argument('-C',
-                     '--compress',
-                     metavar='<csv host>',
-                     type=str,
-                     default=None,
-                     help='Compress the csv hostlist.')
-  args = vars(parser.parse_args())
-  if ('help' in args) or (
-      args['hosts'] is None and args['minus'] is None
-      and args['intersection'] is None and args['compress'] is None
-  ) or (args['minus'] is not None
-        and ':' not in args['minus']) or (args['intersection'] is not None
+    parser = argparse.ArgumentParser(add_help=False,
+                                     argument_default=argparse.SUPPRESS,
+                                     prog='scr_glob_hosts')
+    # default=None, required=True, nargs='+'
+    parser.add_argument('--help',
+                        action='store_true',
+                        help='Show this help message and exit.')
+    parser.add_argument('-c',
+                        '--count',
+                        action='store_true',
+                        default=False,
+                        help='Print the number of hosts.')
+    parser.add_argument('-n',
+                        '--nth',
+                        metavar='<num>',
+                        type=int,
+                        default=None,
+                        help='Output the Nth host (1=lo, -1=hi).')
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument('-h',
+                       '--hosts',
+                       metavar='<hosts>',
+                       type=str,
+                       default=None,
+                       help='Use this hostlist.')
+    group.add_argument('-m',
+                       '--minus',
+                       metavar='<s1:s2>',
+                       type=str,
+                       default=None,
+                       help='Elements of s1 not in s2.')
+    group.add_argument('-i',
+                       '--intersection',
+                       metavar='<s1:s2>',
+                       type=str,
+                       default=None,
+                       help='Intersection of s1 and s2 hosts.')
+    group.add_argument('-C',
+                       '--compress',
+                       metavar='<csv host>',
+                       type=str,
+                       default=None,
+                       help='Compress the csv hostlist.')
+    args = vars(parser.parse_args())
+    if ('help'
+            in args) or (args['hosts'] is None and args['minus'] is None
+                         and args['intersection'] is None and args['compress']
+                         is None) or (args['minus'] is not None
+                                      and ':' not in args['minus']) or (
+                                          args['intersection'] is not None
                                           and ':' not in args['intersection']):
-    parser.print_help()
-  else:
-    ret = scr_glob_hosts(count=args['count'],
-                         nth=args['nth'],
-                         hosts=args['hosts'],
-                         minus=args['minus'],
-                         intersection=args['intersection'],
-                         compress=args['compress'])
-    if ret is not None:
-      print(str(ret))
+        parser.print_help()
+    else:
+        ret = scr_glob_hosts(count=args['count'],
+                             nth=args['nth'],
+                             hosts=args['hosts'],
+                             minus=args['minus'],
+                             intersection=args['intersection'],
+                             compress=args['compress'])
+        if ret is not None:
+            print(str(ret))

--- a/scripts/python/scrjob/scr_halt.py
+++ b/scripts/python/scrjob/scr_halt.py
@@ -5,8 +5,8 @@
 import os, sys
 
 if 'scrjob' not in sys.path:
-  sys.path.insert(0, '/'.join(os.path.realpath(__file__).split('/')[:-2]))
-  import scrjob
+    sys.path.insert(0, '/'.join(os.path.realpath(__file__).split('/')[:-2]))
+    import scrjob
 
 import argparse
 import stat
@@ -30,246 +30,249 @@ def scr_halt(bindir=None,
              remove=False,
              verbose=False,
              dirs=[]):
-  ret = 0
+    ret = 0
 
-  if bindir is None:
-    bindir = scr_const.X_BINDIR
+    if bindir is None:
+        bindir = scr_const.X_BINDIR
 
-  # path to scr_halt_cntl command
-  scr_halt_cntl = os.path.join(bindir, 'scr_halt_cntl')
+    # path to scr_halt_cntl command
+    scr_halt_cntl = os.path.join(bindir, 'scr_halt_cntl')
 
-  # use current working directory if none specified
-  if not dirs:
-    dirs = [os.getcwd()]
+    # use current working directory if none specified
+    if not dirs:
+        dirs = [os.getcwd()]
 
-  # list to accumulate options for scr_halt_cntl command
-  halt_conditions = []
+    # list to accumulate options for scr_halt_cntl command
+    halt_conditions = []
 
-  # the -r option overrides everything else
-  if not remove:
-    # halt after X checkpoints
-    # TODO: check that a valid value was given
-    if checkpoints is not None:
-      checkpoints = str(checkpoints)
-      halt_conditions = ['-c', checkpoints]
+    # the -r option overrides everything else
+    if not remove:
+        # halt after X checkpoints
+        # TODO: check that a valid value was given
+        if checkpoints is not None:
+            checkpoints = str(checkpoints)
+            halt_conditions = ['-c', checkpoints]
 
-    # halt before time
-    if before is not None:
-      secs = parsetime(before)
-      halt_conditions.append('-b')
-      halt_conditions.append(str(secs))
+        # halt before time
+        if before is not None:
+            secs = parsetime(before)
+            halt_conditions.append('-b')
+            halt_conditions.append(str(secs))
 
-    # halt after time
-    if after is not None:
-      secs = parsetime(after)
-      halt_conditions.append('-a')
-      halt_conditions.append(str(secs))
+        # halt after time
+        if after is not None:
+            secs = parsetime(after)
+            halt_conditions.append('-a')
+            halt_conditions.append(str(secs))
 
-    # set (reset) SCR_HALT_SECONDS value
-    # TODO: check that a valid value was given
-    if seconds is not None:
-      halt_conditions.append('-s')
-      halt_conditions.append(seconds)
+        # set (reset) SCR_HALT_SECONDS value
+        # TODO: check that a valid value was given
+        if seconds is not None:
+            halt_conditions.append('-s')
+            halt_conditions.append(seconds)
 
-    # list halt options
-    if dolist:
-      halt_conditions.append('-l')
+        # list halt options
+        if dolist:
+            halt_conditions.append('-l')
 
-    # push options to unset any values
-    if unset_checkpoints:
-      halt_conditions.append('-xc')
-    if unset_before:
-      halt_conditions.append('-xb')
-    if unset_after:
-      halt_conditions.append('-xa')
-    if unset_seconds:
-      halt_conditions.append('-xs')
-    if unset_reason:
-      halt_conditions.append('-xr')
+        # push options to unset any values
+        if unset_checkpoints:
+            halt_conditions.append('-xc')
+        if unset_before:
+            halt_conditions.append('-xb')
+        if unset_after:
+            halt_conditions.append('-xa')
+        if unset_seconds:
+            halt_conditions.append('-xs')
+        if unset_reason:
+            halt_conditions.append('-xr')
 
-    # if we were not given any conditions, set the exit reason to JOB_HALTED
-    if len(halt_conditions) == 0 or immediate:
-      halt_conditions.append('-r')
-      halt_conditions.append('JOB_HALTED')
+        # if we were not given any conditions, set the exit reason to JOB_HALTED
+        if len(halt_conditions) == 0 or immediate:
+            halt_conditions.append('-r')
+            halt_conditions.append('JOB_HALTED')
 
-  # create a halt file in each target prefix directory
-  for d in dirs:
-    print('Updating halt file in ' + d)
-    rc = 0
+    # create a halt file in each target prefix directory
+    for d in dirs:
+        print('Updating halt file in ' + d)
+        rc = 0
 
-    # build the name of the halt file
-    halt_file = os.path.join(d, '.scr', 'halt.scr')
+        # build the name of the halt file
+        halt_file = os.path.join(d, '.scr', 'halt.scr')
 
-    # remove the halt file and move on to next direcotry
-    # if no conditions are specified
-    if halt_conditions == []:
-      try:
-        os.remove(halt_file)
-      except:
-        pass
-      continue
+        # remove the halt file and move on to next direcotry
+        # if no conditions are specified
+        if halt_conditions == []:
+            try:
+                os.remove(halt_file)
+            except:
+                pass
+            continue
 
-    # create scr prefix directory
-    os.makedirs(os.path.join(d, '.scr'), exist_ok=True)
+        # create scr prefix directory
+        os.makedirs(os.path.join(d, '.scr'), exist_ok=True)
 
-    # execute the command
-    # create the halt file with specified conditions
-    # TODO: Set halt file permissions so system admins can modify them
-    ####### ensure we have chmod664 ? then also need to ensure owned path is 775 ?
-    ### If a chmod is good, 664+775 or 660+770
-    ### Doing directories ... when to stop ? 2 dirs ?
-    ### the makedirs is supposed to take a 'mode' argument, that didn't work for me.
-    chmod664 = stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IWGRP | stat.S_IROTH
-    chmod775 = stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR | \
-               stat.S_IRGRP | stat.S_IWGRP | stat.S_IXGRP | \
-               stat.S_IROTH | stat.S_IXOTH
-    chmod660 = stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IWGRP
-    chmod770 = stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR | \
-               stat.S_IRGRP | stat.S_IWGRP | stat.S_IXGRP
-    chmod664 = None
+        # execute the command
+        # create the halt file with specified conditions
+        # TODO: Set halt file permissions so system admins can modify them
+        ####### ensure we have chmod664 ? then also need to ensure owned path is 775 ?
+        ### If a chmod is good, 664+775 or 660+770
+        ### Doing directories ... when to stop ? 2 dirs ?
+        ### the makedirs is supposed to take a 'mode' argument, that didn't work for me.
+        chmod664 = stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IWGRP | stat.S_IROTH
+        chmod775 = stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR | \
+                   stat.S_IRGRP | stat.S_IWGRP | stat.S_IXGRP | \
+                   stat.S_IROTH | stat.S_IXOTH
+        chmod660 = stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IWGRP
+        chmod770 = stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR | \
+                   stat.S_IRGRP | stat.S_IWGRP | stat.S_IXGRP
+        chmod664 = None
 
-    cmd = [scr_halt_cntl, '-f', halt_file]
-    cmd.extend(halt_conditions)
-    output, rc = runproc(cmd, getstdout=True, getstderr=True, verbose=verbose)
-    if rc != 0:
-      if output is not None:
-        print(output[1].strip())
-      print('scr_halt: ERROR: Failed to update halt file for ' + d)
-      ret = 1
-    # TODO For file permissions ?
-    # Doing 664+775
-    #else: # rc == 0:
-    elif chmod664 is not None:
-      # the file
-      try:
-        # 664 OR with whatever was there before
-        os.chmod(halt_file, chmod664 | os.stat(halt_file).st_mode)
-      except:
-        pass
-      chdir = '/'.join(halt_file.split('/')[:-1])
-      try:
-        # do both directories: d / .scr
-        os.chmod(chdir, chmod775 | os.stat(chdir).st_mode)
-        chdir = '/'.join(chdir.split('/')[:-1])
-        os.chmod(chdir, chmod775 | os.stat(chdir).st_mode)
-      except:
-        pass
+        cmd = [scr_halt_cntl, '-f', halt_file]
+        cmd.extend(halt_conditions)
+        output, rc = runproc(cmd,
+                             getstdout=True,
+                             getstderr=True,
+                             verbose=verbose)
+        if rc != 0:
+            if output is not None:
+                print(output[1].strip())
+            print('scr_halt: ERROR: Failed to update halt file for ' + d)
+            ret = 1
+        # TODO For file permissions ?
+        # Doing 664+775
+        #else: # rc == 0:
+        elif chmod664 is not None:
+            # the file
+            try:
+                # 664 OR with whatever was there before
+                os.chmod(halt_file, chmod664 | os.stat(halt_file).st_mode)
+            except:
+                pass
+            chdir = '/'.join(halt_file.split('/')[:-1])
+            try:
+                # do both directories: d / .scr
+                os.chmod(chdir, chmod775 | os.stat(chdir).st_mode)
+                chdir = '/'.join(chdir.split('/')[:-1])
+                os.chmod(chdir, chmod775 | os.stat(chdir).st_mode)
+            except:
+                pass
 
-    # print output to screen
-    if output is not None:
-      print(output[0].strip())
+        # print output to screen
+        if output is not None:
+            print(output[0].strip())
 
-  # kill job if immediate was set
-  # TODO: would like to protect against killing a job in the middle of a checkpoint if possible
-  if immediate:
-    # TODO: lookup active jobid for given prefix directory and halt job based on system
-    print('scr_halt: ERROR: --immediate option not yet supported')
-    return 1
+    # kill job if immediate was set
+    # TODO: would like to protect against killing a job in the middle of a checkpoint if possible
+    if immediate:
+        # TODO: lookup active jobid for given prefix directory and halt job based on system
+        print('scr_halt: ERROR: --immediate option not yet supported')
+        return 1
 
-  return ret
+    return ret
 
 
 if __name__ == '__main__':
-  parser = argparse.ArgumentParser(
-      add_help=False,
-      argument_default=argparse.SUPPRESS,
-      prog='scr_halt',
-      epilog=
-      'TIME arguments are parsed using parsetime.py,\nand t may be specified in one of many formats.\nExamples include \'12pm\', \'yesterday noon\', \'12/25 15:30:33\', and so on.\nIf no directory is specified, the current working directory is used.'
-  )
-  # when prefixes are unambiguous then also adding shortcodes isn't necessary
-  #parser.add_argument('-z', '--all', action='store_true', help='Halt all jobs on the system.')
-  #parser.add_argument('-u', '--user', metavar='LIST', type=str, help='Halt all jobs for a comma-separated LIST of users.')
-  parser.add_argument('-c',
-                      '--checkpoints',
-                      metavar='N',
-                      default=None,
-                      type=int,
-                      help='Halt job after N checkpoints.')
-  parser.add_argument(
-      '-b',
-      '--before',
-      metavar='TIME',
-      default=None,
-      type=str,
-      help='Halt job before specified TIME. Uses SCR_HALT_SECONDS if set.')
-  parser.add_argument('-a',
-                      '--after',
-                      metavar='TIME',
-                      default=None,
-                      type=str,
-                      help='Halt job after specified TIME.')
-  parser.add_argument('-i',
-                      '--immediate',
-                      action='store_true',
-                      default=False,
-                      help='Halt job immediately.')
-  parser.add_argument('-s',
-                      '--seconds',
-                      metavar='N',
-                      default=None,
-                      type=str,
-                      help='Set or reset SCR_HALT_SECONDS for active job.')
-  parser.add_argument(
-      '-l',
-      '--list',
-      action='store_true',
-      default=False,
-      help='List the current halt conditions specified for a job or jobs.')
-  parser.add_argument('--unset-checkpoints',
-                      action='store_true',
-                      default=False,
-                      help='Unset any checkpoint halt condition.')
-  parser.add_argument('--unset-before',
-                      action='store_true',
-                      default=False,
-                      help='Unset any halt before condition.')
-  parser.add_argument('--unset-after',
-                      action='store_true',
-                      default=False,
-                      help='Unset halt after condition.')
-  parser.add_argument('--unset-seconds',
-                      action='store_true',
-                      default=False,
-                      help='Unset halt seconds.')
-  parser.add_argument('--unset-reason',
-                      action='store_true',
-                      default=False,
-                      help='Unset the current halt reason.')
-  parser.add_argument('-r',
-                      '--remove',
-                      action='store_true',
-                      default=False,
-                      help='Remove halt file.')
-  parser.add_argument('-v',
-                      '--verbose',
-                      action='store_true',
-                      default=False,
-                      help='Increase verbosity.')
-  parser.add_argument('-h',
-                      '--help',
-                      action='store_true',
-                      help='Show this help message and exit.')
-  parser.add_argument('dirs', nargs=argparse.REMAINDER, default=[])
-  args = vars(parser.parse_args())
+    parser = argparse.ArgumentParser(
+        add_help=False,
+        argument_default=argparse.SUPPRESS,
+        prog='scr_halt',
+        epilog=
+        'TIME arguments are parsed using parsetime.py,\nand t may be specified in one of many formats.\nExamples include \'12pm\', \'yesterday noon\', \'12/25 15:30:33\', and so on.\nIf no directory is specified, the current working directory is used.'
+    )
+    # when prefixes are unambiguous then also adding shortcodes isn't necessary
+    #parser.add_argument('-z', '--all', action='store_true', help='Halt all jobs on the system.')
+    #parser.add_argument('-u', '--user', metavar='LIST', type=str, help='Halt all jobs for a comma-separated LIST of users.')
+    parser.add_argument('-c',
+                        '--checkpoints',
+                        metavar='N',
+                        default=None,
+                        type=int,
+                        help='Halt job after N checkpoints.')
+    parser.add_argument(
+        '-b',
+        '--before',
+        metavar='TIME',
+        default=None,
+        type=str,
+        help='Halt job before specified TIME. Uses SCR_HALT_SECONDS if set.')
+    parser.add_argument('-a',
+                        '--after',
+                        metavar='TIME',
+                        default=None,
+                        type=str,
+                        help='Halt job after specified TIME.')
+    parser.add_argument('-i',
+                        '--immediate',
+                        action='store_true',
+                        default=False,
+                        help='Halt job immediately.')
+    parser.add_argument('-s',
+                        '--seconds',
+                        metavar='N',
+                        default=None,
+                        type=str,
+                        help='Set or reset SCR_HALT_SECONDS for active job.')
+    parser.add_argument(
+        '-l',
+        '--list',
+        action='store_true',
+        default=False,
+        help='List the current halt conditions specified for a job or jobs.')
+    parser.add_argument('--unset-checkpoints',
+                        action='store_true',
+                        default=False,
+                        help='Unset any checkpoint halt condition.')
+    parser.add_argument('--unset-before',
+                        action='store_true',
+                        default=False,
+                        help='Unset any halt before condition.')
+    parser.add_argument('--unset-after',
+                        action='store_true',
+                        default=False,
+                        help='Unset halt after condition.')
+    parser.add_argument('--unset-seconds',
+                        action='store_true',
+                        default=False,
+                        help='Unset halt seconds.')
+    parser.add_argument('--unset-reason',
+                        action='store_true',
+                        default=False,
+                        help='Unset the current halt reason.')
+    parser.add_argument('-r',
+                        '--remove',
+                        action='store_true',
+                        default=False,
+                        help='Remove halt file.')
+    parser.add_argument('-v',
+                        '--verbose',
+                        action='store_true',
+                        default=False,
+                        help='Increase verbosity.')
+    parser.add_argument('-h',
+                        '--help',
+                        action='store_true',
+                        help='Show this help message and exit.')
+    parser.add_argument('dirs', nargs=argparse.REMAINDER, default=[])
+    args = vars(parser.parse_args())
 
-  if 'help' in args:
-    parser.print_help()
-  #elif 'all' in args or 'user' in args:
-  #  print('scr_halt: ERROR: --all and --user options not yet supported')
-  else:
-    ret = scr_halt(checkpoints=args['checkpoints'],
-                   before=args['before'],
-                   after=args['after'],
-                   immediate=args['immediate'],
-                   seconds=args['seconds'],
-                   dolist=args['list'],
-                   unset_checkpoints=args['unset_checkpoints'],
-                   unset_before=args['unset_before'],
-                   unset_after=args['unset_after'],
-                   unset_seconds=args['unset_seconds'],
-                   unset_reason=args['unset_reason'],
-                   remove=args['remove'],
-                   verbose=args['verbose'],
-                   dirs=args['dirs'])
-    print(str(ret))
+    if 'help' in args:
+        parser.print_help()
+    #elif 'all' in args or 'user' in args:
+    #  print('scr_halt: ERROR: --all and --user options not yet supported')
+    else:
+        ret = scr_halt(checkpoints=args['checkpoints'],
+                       before=args['before'],
+                       after=args['after'],
+                       immediate=args['immediate'],
+                       seconds=args['seconds'],
+                       dolist=args['list'],
+                       unset_checkpoints=args['unset_checkpoints'],
+                       unset_before=args['unset_before'],
+                       unset_after=args['unset_after'],
+                       unset_seconds=args['unset_seconds'],
+                       unset_reason=args['unset_reason'],
+                       remove=args['remove'],
+                       verbose=args['verbose'],
+                       dirs=args['dirs'])
+        print(str(ret))

--- a/scripts/python/scrjob/scr_hostlist.py
+++ b/scripts/python/scrjob/scr_hostlist.py
@@ -24,124 +24,124 @@ import argparse, re, sys
 # numbersfromrange('0003,99,999,123,1234,2345667')
 # ret -> ['0000003', '0000099', '0000999', '0000123', '0001234', '2345667']
 def numbersfromrange(numstring):
-  numbers = []
-  startrange = 0
-  buildnum = 0
-  havestart = False
-  digits = 0
-  maxdigits = 0
-  once = False
-  leadzero = False
-  for c in numstring:
-    if c == ',':
-      if havestart == True:
+    numbers = []
+    startrange = 0
+    buildnum = 0
+    havestart = False
+    digits = 0
+    maxdigits = 0
+    once = False
+    leadzero = False
+    for c in numstring:
+        if c == ',':
+            if havestart == True:
+                for num in range(startrange, buildnum + 1):
+                    numbers.append(num)
+                havestart = False
+            else:
+                numbers.append(buildnum)
+            buildnum = 0
+            if digits > maxdigits:
+                maxdigits = digits
+            digits = 0
+        elif c == '-':
+            havestart = True
+            startrange = buildnum
+            buildnum = 0
+            if digits > maxdigits:
+                maxdigits = digits
+            digits = 0
+        elif c.isnumeric() == True:
+            if buildnum == 0 and digits > 0:
+                leadzero = True
+            else:
+                buildnum *= 10
+            digits += 1
+            buildnum += int(c)
+    if havestart == True:
         for num in range(startrange, buildnum + 1):
-          numbers.append(num)
-        havestart = False
-      else:
+            numbers.append(num)
+    else:
         numbers.append(buildnum)
-      buildnum = 0
-      if digits > maxdigits:
-        maxdigits = digits
-      digits = 0
-    elif c == '-':
-      havestart = True
-      startrange = buildnum
-      buildnum = 0
-      if digits > maxdigits:
-        maxdigits = digits
-      digits = 0
-    elif c.isnumeric() == True:
-      if buildnum == 0 and digits > 0:
-        leadzero = True
-      else:
-        buildnum *= 10
-      digits += 1
-      buildnum += int(c)
-  if havestart == True:
-    for num in range(startrange, buildnum + 1):
-      numbers.append(num)
-  else:
-    numbers.append(buildnum)
-  ret = []
-  if leadzero == True:
-    if digits > maxdigits:
-      maxdigits = digits
-    for num in numbers:
-      strval = str(num)
-      if len(strval) < maxdigits:
-        strval = ('0' * (maxdigits - len(strval))) + strval
-      ret.append(strval)
-  else:
-    for num in numbers:
-      ret.append(str(num))
-  return ret
+    ret = []
+    if leadzero == True:
+        if digits > maxdigits:
+            maxdigits = digits
+        for num in numbers:
+            strval = str(num)
+            if len(strval) < maxdigits:
+                strval = ('0' * (maxdigits - len(strval))) + strval
+            ret.append(strval)
+    else:
+        for num in numbers:
+            ret.append(str(num))
+    return ret
 
 
 # return the int value of the rightmost number
 def numfromhost(host=''):
-  number = 0
-  place = 1
-  for i in range(len(host)-1,-1,-1):
-    if host[i] == ',' or host[i] == '-' or host[i] == '[':
-      break
-    if host[i].isnumeric():
-      number += int(host[i]) * place
-      place *= 10
-  return number
+    number = 0
+    place = 1
+    for i in range(len(host) - 1, -1, -1):
+        if host[i] == ',' or host[i] == '-' or host[i] == '[':
+            break
+        if host[i].isnumeric():
+            number += int(host[i]) * place
+            place *= 10
+    return number
 
 
 # return a list from a host string
 def splithosts(hosts=''):
-  if type(hosts) is not str:
-    return hosts
-  # split the host string on commas
-  hosts = hosts.split(',')
-  # we could have a host set of the form: host[1,3-5]
-  # we shouldn't have split on commas if they are within brackets
-  parts = []
-  # track whether we are continuing the same part
-  samehost = False
-  i = -1
-  for host in hosts:
-    if samehost:
-      parts[i] += ',' + host
-      if ']' in host:
-        samehost = False
-    else:
-      parts.append(host)
-      i += 1
-      if '[' in host and ']' not in host:
-        samehost = True
-  return parts
+    if type(hosts) is not str:
+        return hosts
+    # split the host string on commas
+    hosts = hosts.split(',')
+    # we could have a host set of the form: host[1,3-5]
+    # we shouldn't have split on commas if they are within brackets
+    parts = []
+    # track whether we are continuing the same part
+    samehost = False
+    i = -1
+    for host in hosts:
+        if samehost:
+            parts[i] += ',' + host
+            if ']' in host:
+                samehost = False
+        else:
+            parts.append(host)
+            i += 1
+            if '[' in host and ']' not in host:
+                samehost = True
+    return parts
 
 
 # sort a string of hosts in ascending order
 def sorthoststring(hosts=''):
-  if type(hosts) is list:
-    hosts = ','.join(hosts)
-  if hosts is None or hosts == '' or ',' not in hosts:
-    return hosts if hosts is not None else ''
-  parts = splithosts(hosts)
-  hosts = [ parts[0] ]
-  leftnum = numfromhost(parts[0])
-  for righti in range(1,len(parts)):
-    number = numfromhost(parts[righti])
-    # we need to put this one earlier
-    if number < leftnum:
-      hosts.append('')
-      for lefti in range(righti-1,-1,-1):
-        if number < numfromhost(hosts[lefti]):
-          hosts[lefti+1] = hosts[lefti]
+    if type(hosts) is list:
+        hosts = ','.join(hosts)
+    if hosts is None or hosts == '' or ',' not in hosts:
+        return hosts if hosts is not None else ''
+    parts = splithosts(hosts)
+    hosts = [parts[0]]
+    leftnum = numfromhost(parts[0])
+    for righti in range(1, len(parts)):
+        number = numfromhost(parts[righti])
+        # we need to put this one earlier
+        if number < leftnum:
+            hosts.append('')
+            for lefti in range(righti - 1, -1, -1):
+                if number < numfromhost(hosts[lefti]):
+                    hosts[lefti + 1] = hosts[lefti]
+                else:
+                    hosts[lefti + 1] = parts[righti]
+                    break
+            if number < numfromhost(hosts[0]):
+                hosts[0] = parts[righti]
         else:
-          hosts[lefti+1] = parts[righti]
-          break
-      if number < numfromhost(hosts[0]):
-        hosts[0] = parts[righti]
-    else:
-      hosts.append(parts[righti])
-      leftnum = number
-  return ','.join(hosts)
+            hosts.append(parts[righti])
+            leftnum = number
+    return ','.join(hosts)
 
 
 # rangefromnumbers is a helper function to collapse a list of numbers, if possible.
@@ -149,57 +149,57 @@ def sorthoststring(hosts=''):
 # '1,2,3,4,5,9,11,12' -> '1-5,9,11-12'
 # '1,2,3,5-7' -> '1-3,5-7'
 def rangefromnumbers(numstring):
-  if len(numstring) == 0:
-    return ''
-  if ',' not in numstring:
-    return numstring
-  ret = ''
-  firstval = 0
-  checknext = False
-  haverange = False
-  nextval = 0
-  buildval = 0
-  for c in numstring:
-    if c.isnumeric() == True:
-      buildval *= 10
-      buildval += int(c)
-    elif c == ',':
-      if haverange == True:
-        haverange = False
-        checknext = True
-        nextval = buildval + 1
-      elif checknext == True:
-        if buildval > nextval:
-          if nextval == firstval + 1:
-            ret += str(firstval) + ','
-          else:
-            ret += str(firstval) + '-' + str(nextval - 1) + ','
-          firstval = buildval
-        nextval = buildval + 1
-      else:  #if checknext==False:
-        checknext = True
-        firstval = buildval
-        nextval = firstval + 1
-      buildval = 0
-    elif c == '-':
-      haverange = True
-      if checknext == False or buildval != nextval:
+    if len(numstring) == 0:
+        return ''
+    if ',' not in numstring:
+        return numstring
+    ret = ''
+    firstval = 0
+    checknext = False
+    haverange = False
+    nextval = 0
+    buildval = 0
+    for c in numstring:
+        if c.isnumeric() == True:
+            buildval *= 10
+            buildval += int(c)
+        elif c == ',':
+            if haverange == True:
+                haverange = False
+                checknext = True
+                nextval = buildval + 1
+            elif checknext == True:
+                if buildval > nextval:
+                    if nextval == firstval + 1:
+                        ret += str(firstval) + ','
+                    else:
+                        ret += str(firstval) + '-' + str(nextval - 1) + ','
+                    firstval = buildval
+                nextval = buildval + 1
+            else:  #if checknext==False:
+                checknext = True
+                firstval = buildval
+                nextval = firstval + 1
+            buildval = 0
+        elif c == '-':
+            haverange = True
+            if checknext == False or buildval != nextval:
+                if nextval == firstval + 1:
+                    ret += str(firstval) + ','
+                else:
+                    ret += str(firstval) + '-' + str(nextval - 1) + ','
+                firstval = buildval
+            buildval = 0
+    if haverange == True:
+        ret += str(firstval) + '-' + str(buildval)
+    elif buildval > nextval:
         if nextval == firstval + 1:
-          ret += str(firstval) + ','
+            ret += str(firstval) + ',' + str(buildval)
         else:
-          ret += str(firstval) + '-' + str(nextval - 1) + ','
-        firstval = buildval
-      buildval = 0
-  if haverange == True:
-    ret += str(firstval) + '-' + str(buildval)
-  elif buildval > nextval:
-    if nextval == firstval + 1:
-      ret += str(firstval) + ',' + str(buildval)
+            ret += str(firstval) + '-' + str(nextval - 1) + ',' + str(buildval)
     else:
-      ret += str(firstval) + '-' + str(nextval - 1) + ',' + str(buildval)
-  else:
-    ret += str(firstval) + '-' + str(buildval)
-  return ret
+        ret += str(firstval) + '-' + str(buildval)
+    return ret
 
 
 # Returns a list of hostnames given a hostlist string
@@ -211,281 +211,281 @@ def rangefromnumbers(numstring):
 # left fills with 0 if a host starts with 0:
 #   machine[08-10] --> machine08,machine09,machine10
 def expand(nodelist):
-  if nodelist is None:
-    return []
-  nodelist = sorthoststring(nodelist)
-  if nodelist == '':
-    return []
-  # list of gathered nodes (string list)
-  prefixes = []
-  # list of numstrings
-  numstrings = []
-  # corresponding list of suffixes
-  suffixes = []
-  # building strings
-  prefix = ''
-  numstring = ''
-  suffix = ''
-  # split the input on commas
-  chunks = nodelist.split(',')
-  # iterate over each chunk, can be one of the forms:
-  # 'rhea2' 'rhea[2' 'rhea[2-3' '3' '5-7' '8]' '8].llnl' 'rhea[2-3].llnl' 'rhea2.llnl'
-  for chunk in chunks:
-    # this chunk has a prefix and at least one number
-    if '[' in chunk:
-      pieces = chunk.split('[')
-      # if we have the closing bracket this chunk is complete
-      if ']' in pieces[1]:
-        prefixes.append(pieces[0])
-        prefix = ''
-        pieces = pieces[1].split(']')
-        numstrings.append(pieces[0])
-        if len(pieces) > 1:
-          suffixes.append(pieces[1])
+    if nodelist is None:
+        return []
+    nodelist = sorthoststring(nodelist)
+    if nodelist == '':
+        return []
+    # list of gathered nodes (string list)
+    prefixes = []
+    # list of numstrings
+    numstrings = []
+    # corresponding list of suffixes
+    suffixes = []
+    # building strings
+    prefix = ''
+    numstring = ''
+    suffix = ''
+    # split the input on commas
+    chunks = nodelist.split(',')
+    # iterate over each chunk, can be one of the forms:
+    # 'rhea2' 'rhea[2' 'rhea[2-3' '3' '5-7' '8]' '8].llnl' 'rhea[2-3].llnl' 'rhea2.llnl'
+    for chunk in chunks:
+        # this chunk has a prefix and at least one number
+        if '[' in chunk:
+            pieces = chunk.split('[')
+            # if we have the closing bracket this chunk is complete
+            if ']' in pieces[1]:
+                prefixes.append(pieces[0])
+                prefix = ''
+                pieces = pieces[1].split(']')
+                numstrings.append(pieces[0])
+                if len(pieces) > 1:
+                    suffixes.append(pieces[1])
+                else:
+                    suffixes.append('')
+            # otherwise there is only the prefix and some number/range
+            else:
+                prefix = pieces[0]
+                numstring = pieces[1]
+        # a bracket is closed
+        elif ']' in chunk:
+            pieces = chunk.split(']')
+            if len(numstring) > 0:
+                numstring += ','
+            numstring += pieces[0]
+            if len(pieces) > 1:
+                suffix = pieces[1]
+            else:
+                suffix = ''
+            if prefix != '':
+                prefixes.append(prefix)
+                prefix = ''
+            numstrings.append(numstring)
+            numstring = ''
+            suffixes.append(suffix)
+            suffix = ''
+        # this chunk is a single machine and has no bracket
+        elif prefix == '':
+            pieces = re.split(r'(\D+)', chunk)
+            # a correctly formed machine name will create the list:
+            # ['', 'rhea', '42', '.llnl', '']
+            # or
+            # ['', 'rhea', '42']
+            if len(pieces) > 3:
+                suffix = pieces[3]
+            else:
+                suffix = ''
+            if len(pieces) > 1:
+                prefix = pieces[1]
+            else:
+                prefix = ''
+            if len(pieces) > 2:
+                numstring = pieces[2]
+            prefixes.append(prefix)
+            numstrings.append(numstring)
+            suffixes.append(suffix)
+            prefix = ''
+            numstring = ''
+            suffix = ''
+        # otherwise we must be in a number section (or malformed / mismatched brackets)
         else:
-          suffixes.append('')
-      # otherwise there is only the prefix and some number/range
-      else:
-        prefix = pieces[0]
-        numstring = pieces[1]
-    # a bracket is closed
-    elif ']' in chunk:
-      pieces = chunk.split(']')
-      if len(numstring) > 0:
-        numstring += ','
-      numstring += pieces[0]
-      if len(pieces) > 1:
-        suffix = pieces[1]
-      else:
-        suffix = ''
-      if prefix != '':
+            numstring += ',' + chunk
+    if prefix != '':
         prefixes.append(prefix)
-        prefix = ''
-      numstrings.append(numstring)
-      numstring = ''
-      suffixes.append(suffix)
-      suffix = ''
-    # this chunk is a single machine and has no bracket
-    elif prefix == '':
-      pieces = re.split(r'(\D+)', chunk)
-      # a correctly formed machine name will create the list:
-      # ['', 'rhea', '42', '.llnl', '']
-      # or
-      # ['', 'rhea', '42']
-      if len(pieces) > 3:
-        suffix = pieces[3]
-      else:
-        suffix = ''
-      if len(pieces) > 1:
-        prefix = pieces[1]
-      else:
-        prefix = ''
-      if len(pieces) > 2:
-        numstring = pieces[2]
-      prefixes.append(prefix)
-      numstrings.append(numstring)
-      suffixes.append(suffix)
-      prefix = ''
-      numstring = ''
-      suffix = ''
-    # otherwise we must be in a number section (or malformed / mismatched brackets)
-    else:
-      numstring += ',' + chunk
-  if prefix != '':
-    prefixes.append(prefix)
-    numstrings.append(numstring)
-    suffixes.append(suffix)
-  # the lists are ready
-  ret = []
-  for i in range(len(prefixes)):
-    nums = []
-    # no prefix, the number is stored in the prefix
-    if numstrings[i] == '':
-      nums = numbersfromrange(prefixes[i])
-    else:
-      nums = numbersfromrange(numstrings[i])
-    for num in nums:
-      ret.append(prefixes[i] + num + suffixes[i])
-  return ret
+        numstrings.append(numstring)
+        suffixes.append(suffix)
+    # the lists are ready
+    ret = []
+    for i in range(len(prefixes)):
+        nums = []
+        # no prefix, the number is stored in the prefix
+        if numstrings[i] == '':
+            nums = numbersfromrange(prefixes[i])
+        else:
+            nums = numbersfromrange(numstrings[i])
+        for num in nums:
+            ret.append(prefixes[i] + num + suffixes[i])
+    return ret
 
 
 # Returns a hostlist string given a list of hostnames
 # compress('rhea2','rhea3','rhea4','rhea6') returns "rhea[2-4,6]"
 def compress_range(nodelist):
-  if nodelist is None:
-    return ''
-  nodelist = sorthoststring(nodelist)
-  nodelist = splithosts(nodelist)
-  if len(nodelist) == 0:
-    return ''
-  # dictionary keyed on prefix+'0'+suffix
-  # holds a number string
-  nodedict = {}
-  for node in nodelist:
-    node = node.strip()
-    if len(node) == 0:
-      continue
-    # a correctly formed machine name will create the list:
-    # ['', 'rhea', '42', '.llnl', '']
-    # or
-    # ['', 'rhea', '42']
-    pieces = re.split(r'(\D+)', node)
-    key = pieces[1]
-    if len(pieces) > 3:
-      key += '#' + pieces[3]
-    if key in nodedict:
-      nodedict[key] += ',' + pieces[2]
-    else:
-      nodedict[key] = pieces[2]
-  ret = ''
-  for key in nodedict:
-    prefix = key
-    suffix = ''
-    if '#' in key:
-      pieces = key.split('#')
-      prefix = pieces[0]
-      suffix = pieces[1]
-    rangenums = rangefromnumbers(nodedict[key])
-    if ret != '':
-      ret += ','
-    ret += prefix
-    if ',' in rangenums or '-' in rangenums:
-      ret += '[' + rangenums + ']'
-    else:
-      ret += rangenums
-    ret += suffix
-  return ret
+    if nodelist is None:
+        return ''
+    nodelist = sorthoststring(nodelist)
+    nodelist = splithosts(nodelist)
+    if len(nodelist) == 0:
+        return ''
+    # dictionary keyed on prefix+'0'+suffix
+    # holds a number string
+    nodedict = {}
+    for node in nodelist:
+        node = node.strip()
+        if len(node) == 0:
+            continue
+        # a correctly formed machine name will create the list:
+        # ['', 'rhea', '42', '.llnl', '']
+        # or
+        # ['', 'rhea', '42']
+        pieces = re.split(r'(\D+)', node)
+        key = pieces[1]
+        if len(pieces) > 3:
+            key += '#' + pieces[3]
+        if key in nodedict:
+            nodedict[key] += ',' + pieces[2]
+        else:
+            nodedict[key] = pieces[2]
+    ret = ''
+    for key in nodedict:
+        prefix = key
+        suffix = ''
+        if '#' in key:
+            pieces = key.split('#')
+            prefix = pieces[0]
+            suffix = pieces[1]
+        rangenums = rangefromnumbers(nodedict[key])
+        if ret != '':
+            ret += ','
+        ret += prefix
+        if ',' in rangenums or '-' in rangenums:
+            ret += '[' + rangenums + ']'
+        else:
+            ret += rangenums
+        ret += suffix
+    return ret
 
 
 # Returns a hostlist string given a list of hostnames
 # ( will also try to ensure a string is a comma separated string )
 # compress(['rhea2','rhea3','rhea4','rhea6']) returns "rhea2,rhea3,rhea4,rhea6"
 def compress(hostlist):
-  if hostlist is None:
-    return ''
-  if type(hostlist) is str:
-    # turn any commas (plus space) into just a space
-    hostlist = re.sub('\s*,\s*', ' ', hostlist)
-    # collapse all whitespace to single space, then remove any leading/trailing space
-    hostlist = re.sub('\s+', ' ', hostlist).strip()
-    # put commas into the spaces
-    hostlist = re.sub('\s', ',', hostlist)
-  hostlist = sorthoststring(hostlist)
-  return hostlist
+    if hostlist is None:
+        return ''
+    if type(hostlist) is str:
+        # turn any commas (plus space) into just a space
+        hostlist = re.sub('\s*,\s*', ' ', hostlist)
+        # collapse all whitespace to single space, then remove any leading/trailing space
+        hostlist = re.sub('\s+', ' ', hostlist).strip()
+        # put commas into the spaces
+        hostlist = re.sub('\s', ',', hostlist)
+    hostlist = sorthoststring(hostlist)
+    return hostlist
 
 
 # Given references to two lists, subtract elements in list 2 from list 1 and return remainder
 def diff(set1, set2):
-  if type(set1) is str:
-    set1 = set1.split(',')
-  if type(set2) is str:
-    set2 = set2.split(',')
-  # we should have two list references
-  if set1 is None:
-    return []
-  if set2 is None:
-    return set1
-  if len(set1) == 0:
-    return []
-  if len(set2) == 0:
-    return set1
-  ret = set1.copy()
-  for node in set2:
-    if node in ret:
-      ret.remove(node)
-  listvals = compress(ret)
-  ret = expand(listvals)
-  return ret
+    if type(set1) is str:
+        set1 = set1.split(',')
+    if type(set2) is str:
+        set2 = set2.split(',')
+    # we should have two list references
+    if set1 is None:
+        return []
+    if set2 is None:
+        return set1
+    if len(set1) == 0:
+        return []
+    if len(set2) == 0:
+        return set1
+    ret = set1.copy()
+    for node in set2:
+        if node in ret:
+            ret.remove(node)
+    listvals = compress(ret)
+    ret = expand(listvals)
+    return ret
 
 
 def intersect(set1, set2):
-  if type(set1) is str:
-    set1 = set1.split(',')
-  if type(set2) is str:
-    set2 = set2.split(',')
-  if set1 is None or set2 is None:
-    return []
-  if len(set1) == 0 or len(set2) == 0:
-    return []
-  ret = []
-  for node in set1:
-    if node in set2:
-      ret.append(node)
-  listvals = compress(ret)
-  ret = expand(listvals)
-  return ret
+    if type(set1) is str:
+        set1 = set1.split(',')
+    if type(set2) is str:
+        set2 = set2.split(',')
+    if set1 is None or set2 is None:
+        return []
+    if len(set1) == 0 or len(set2) == 0:
+        return []
+    ret = []
+    for node in set1:
+        if node in set2:
+            ret.append(node)
+    listvals = compress(ret)
+    ret = expand(listvals)
+    return ret
 
 
 if __name__ == '__main__':
-  parser = argparse.ArgumentParser(
-      add_help=False,
-      argument_default=argparse.SUPPRESS,
-      prog='scr_hostlist',
-      epilog='(use a colon to separate sets when using diff or intersect)')
-  parser.add_argument('-h',
-                      '--help',
-                      action='store_true',
-                      help='Show this help message and exit.')
-  parser.add_argument(
-      '--numbersfromrange',
-      metavar='<numberlist>',
-      type=str,
-      help='Expands a number list/range using numbers, commas, and hyphens.')
-  parser.add_argument(
-      '--rangefromnumbers',
-      metavar='<numberlist>',
-      type=str,
-      help='Compresses a number list/range using numbers, commas, and hyphens.'
-  )
-  parser.add_argument('--expand',
-                      metavar='<numberlist>',
-                      type=str,
-                      help='Returns a list from a given hostname string.')
-  parser.add_argument(
-      '--compress_range',
-      metavar='host',
-      nargs='+',
-      help='Returns a compressed string given a list of hostnames')
-  parser.add_argument('--compress',
-                      metavar='host',
-                      nargs='+',
-                      help='Returns the hosts as a comma separated string')
-  parser.add_argument('--diff',
-                      metavar='<set1:set2>',
-                      type=str,
-                      help='Returns elements of set1 not in set2.')
-  parser.add_argument('--intersect',
-                      metavar='<set1:set2>',
-                      type=str,
-                      help='Returns elements of set1 that are in set2.')
-  args = vars(parser.parse_args())
-  if 'help' in args:
-    parser.print_help()
-    sys.exit(0)
-  if 'numbersfromrange' in args:
-    print('numbersfromrange(' + args['numbersfromrange'] + ')')
-    print('  -> ' + str(numbersfromrange(args['numbersfromrange'])))
-  if 'rangefromnumbers' in args:
-    print('rangefromnumbers(' + args['rangefromnumbers'] + ')')
-    print('  -> ' + str(rangefromnumbers(args['rangefromnumbers'])))
-  if 'expand' in args:
-    print('expand(' + args['expand'] + ')')
-    print('  -> ' + str(expand(args['expand'])))
-  if 'compress_range' in args:
-    print('compress_range(' + str(args['compress_range']) + ')')
-    print('  -> ' + str(compress_range(args['compress_range'])))
-  if 'compress' in args:
-    print('compress(' + str(args['compress']) + ')')
-    print('  -> ' + str(compress(args['compress'])))
-  if 'diff' in args and ':' in args['diff']:
-    parts = args['diff'].split(':')
-    parts[0] = parts[0].split(',')
-    parts[1] = parts[1].split(',')
-    print('diff(' + str(parts[0]) + ':' + str(parts[1]) + ')')
-    print('  -> ' + str(diff(parts[0], parts[1])))
-  if 'intersect' in args and ':' in args['intersect']:
-    parts = args['intersect'].split(':')
-    parts[0] = parts[0].split(',')
-    parts[1] = parts[1].split(',')
-    print('intersect(' + str(parts[0]) + ':' + str(parts[1]) + ')')
-    print('  -> ' + str(intersect(parts[0], parts[1])))
+    parser = argparse.ArgumentParser(
+        add_help=False,
+        argument_default=argparse.SUPPRESS,
+        prog='scr_hostlist',
+        epilog='(use a colon to separate sets when using diff or intersect)')
+    parser.add_argument('-h',
+                        '--help',
+                        action='store_true',
+                        help='Show this help message and exit.')
+    parser.add_argument(
+        '--numbersfromrange',
+        metavar='<numberlist>',
+        type=str,
+        help='Expands a number list/range using numbers, commas, and hyphens.')
+    parser.add_argument(
+        '--rangefromnumbers',
+        metavar='<numberlist>',
+        type=str,
+        help=
+        'Compresses a number list/range using numbers, commas, and hyphens.')
+    parser.add_argument('--expand',
+                        metavar='<numberlist>',
+                        type=str,
+                        help='Returns a list from a given hostname string.')
+    parser.add_argument(
+        '--compress_range',
+        metavar='host',
+        nargs='+',
+        help='Returns a compressed string given a list of hostnames')
+    parser.add_argument('--compress',
+                        metavar='host',
+                        nargs='+',
+                        help='Returns the hosts as a comma separated string')
+    parser.add_argument('--diff',
+                        metavar='<set1:set2>',
+                        type=str,
+                        help='Returns elements of set1 not in set2.')
+    parser.add_argument('--intersect',
+                        metavar='<set1:set2>',
+                        type=str,
+                        help='Returns elements of set1 that are in set2.')
+    args = vars(parser.parse_args())
+    if 'help' in args:
+        parser.print_help()
+        sys.exit(0)
+    if 'numbersfromrange' in args:
+        print('numbersfromrange(' + args['numbersfromrange'] + ')')
+        print('  -> ' + str(numbersfromrange(args['numbersfromrange'])))
+    if 'rangefromnumbers' in args:
+        print('rangefromnumbers(' + args['rangefromnumbers'] + ')')
+        print('  -> ' + str(rangefromnumbers(args['rangefromnumbers'])))
+    if 'expand' in args:
+        print('expand(' + args['expand'] + ')')
+        print('  -> ' + str(expand(args['expand'])))
+    if 'compress_range' in args:
+        print('compress_range(' + str(args['compress_range']) + ')')
+        print('  -> ' + str(compress_range(args['compress_range'])))
+    if 'compress' in args:
+        print('compress(' + str(args['compress']) + ')')
+        print('  -> ' + str(compress(args['compress'])))
+    if 'diff' in args and ':' in args['diff']:
+        parts = args['diff'].split(':')
+        parts[0] = parts[0].split(',')
+        parts[1] = parts[1].split(',')
+        print('diff(' + str(parts[0]) + ':' + str(parts[1]) + ')')
+        print('  -> ' + str(diff(parts[0], parts[1])))
+    if 'intersect' in args and ':' in args['intersect']:
+        parts = args['intersect'].split(':')
+        parts[0] = parts[0].split(',')
+        parts[1] = parts[1].split(',')
+        print('intersect(' + str(parts[0]) + ':' + str(parts[1]) + ')')
+        print('  -> ' + str(intersect(parts[0], parts[1])))

--- a/scripts/python/scrjob/scr_inspect.py
+++ b/scripts/python/scrjob/scr_inspect.py
@@ -5,8 +5,8 @@
 import os, sys
 
 if 'scrjob' not in sys.path:
-  sys.path.insert(0, '/'.join(os.path.realpath(__file__).split('/')[:-2]))
-  import scrjob
+    sys.path.insert(0, '/'.join(os.path.realpath(__file__).split('/')[:-2]))
+    import scrjob
 
 import argparse, re, subprocess
 from scrjob import scr_const, scr_hostlist
@@ -16,7 +16,7 @@ from scrjob.launchers import AutoJobLauncher
 
 
 def scr_inspect(jobnodes=None, up=None, down=None, cntldir=None, scr_env=None):
-  """this method runs scr_inspect_cache on each node using Joblauncher.parallel_exec
+    """this method runs scr_inspect_cache on each node using Joblauncher.parallel_exec
 
   Returns
   -------
@@ -24,209 +24,209 @@ def scr_inspect(jobnodes=None, up=None, down=None, cntldir=None, scr_env=None):
   
   On error this method returns the integer 1
   """
-  bindir = scr_const.X_BINDIR
-  pdsh = scr_const.PDSH_EXE
+    bindir = scr_const.X_BINDIR
+    pdsh = scr_const.PDSH_EXE
 
-  if scr_env is None:
-    scr_env = SCR_Env()
-  if scr_env.resmgr is None:
-    scr_env.resmgr = AutoResourceManager()
-  if scr_env.launcher is None:
-    scr_env.launcher = AutoJobLauncher()
+    if scr_env is None:
+        scr_env = SCR_Env()
+    if scr_env.resmgr is None:
+        scr_env.resmgr = AutoResourceManager()
+    if scr_env.launcher is None:
+        scr_env.launcher = AutoJobLauncher()
 
-  # tag output files with jobid
-  jobid = scr_env.getjobid()
-  if jobid is None:
-    print('scr_inspect: ERROR: Could not determine jobid.')
-    return 1
+    # tag output files with jobid
+    jobid = scr_env.getjobid()
+    if jobid is None:
+        print('scr_inspect: ERROR: Could not determine jobid.')
+        return 1
 
-  # read node set of job
-  jobset = scr_env.get_scr_nodelist()
-  if jobset is None:
-    jobset = scr_env.resmgr.get_job_nodes()
+    # read node set of job
+    jobset = scr_env.get_scr_nodelist()
     if jobset is None:
-      print('scr_inspect: ERROR: Could not determine nodeset.')
-      return 1
+        jobset = scr_env.resmgr.get_job_nodes()
+        if jobset is None:
+            print('scr_inspect: ERROR: Could not determine nodeset.')
+            return 1
 
-  # can't get directories
-  if cntldir is None:
-    print('scr_inspect: ERROR: Control directory must be specified.')
-    return 1
+    # can't get directories
+    if cntldir is None:
+        print('scr_inspect: ERROR: Control directory must be specified.')
+        return 1
 
-  # get nodesets
-  if jobnodes is None:
-    print('scr_inspect: ERROR: Job nodes must be specified.')
-    return 1
+    # get nodesets
+    if jobnodes is None:
+        print('scr_inspect: ERROR: Job nodes must be specified.')
+        return 1
 
-  jobnodes = scr_hostlist.expand(jobnodes)
-  upnodes = []
-  downnodes = []
-  if down is not None:
-    downnodes = scr_hostlist.expand(down)
-    upnodes = scr_hostlist.diff(jobnodes, downnodes)
-  elif up is not None:
-    upnodes = scr_hostlist.expand(up)
-    downnodes = scr_hostlist.diff(jobnodes, upnodes)
-  else:
-    upnodes = jobnodes
+    jobnodes = scr_hostlist.expand(jobnodes)
+    upnodes = []
+    downnodes = []
+    if down is not None:
+        downnodes = scr_hostlist.expand(down)
+        upnodes = scr_hostlist.diff(jobnodes, downnodes)
+    elif up is not None:
+        upnodes = scr_hostlist.expand(up)
+        downnodes = scr_hostlist.diff(jobnodes, upnodes)
+    else:
+        upnodes = jobnodes
 
-  # make the list a comma separated string
-  upnodes = ','.join(upnodes)
+    # make the list a comma separated string
+    upnodes = ','.join(upnodes)
 
-  # build the output filenames
-  pwd = os.getcwd()
-  os.makedirs(pwd + '/.scr', exist_ok=True)
-  output = pwd + '/.scr/scr_inspect.pdsh.o.' + jobid
-  error = pwd + '/.scr/scr_inspect.pdsh.e.' + jobid
+    # build the output filenames
+    pwd = os.getcwd()
+    os.makedirs(pwd + '/.scr', exist_ok=True)
+    output = pwd + '/.scr/scr_inspect.pdsh.o.' + jobid
+    error = pwd + '/.scr/scr_inspect.pdsh.e.' + jobid
 
-  # run scr_inspect_cache via pdsh / clustershell
-  argv = [bindir + '/scr_inspect_cache', cntldir + '/filemap.scrinfo']
-  out = scr_env.launcher.parallel_exec(argv=argv,
-                                       runnodes=upnodes)[0]
-  try:
-    with open(output, 'w') as outfile:
-      outfile.write(out[0])
-  except Exception as e:
-    print(e)
-    print('scr_inspect: ERROR: Error writing scr_inspect_cache stdout')
-  try:
-    with open(error, 'w') as errfile:
-      errfile.write(out[1])
-  except Exception as e:
-    print(e)
-    print('scr_inspect: ERROR: Error writing scr_inspect_cache stderr')
+    # run scr_inspect_cache via pdsh / clustershell
+    argv = [bindir + '/scr_inspect_cache', cntldir + '/filemap.scrinfo']
+    out = scr_env.launcher.parallel_exec(argv=argv, runnodes=upnodes)[0]
+    try:
+        with open(output, 'w') as outfile:
+            outfile.write(out[0])
+    except Exception as e:
+        print(e)
+        print('scr_inspect: ERROR: Error writing scr_inspect_cache stdout')
+    try:
+        with open(error, 'w') as errfile:
+            errfile.write(out[1])
+    except Exception as e:
+        print(e)
+        print('scr_inspect: ERROR: Error writing scr_inspect_cache stderr')
 
-  # scan output file for list of partners and failed copies
-  groups = {}
-  types = {}
+    # scan output file for list of partners and failed copies
+    groups = {}
+    types = {}
 
-  # open the file, exit with error if we can't
-  readout = False
-  try:
-    with open(output, 'r') as infile:
-      readout = True
-      for line in infile.readlines():
-        line = line.rstrip()
-        search = re.search(
-            r'DSET=(\d+) RANK=(\d+) TYPE=(\w+) GROUPS=(\d+) GROUP_ID=(\d+) GROUP_SIZE=(\d+) GROUP_RANK=(\d+)',
-            line)
-        if search is not None:
-          dset = int(search.group(1))
-          rank = int(search.group(2))
-          atype = search.group(3)
-          ngroups = int(search.group(4))
-          group_id = int(search.group(5))
-          group_size = int(search.group(6))
-          group_rank = int(search.group(7))
-          if dset not in groups:
-            groups[dset] = {}
-            groups[dset]['ids'] = {}
-          if group_id not in groups[dset]['ids']:
-            groups[dset]['ids'][group_id] = {}
-            groups[dset]['ids'][group_id]['ranks'] = {}
-          groups[dset]['ids'][group_id]['ranks'][group_rank] = 1
-          groups[dset]['ids'][group_id]['size'] = group_size
-          groups[dset]['groups'] = ngroups
-          types[dset] = atype
-  except Exception as e:
-    print(e)
-    print('scr_inspect: ERROR: Reading and processing output file \"' +
-          output + '\"')
-    return 1
+    # open the file, exit with error if we can't
+    readout = False
+    try:
+        with open(output, 'r') as infile:
+            readout = True
+            for line in infile.readlines():
+                line = line.rstrip()
+                search = re.search(
+                    r'DSET=(\d+) RANK=(\d+) TYPE=(\w+) GROUPS=(\d+) GROUP_ID=(\d+) GROUP_SIZE=(\d+) GROUP_RANK=(\d+)',
+                    line)
+                if search is not None:
+                    dset = int(search.group(1))
+                    rank = int(search.group(2))
+                    atype = search.group(3)
+                    ngroups = int(search.group(4))
+                    group_id = int(search.group(5))
+                    group_size = int(search.group(6))
+                    group_rank = int(search.group(7))
+                    if dset not in groups:
+                        groups[dset] = {}
+                        groups[dset]['ids'] = {}
+                    if group_id not in groups[dset]['ids']:
+                        groups[dset]['ids'][group_id] = {}
+                        groups[dset]['ids'][group_id]['ranks'] = {}
+                    groups[dset]['ids'][group_id]['ranks'][group_rank] = 1
+                    groups[dset]['ids'][group_id]['size'] = group_size
+                    groups[dset]['groups'] = ngroups
+                    types[dset] = atype
+    except Exception as e:
+        print(e)
+        print('scr_inspect: ERROR: Reading and processing output file \"' +
+              output + '\"')
+        return 1
 
-  # starting with the most recent dataset, check whether we have (or may be able to recover) all files
-  possible_dsets = []
-  dsets = list(groups.keys())
-  dsets.sort()
-  for dset in dsets:
-    # get the expected number of groups and the dataset type
-    expected_groups = groups[dset]['groups']
-    atype = types[dset]
+    # starting with the most recent dataset, check whether we have (or may be able to recover) all files
+    possible_dsets = []
+    dsets = list(groups.keys())
+    dsets.sort()
+    for dset in dsets:
+        # get the expected number of groups and the dataset type
+        expected_groups = groups[dset]['groups']
+        atype = types[dset]
 
-    # count the number of groups we find, and the number we can't recover
-    num_groups = 0
-    missing_groups = 0
-    sortedids = list(groups[dset]['ids'].keys())
-    sortedids.sort()
-    for group in sortedids:
-      # add this group to our running total, and get its size
-      num_groups += 1
-      group_size = groups[dset]['ids'][group]['size']
+        # count the number of groups we find, and the number we can't recover
+        num_groups = 0
+        missing_groups = 0
+        sortedids = list(groups[dset]['ids'].keys())
+        sortedids.sort()
+        for group in sortedids:
+            # add this group to our running total, and get its size
+            num_groups += 1
+            group_size = groups[dset]['ids'][group]['size']
 
-      # count the number of ranks we're missing from this dataset
-      missing_ranks = []
-      for i in range(group_size):
-        if i not in groups[dset]['ids'][group]['ranks']:
-          missing_ranks.append(i)
+            # count the number of ranks we're missing from this dataset
+            missing_ranks = []
+            for i in range(group_size):
+                if i not in groups[dset]['ids'][group]['ranks']:
+                    missing_ranks.append(i)
 
-      # determine whether we are missing too many ranks from this group based on the dataset type
-      missing_too_many = False
-      if (type == 'LOCAL' or type == 'PARTNER') and len(missing_ranks) > 0:
-        missing_too_many = True
-      elif type == 'XOR' and len(missing_ranks) > 1:
-        missing_too_many = True
+            # determine whether we are missing too many ranks from this group based on the dataset type
+            missing_too_many = False
+            if (type == 'LOCAL'
+                    or type == 'PARTNER') and len(missing_ranks) > 0:
+                missing_too_many = True
+            elif type == 'XOR' and len(missing_ranks) > 1:
+                missing_too_many = True
 
-      # if we're missing too many ranks from this group, add it to the total
-      if missing_too_many == True:
-        missing_groups += 1
+            # if we're missing too many ranks from this group, add it to the total
+            if missing_too_many == True:
+                missing_groups += 1
 
-    # if we have a chance to recover files from all groups of this dataset, add it to the list
-    if num_groups == expected_groups and missing_groups == 0:
-      possible_dsets.append(dset)
+        # if we have a chance to recover files from all groups of this dataset, add it to the list
+        if num_groups == expected_groups and missing_groups == 0:
+            possible_dsets.append(dset)
 
-  # failed to find a full dataset to even attempt
-  if len(possible_dsets) == 0:
-    return 1
+    # failed to find a full dataset to even attempt
+    if len(possible_dsets) == 0:
+        return 1
 
-  # return the list the datasets we have a shot of recovering
-  return ' '.join(possible_dsets)
+    # return the list the datasets we have a shot of recovering
+    return ' '.join(possible_dsets)
 
 
 if __name__ == '__main__':
-  parser = argparse.ArgumentParser(
-      add_help=False,
-      argument_default=argparse.SUPPRESS,
-      prog='scr_inspect',
-      epilog=
-      'The jobid and job node set must be able to be obtained from the environment.'
-  )
-  parser.add_argument('-h',
-                      '--help',
-                      action='store_true',
-                      help='Show this help message and exit.')
-  parser.add_argument('-j',
-                      '--jobset',
-                      default=None,
-                      metavar='<nodeset>',
-                      type=str,
-                      help='Job nodes.')
-  parser.add_argument('-u',
-                      '--up',
-                      default=None,
-                      metavar='<nodeset>',
-                      type=str,
-                      help='Up nodes.')
-  parser.add_argument('-d',
-                      '--down',
-                      default=None,
-                      metavar='<nodeset>',
-                      type=str,
-                      help='Down nodes.')
-  parser.add_argument('-f',
-                      '--from',
-                      default=None,
-                      metavar='<ctrl dir>',
-                      type=str,
-                      help='Control directory.')
-  args = vars(parser.parse_args())
-  if 'help' in args:
-    parser.print_help()
-  elif args['jobset'] is None or args['from'] is None:
-    parser.print_help()
-    print('Job nodes and control directory must be specified.')
-  else:
-    ret = scr_inspect(jobnodes=args['jobset'],
-                      up=args['up'],
-                      down=args['down'],
-                      cntldir=args['from'])
-    print('scr_inspect returned ' + str(ret))
+    parser = argparse.ArgumentParser(
+        add_help=False,
+        argument_default=argparse.SUPPRESS,
+        prog='scr_inspect',
+        epilog=
+        'The jobid and job node set must be able to be obtained from the environment.'
+    )
+    parser.add_argument('-h',
+                        '--help',
+                        action='store_true',
+                        help='Show this help message and exit.')
+    parser.add_argument('-j',
+                        '--jobset',
+                        default=None,
+                        metavar='<nodeset>',
+                        type=str,
+                        help='Job nodes.')
+    parser.add_argument('-u',
+                        '--up',
+                        default=None,
+                        metavar='<nodeset>',
+                        type=str,
+                        help='Up nodes.')
+    parser.add_argument('-d',
+                        '--down',
+                        default=None,
+                        metavar='<nodeset>',
+                        type=str,
+                        help='Down nodes.')
+    parser.add_argument('-f',
+                        '--from',
+                        default=None,
+                        metavar='<ctrl dir>',
+                        type=str,
+                        help='Control directory.')
+    args = vars(parser.parse_args())
+    if 'help' in args:
+        parser.print_help()
+    elif args['jobset'] is None or args['from'] is None:
+        parser.print_help()
+        print('Job nodes and control directory must be specified.')
+    else:
+        ret = scr_inspect(jobnodes=args['jobset'],
+                          up=args['up'],
+                          down=args['down'],
+                          cntldir=args['from'])
+        print('scr_inspect returned ' + str(ret))

--- a/scripts/python/scrjob/scr_jsrun.py
+++ b/scripts/python/scrjob/scr_jsrun.py
@@ -8,26 +8,27 @@
 import os, sys
 
 if 'scrjob' not in sys.path:
-  sys.path.insert(0, '/'.join(os.path.realpath(__file__).split('/')[:-2]))
-  import scrjob
+    sys.path.insert(0, '/'.join(os.path.realpath(__file__).split('/')[:-2]))
+    import scrjob
 
 from scrjob.scr_run import *
 
 if __name__ == '__main__':
-  # just printing help, print the help and exit
-  if len(sys.argv) < 3 or '-h' in sys.argv[1:] or '--help' in sys.argv[1:]:
-    print_usage('jsrun')
-  elif not any(
-      arg.startswith('-h') or arg.startswith('--help') or arg.startswith('-rc')
-      or arg.startswith('--run-cmd') or arg.startswith('-rs')
-      or arg.startswith('--restart-cmd') for arg in sys.argv):
-    # then we were called with: scr_srun [launcher args]
-    scr_run(launcher='jsrun', launcher_args=sys.argv[1:])
-  else:
-    launcher, launcher_args, run_cmd, restart_cmd, restart_args = parseargs(
-        sys.argv[1:], launcher='jsrun')
-    scr_run(launcher='jsrun',
-            launcher_args=launcher_args,
-            run_cmd=run_cmd,
-            restart_cmd=restart_cmd,
-            restart_args=restart_args)
+    # just printing help, print the help and exit
+    if len(sys.argv) < 3 or '-h' in sys.argv[1:] or '--help' in sys.argv[1:]:
+        print_usage('jsrun')
+    elif not any(
+            arg.startswith('-h') or arg.startswith('--help')
+            or arg.startswith('-rc') or arg.startswith('--run-cmd')
+            or arg.startswith('-rs') or arg.startswith('--restart-cmd')
+            for arg in sys.argv):
+        # then we were called with: scr_srun [launcher args]
+        scr_run(launcher='jsrun', launcher_args=sys.argv[1:])
+    else:
+        launcher, launcher_args, run_cmd, restart_cmd, restart_args = parseargs(
+            sys.argv[1:], launcher='jsrun')
+        scr_run(launcher='jsrun',
+                launcher_args=launcher_args,
+                run_cmd=run_cmd,
+                restart_cmd=restart_cmd,
+                restart_args=restart_args)

--- a/scripts/python/scrjob/scr_kill_jobstep.py
+++ b/scripts/python/scrjob/scr_kill_jobstep.py
@@ -1,7 +1,6 @@
 #! /usr/bin/env python3
 
 # scr_kill_jobstep.py
-
 """
 This script can use the 'scancel' or equivalent command
 to kill a jobstep with the jobstep id supplied via the command line.
@@ -12,8 +11,8 @@ This requires specifying both the joblauncher and a jobstep id.
 import os, sys
 
 if 'scrjob' not in sys.path:
-  sys.path.insert(0, '/'.join(os.path.realpath(__file__).split('/')[:-2]))
-  import scrjob
+    sys.path.insert(0, '/'.join(os.path.realpath(__file__).split('/')[:-2]))
+    import scrjob
 
 import argparse
 from scrjob import scr_const
@@ -21,39 +20,39 @@ from scrjob.scr_common import runproc
 from scrjob.launchers import AutoJobLauncher
 
 if __name__ == '__main__':
-  parser = argparse.ArgumentParser(add_help=False,
-                                   argument_default=argparse.SUPPRESS,
-                                   prog='scr_kill_jobstep')
-  parser.add_argument('-h',
-                      '--help',
-                      action='store_true',
-                      help='Show this help message and exit.')
-  parser.add_argument('-b',
-                      '--bindir',
-                      metavar='<bindir>',
-                      default=None,
-                      help='Specify the bin directory.')
-  parser.add_argument('-l',
-                      '--launcher',
-                      metavar='<launcher>',
-                      default=None,
-                      help='Specify the job launcher.')
-  parser.add_argument('-j',
-                      '--jobStepId',
-                      metavar='<jobstepid>',
-                      type=str,
-                      help='The job step id to kill.')
-  args = vars(parser.parse_args())
-  if 'help' in args:
-    parser.print_help()
-  elif 'jobStepId' not in args:
-    print('You must specify the job step id to kill.')
-  elif 'launcher' not in args:
-    print('You must specify the job launcher used to launch the job.')
-  else:
-    launcher = AutoJobLauncher(args['launcher'])
-    print('Joblauncher:')
-    print(str(type(launcher)))
-    print('Jobstep id: ' + args['jobStepId'])
-    print('Calling launcher.scr_kill_jobstep . . .')
-    launcher.scr_kill_jobstep(jobstep=args['jobStepId'])
+    parser = argparse.ArgumentParser(add_help=False,
+                                     argument_default=argparse.SUPPRESS,
+                                     prog='scr_kill_jobstep')
+    parser.add_argument('-h',
+                        '--help',
+                        action='store_true',
+                        help='Show this help message and exit.')
+    parser.add_argument('-b',
+                        '--bindir',
+                        metavar='<bindir>',
+                        default=None,
+                        help='Specify the bin directory.')
+    parser.add_argument('-l',
+                        '--launcher',
+                        metavar='<launcher>',
+                        default=None,
+                        help='Specify the job launcher.')
+    parser.add_argument('-j',
+                        '--jobStepId',
+                        metavar='<jobstepid>',
+                        type=str,
+                        help='The job step id to kill.')
+    args = vars(parser.parse_args())
+    if 'help' in args:
+        parser.print_help()
+    elif 'jobStepId' not in args:
+        print('You must specify the job step id to kill.')
+    elif 'launcher' not in args:
+        print('You must specify the job launcher used to launch the job.')
+    else:
+        launcher = AutoJobLauncher(args['launcher'])
+        print('Joblauncher:')
+        print(str(type(launcher)))
+        print('Jobstep id: ' + args['jobStepId'])
+        print('Calling launcher.scr_kill_jobstep . . .')
+        launcher.scr_kill_jobstep(jobstep=args['jobStepId'])

--- a/scripts/python/scrjob/scr_list_dir.py
+++ b/scripts/python/scrjob/scr_list_dir.py
@@ -5,8 +5,8 @@
 import os, sys
 
 if 'scrjob' not in sys.path:
-  sys.path.insert(0, '/'.join(os.path.realpath(__file__).split('/')[:-2]))
-  import scrjob
+    sys.path.insert(0, '/'.join(os.path.realpath(__file__).split('/')[:-2]))
+    import scrjob
 
 import argparse
 from scrjob import scr_const
@@ -16,71 +16,71 @@ from scrjob.scr_param import SCR_Param
 from scrjob.resmgrs import AutoResourceManager
 
 if __name__ == '__main__':
-  """this is an external driver for the internal list_dir method
+    """this is an external driver for the internal list_dir method
 
   This script is for stand-alone purposes and is not used within other scripts
 
   This script can be used to test the list_dir method of list_dir.py
   """
-  parser = argparse.ArgumentParser(add_help=False,
-                                   argument_default=argparse.SUPPRESS,
-                                   prog='scr_list_dir')
-  parser.add_argument('-h',
-                      '--help',
-                      action='store_true',
-                      help='Show this help message and exit.')
-  parser.add_argument('-u',
-                      '--user',
-                      default=None,
-                      metavar='<user>',
-                      type=str,
-                      help='Specify username.')
-  parser.add_argument('-j',
-                      '--jobid',
-                      default=None,
-                      metavar='<id>',
-                      type=str,
-                      help='Specify jobid.')
-  parser.add_argument('-b',
-                      '--base',
-                      action='store_true',
-                      default=False,
-                      help='List base portion of cache/control directory')
-  parser.add_argument('-p',
-                      '--prefix',
-                      default=None,
-                      metavar='<id>',
-                      type=str,
-                      help='Specify the prefix directory.')
-  parser.add_argument('control/cache',
-                      choices=['control', 'cache'],
-                      metavar='<control | cache>',
-                      nargs='?',
-                      default=None,
-                      help='Specify the directory to list.')
-  args = vars(parser.parse_args())
-  if 'help' in args:
-    parser.print_help()
-    sys.exit(0)
-  elif args['control/cache'] is None:
-    print('Control or cache must be specified.')
-    sys.exit(1)
-  else:
-    # TODO: read cache directory from config file
-    bindir = scr_const.X_BINDIR
-    # ensure scr_env is set
-    scr_env = SCR_Env(prefix=args['prefix'])
-    scr_env.resmgr = AutoResourceManager()
-    scr_env.param = SCR_Param()
-    ret = list_dir(user=args['user'],
-                   jobid=args['jobid'],
-                   base=args['base'],
-                   runcmd=args['control/cache'],
-                   scr_env=scr_env,
-                   bindir=bindir)
-    if type(ret) is int:
-      # an error message will already have been printed
-      sys.exit(ret)
-    # print the returned space separated string
-    print(str(ret))
-    sys.exit(0)
+    parser = argparse.ArgumentParser(add_help=False,
+                                     argument_default=argparse.SUPPRESS,
+                                     prog='scr_list_dir')
+    parser.add_argument('-h',
+                        '--help',
+                        action='store_true',
+                        help='Show this help message and exit.')
+    parser.add_argument('-u',
+                        '--user',
+                        default=None,
+                        metavar='<user>',
+                        type=str,
+                        help='Specify username.')
+    parser.add_argument('-j',
+                        '--jobid',
+                        default=None,
+                        metavar='<id>',
+                        type=str,
+                        help='Specify jobid.')
+    parser.add_argument('-b',
+                        '--base',
+                        action='store_true',
+                        default=False,
+                        help='List base portion of cache/control directory')
+    parser.add_argument('-p',
+                        '--prefix',
+                        default=None,
+                        metavar='<id>',
+                        type=str,
+                        help='Specify the prefix directory.')
+    parser.add_argument('control/cache',
+                        choices=['control', 'cache'],
+                        metavar='<control | cache>',
+                        nargs='?',
+                        default=None,
+                        help='Specify the directory to list.')
+    args = vars(parser.parse_args())
+    if 'help' in args:
+        parser.print_help()
+        sys.exit(0)
+    elif args['control/cache'] is None:
+        print('Control or cache must be specified.')
+        sys.exit(1)
+    else:
+        # TODO: read cache directory from config file
+        bindir = scr_const.X_BINDIR
+        # ensure scr_env is set
+        scr_env = SCR_Env(prefix=args['prefix'])
+        scr_env.resmgr = AutoResourceManager()
+        scr_env.param = SCR_Param()
+        ret = list_dir(user=args['user'],
+                       jobid=args['jobid'],
+                       base=args['base'],
+                       runcmd=args['control/cache'],
+                       scr_env=scr_env,
+                       bindir=bindir)
+        if type(ret) is int:
+            # an error message will already have been printed
+            sys.exit(ret)
+        # print the returned space separated string
+        print(str(ret))
+        sys.exit(0)

--- a/scripts/python/scrjob/scr_list_down_nodes.py
+++ b/scripts/python/scrjob/scr_list_down_nodes.py
@@ -6,8 +6,8 @@
 import os, sys
 
 if 'scrjob' not in sys.path:
-  sys.path.insert(0, '/'.join(os.path.realpath(__file__).split('/')[:-2]))
-  import scrjob
+    sys.path.insert(0, '/'.join(os.path.realpath(__file__).split('/')[:-2]))
+    import scrjob
 
 import argparse
 from scrjob.list_down_nodes import list_down_nodes
@@ -18,75 +18,77 @@ from scrjob.launchers import AutoJobLauncher
 from scrjob.cli import SCRLog
 
 if __name__ == '__main__':
-  parser = argparse.ArgumentParser(add_help=False,
-                                   argument_default=argparse.SUPPRESS,
-                                   prog='scr_list_down_nodes')
-  parser.add_argument('--help',
-                      action='store_true',
-                      help='Show this help message and exit.')
-  parser.add_argument('-j',
-                      '--joblauncher',
-                      type=str,
-                      help='Required: Specify the job launcher.')
-  parser.add_argument('-r',
-                      '--reason',
-                      action='store_true',
-                      default=False,
-                      help='Print reason node is down.')
-  parser.add_argument(
+    parser = argparse.ArgumentParser(add_help=False,
+                                     argument_default=argparse.SUPPRESS,
+                                     prog='scr_list_down_nodes')
+    parser.add_argument('--help',
+                        action='store_true',
+                        help='Show this help message and exit.')
+    parser.add_argument('-j',
+                        '--joblauncher',
+                        type=str,
+                        help='Required: Specify the job launcher.')
+    parser.add_argument('-r',
+                        '--reason',
+                        action='store_true',
+                        default=False,
+                        help='Print reason node is down.')
+    parser.add_argument(
         '-f',
         '--free',
         action='store_true',
         default=False,
         help=
-        'Test required drive space based on free amount, rather than capacity.')
-  parser.add_argument('-d',
-                      '--down',
-                      metavar='<nodeset>',
-                      type=str,
-                      default=None,
-                      help='Force nodes to be down without testing.')
-  parser.add_argument('-l',
-                      '--log',
-                      action='store_true',
-                      default=False,
-                      help='Add entry to SCR log for each down node.')
-  parser.add_argument('-s',
-                      '--secs',
-                      metavar='N',
-                      type=str,
-                      default=None,
-                      help='Specify the job\'s runtime seconds for SCR log.')
-  parser.add_argument('[nodeset]',
-                      nargs='*',
-                      default=None,
-                      help='Specify the complete set of nodes to check within.')
-  args = vars(parser.parse_args())
-  if 'help' in args or 'joblauncher' not in args:
-    parser.print_help()
-    sys.exit(0)
-  else:
-    scr_env = SCR_Env()
-    scr_env.resmgr = AutoResourceManager()
-    scr_env.param = SCR_Param()
-    scr_env.launcher = AutoJobLauncher(args['joblauncher'])
+        'Test required drive space based on free amount, rather than capacity.'
+    )
+    parser.add_argument('-d',
+                        '--down',
+                        metavar='<nodeset>',
+                        type=str,
+                        default=None,
+                        help='Force nodes to be down without testing.')
+    parser.add_argument('-l',
+                        '--log',
+                        action='store_true',
+                        default=False,
+                        help='Add entry to SCR log for each down node.')
+    parser.add_argument('-s',
+                        '--secs',
+                        metavar='N',
+                        type=str,
+                        default=None,
+                        help='Specify the job\'s runtime seconds for SCR log.')
+    parser.add_argument(
+        '[nodeset]',
+        nargs='*',
+        default=None,
+        help='Specify the complete set of nodes to check within.')
+    args = vars(parser.parse_args())
+    if 'help' in args or 'joblauncher' not in args:
+        parser.print_help()
+        sys.exit(0)
+    else:
+        scr_env = SCR_Env()
+        scr_env.resmgr = AutoResourceManager()
+        scr_env.param = SCR_Param()
+        scr_env.launcher = AutoJobLauncher(args['joblauncher'])
 
-    # create log object if asked to log down nodes
-    log = None
-    if args['log']:
-      prefix = scr_env.get_prefix()
-      jobid = scr_env.resmgr.getjobid()
-      user = scr_env.get_user()
-      log = SCRLog(prefix, jobid, user=user)
+        # create log object if asked to log down nodes
+        log = None
+        if args['log']:
+            prefix = scr_env.get_prefix()
+            jobid = scr_env.resmgr.getjobid()
+            user = scr_env.get_user()
+            log = SCRLog(prefix, jobid, user=user)
 
-    ret = list_down_nodes(reason=args['reason'],
-                          free=args['free'],
-                          nodeset_down=args['down'],
-                          runtime_secs=args['secs'],
-                          nodeset=args['[nodeset]'],
-                          scr_env=scr_env,
-                          log=log)
-    if ret == 0:
-      print('scr_list_down_nodes.py: No down nodes')
-    elif ret != 1:
-      print(ret)
+        ret = list_down_nodes(reason=args['reason'],
+                              free=args['free'],
+                              nodeset_down=args['down'],
+                              runtime_secs=args['secs'],
+                              nodeset=args['[nodeset]'],
+                              scr_env=scr_env,
+                              log=log)
+        if ret == 0:
+            print('scr_list_down_nodes.py: No down nodes')
+        elif ret != 1:
+            print(ret)

--- a/scripts/python/scrjob/scr_lrun.py
+++ b/scripts/python/scrjob/scr_lrun.py
@@ -8,26 +8,27 @@
 import os, sys
 
 if 'scrjob' not in sys.path:
-  sys.path.insert(0, '/'.join(os.path.realpath(__file__).split('/')[:-2]))
-  import scrjob
+    sys.path.insert(0, '/'.join(os.path.realpath(__file__).split('/')[:-2]))
+    import scrjob
 
 from scrjob.scr_run import *
 
 if __name__ == '__main__':
-  # just printing help, print the help and exit
-  if len(sys.argv) < 3 or '-h' in sys.argv[1:] or '--help' in sys.argv[1:]:
-    print_usage('lrun')
-  elif not any(
-      arg.startswith('-h') or arg.startswith('--help') or arg.startswith('-rc')
-      or arg.startswith('--run-cmd') or arg.startswith('-rs')
-      or arg.startswith('--restart-cmd') for arg in sys.argv):
-    # then we were called with: scr_srun [launcher args]
-    scr_run(launcher='lrun', launcher_args=sys.argv[1:])
-  else:
-    launcher, launcher_args, run_cmd, restart_cmd, restart_args = parseargs(
-        sys.argv[1:], launcher='lrun')
-    scr_run(launcher='lrun',
-            launcher_args=launcher_args,
-            run_cmd=run_cmd,
-            restart_cmd=restart_cmd,
-            restart_args=restart_args)
+    # just printing help, print the help and exit
+    if len(sys.argv) < 3 or '-h' in sys.argv[1:] or '--help' in sys.argv[1:]:
+        print_usage('lrun')
+    elif not any(
+            arg.startswith('-h') or arg.startswith('--help')
+            or arg.startswith('-rc') or arg.startswith('--run-cmd')
+            or arg.startswith('-rs') or arg.startswith('--restart-cmd')
+            for arg in sys.argv):
+        # then we were called with: scr_srun [launcher args]
+        scr_run(launcher='lrun', launcher_args=sys.argv[1:])
+    else:
+        launcher, launcher_args, run_cmd, restart_cmd, restart_args = parseargs(
+            sys.argv[1:], launcher='lrun')
+        scr_run(launcher='lrun',
+                launcher_args=launcher_args,
+                run_cmd=run_cmd,
+                restart_cmd=restart_cmd,
+                restart_args=restart_args)

--- a/scripts/python/scrjob/scr_mpirun.py
+++ b/scripts/python/scrjob/scr_mpirun.py
@@ -8,26 +8,27 @@
 import os, sys
 
 if 'scrjob' not in sys.path:
-  sys.path.insert(0, '/'.join(os.path.realpath(__file__).split('/')[:-2]))
-  import scrjob
+    sys.path.insert(0, '/'.join(os.path.realpath(__file__).split('/')[:-2]))
+    import scrjob
 
 from scrjob.scr_run import *
 
 if __name__ == '__main__':
-  # just printing help, print the help and exit
-  if len(sys.argv) < 3 or '-h' in sys.argv[1:] or '--help' in sys.argv[1:]:
-    print_usage('mpirun')
-  elif not any(
-      arg.startswith('-h') or arg.startswith('--help') or arg.startswith('-rc')
-      or arg.startswith('--run-cmd') or arg.startswith('-rs')
-      or arg.startswith('--restart-cmd') for arg in sys.argv):
-    # then we were called with: scr_srun [launcher args]
-    scr_run(launcher='mpirun', launcher_args=sys.argv[1:])
-  else:
-    launcher, launcher_args, run_cmd, restart_cmd, restart_args = parseargs(
-        sys.argv[1:], launcher='mpirun')
-    scr_run(launcher='mpirun',
-            launcher_args=launcher_args,
-            run_cmd=run_cmd,
-            restart_cmd=restart_cmd,
-            restart_args=restart_args)
+    # just printing help, print the help and exit
+    if len(sys.argv) < 3 or '-h' in sys.argv[1:] or '--help' in sys.argv[1:]:
+        print_usage('mpirun')
+    elif not any(
+            arg.startswith('-h') or arg.startswith('--help')
+            or arg.startswith('-rc') or arg.startswith('--run-cmd')
+            or arg.startswith('-rs') or arg.startswith('--restart-cmd')
+            for arg in sys.argv):
+        # then we were called with: scr_srun [launcher args]
+        scr_run(launcher='mpirun', launcher_args=sys.argv[1:])
+    else:
+        launcher, launcher_args, run_cmd, restart_cmd, restart_args = parseargs(
+            sys.argv[1:], launcher='mpirun')
+        scr_run(launcher='mpirun',
+                launcher_args=launcher_args,
+                run_cmd=run_cmd,
+                restart_cmd=restart_cmd,
+                restart_args=restart_args)

--- a/scripts/python/scrjob/scr_param.py
+++ b/scripts/python/scrjob/scr_param.py
@@ -6,8 +6,8 @@
 import os, sys
 
 if 'scrjob' not in sys.path:
-  sys.path.insert(0, '/'.join(os.path.realpath(__file__).split('/')[:-2]))
-  import scrjob
+    sys.path.insert(0, '/'.join(os.path.realpath(__file__).split('/')[:-2]))
+    import scrjob
 
 import re
 from scrjob import scr_const
@@ -15,199 +15,203 @@ from scrjob.scr_common import interpolate_variables, scr_prefix
 
 
 class SCR_Param():
-  def __init__(self):
-    sysconf = scr_const.SCR_CONFIG_FILE
-    # get current working dir
-    # use value in $SCR_PREFIX if set
-    prefix = scr_prefix()
-    # define user config file
-    # use SCR_CONF_FILE if set
-    usrfile = os.environ.get('SCR_CONF_FILE')
-    # if not set look in the prefix directory
-    if usrfile is None:
-      usrfile = prefix + '/.scrconf'
-    # read in the app configuration file, if specified
-    appfile = prefix + '/.scr/app.conf'
 
-    #if os.path.isfile(appfile) and os.access(appfile,'R_OK'):
-    # better to just try than to check for permission
-    # the read_config_file method has a try catch block
-    self.appconf = self.read_config_file(appfile)
+    def __init__(self):
+        sysconf = scr_const.SCR_CONFIG_FILE
+        # get current working dir
+        # use value in $SCR_PREFIX if set
+        prefix = scr_prefix()
+        # define user config file
+        # use SCR_CONF_FILE if set
+        usrfile = os.environ.get('SCR_CONF_FILE')
+        # if not set look in the prefix directory
+        if usrfile is None:
+            usrfile = prefix + '/.scrconf'
+        # read in the app configuration file, if specified
+        appfile = prefix + '/.scr/app.conf'
 
-    # read in the user configuration file, if specified
-    self.usrconf = self.read_config_file(usrfile)
+        #if os.path.isfile(appfile) and os.access(appfile,'R_OK'):
+        # better to just try than to check for permission
+        # the read_config_file method has a try catch block
+        self.appconf = self.read_config_file(appfile)
 
-    # read in the system configuration file
-    self.sysconf = self.read_config_file(sysconf)
+        # read in the user configuration file, if specified
+        self.usrconf = self.read_config_file(usrfile)
 
-    self.compile = {}
-    # set our compile time constants
-    self.compile['CNTLDIR'] = {}
-    self.compile['CNTLDIR'][scr_const.SCR_CNTL_BASE] = {}
-    self.compile['CACHEDIR'] = {}
-    self.compile['CACHEDIR'][scr_const.SCR_CACHE_BASE] = {}
-    self.compile['SCR_CNTL_BASE'] = {}
-    self.compile['SCR_CNTL_BASE'][scr_const.SCR_CNTL_BASE] = {}
-    self.compile['SCR_CACHE_BASE'] = {}
-    self.compile['SCR_CACHE_BASE'][scr_const.SCR_CACHE_BASE] = {}
-    self.compile['SCR_CACHE_SIZE'] = {}
-    self.compile['SCR_CACHE_SIZE'][scr_const.SCR_CACHE_SIZE] = {}
+        # read in the system configuration file
+        self.sysconf = self.read_config_file(sysconf)
 
-    # set our restricted parameters,
-    # these can't be set via env vars or user conf file
-    self.no_user = {}
+        self.compile = {}
+        # set our compile time constants
+        self.compile['CNTLDIR'] = {}
+        self.compile['CNTLDIR'][scr_const.SCR_CNTL_BASE] = {}
+        self.compile['CACHEDIR'] = {}
+        self.compile['CACHEDIR'][scr_const.SCR_CACHE_BASE] = {}
+        self.compile['SCR_CNTL_BASE'] = {}
+        self.compile['SCR_CNTL_BASE'][scr_const.SCR_CNTL_BASE] = {}
+        self.compile['SCR_CACHE_BASE'] = {}
+        self.compile['SCR_CACHE_BASE'][scr_const.SCR_CACHE_BASE] = {}
+        self.compile['SCR_CACHE_SIZE'] = {}
+        self.compile['SCR_CACHE_SIZE'][scr_const.SCR_CACHE_SIZE] = {}
 
-    # NOTE: At this point we could scan the environment and user config file
-    # for restricted parameters to print a warning.  However, in this case
-    # printing the extra messages from a perl script whose output is used by
-    # other scripts as input may do more harm than good.  Printing the
-    # warning in the library should be sufficient.
+        # set our restricted parameters,
+        # these can't be set via env vars or user conf file
+        self.no_user = {}
 
-    # if CACHE_BASE and CACHE_SIZE are set and the user didn't set CACHEDESC,
-    # create a single CACHEDESC in the user hash
-    self.cache_base = self.get('SCR_CACHE_BASE')
-    self.cache_size = self.get('SCR_CACHE_SIZE')
-    if 'CACHE' not in self.usrconf and self.cache_base is not None and self.cache_size is not None:
-      self.usrconf['CACHE'] = {}
-      self.usrconf['CACHE'][self.cache_base] = {}
-      self.usrconf['CACHE'][self.cache_base]['SIZE'] = {}
-      self.usrconf['CACHE'][self.cache_base]['SIZE'][self.cache_size] = {}
+        # NOTE: At this point we could scan the environment and user config file
+        # for restricted parameters to print a warning.  However, in this case
+        # printing the extra messages from a perl script whose output is used by
+        # other scripts as input may do more harm than good.  Printing the
+        # warning in the library should be sufficient.
 
-  def read_config_file(self, filename):
-    h = {}
-    try:
-      os.makedirs('/'.join(filename.split('/')[:-1]), exist_ok=True)
-      with open(filename, 'r') as infile:
-        for line in infile.readlines():
-          line = line.strip()
-          line = re.sub('=', ' ', line)  # replace '=' with spaces
-          parts = line.split(' ')
-          key = ''
-          top_key = ''
-          top_value = ''
-          lastpart = len(parts) - 1
-          first = True  # need the next top_key
-          for i, part in enumerate(parts):
-            if len(part) == 0:  # input had double-spaces
-              continue
-            if part[0] == '#':
-              break
-            # read in the value (should have at least one more item in the list)
-            if first == True:
-              if i == lastpart:
-                print('scr_param: ERROR: Invalid key=value pair detected in ' +
-                      filename + '.')
-                return {}
-              key = part.upper()
-              first = False
+        # if CACHE_BASE and CACHE_SIZE are set and the user didn't set CACHEDESC,
+        # create a single CACHEDESC in the user hash
+        self.cache_base = self.get('SCR_CACHE_BASE')
+        self.cache_size = self.get('SCR_CACHE_SIZE')
+        if 'CACHE' not in self.usrconf and self.cache_base is not None and self.cache_size is not None:
+            self.usrconf['CACHE'] = {}
+            self.usrconf['CACHE'][self.cache_base] = {}
+            self.usrconf['CACHE'][self.cache_base]['SIZE'] = {}
+            self.usrconf['CACHE'][self.cache_base]['SIZE'][
+                self.cache_size] = {}
+
+    def read_config_file(self, filename):
+        h = {}
+        try:
+            os.makedirs('/'.join(filename.split('/')[:-1]), exist_ok=True)
+            with open(filename, 'r') as infile:
+                for line in infile.readlines():
+                    line = line.strip()
+                    line = re.sub('=', ' ', line)  # replace '=' with spaces
+                    parts = line.split(' ')
+                    key = ''
+                    top_key = ''
+                    top_value = ''
+                    lastpart = len(parts) - 1
+                    first = True  # need the next top_key
+                    for i, part in enumerate(parts):
+                        if len(part) == 0:  # input had double-spaces
+                            continue
+                        if part[0] == '#':
+                            break
+                        # read in the value (should have at least one more item in the list)
+                        if first == True:
+                            if i == lastpart:
+                                print(
+                                    'scr_param: ERROR: Invalid key=value pair detected in '
+                                    + filename + '.')
+                                return {}
+                            key = part.upper()
+                            first = False
+                        else:
+                            value = interpolate_variables(part)
+                            if top_key != '':
+                                if key not in h[top_key][top_value]:
+                                    h[top_key][top_value][key] = {}
+                                h[top_key][top_value][key][value] = {}
+                            else:
+                                top_key = key
+                                top_value = value
+                                if top_key not in h:
+                                    h[top_key] = {}
+                                if top_value not in h[top_key]:
+                                    h[top_key][top_value] = {}
+                            first = True
+
+        except Exception as e:
+            # print(e)
+            # print('scr_param: ERROR: Could not open file: '+filename)
+            return {}
+        return h
+
+    def get(self, name):
+        val = os.environ.get(name)
+
+        # if param is set in environment, return that value
+        if name not in self.no_user and val is not None:
+            return interpolate_variables(val)
+
+        # otherwise, check whether we have it defined in our user config file
+        if name not in self.no_user and name in self.usrconf:
+            return list(self.usrconf[name].keys())[0]
+
+        # if param was set by the code, return that value
+        if name in self.appconf:
+            return list(self.appconf[name].keys())[0]
+
+        # otherwise, check whether we have it defined in our system config file
+        if name in self.sysconf:
+            return list(self.sysconf[name].keys())[0]
+
+        # otherwise, check whether its a compile time constant
+        if name in self.compile:
+            return list(self.compile[name].keys())[0]
+
+        return None
+
+    def get_hash(self, name):
+        val = os.environ.get(name)
+
+        # if param is set in environment, return that value
+        if name not in self.no_user and val is not None:
+            h = {}
+            name = interpolate_variables(val)
+            h[name] = {}
+            return h
+
+        # otherwise, check whether we have it defined in our user config file
+        if name not in self.no_user and name in self.usrconf:
+            return self.usrconf[name].copy()
+
+        # otherwise, check whether we have it defined in our system config file
+        if name in self.sysconf:
+            return self.sysconf[name].copy()
+
+        # otherwise, check whether its a compile time constant
+        if name in self.compile:
+            return self.compile[name].copy()
+
+        return None
+
+    # convert byte string like 2kb, 1.5m, 200GB, 1.4T to integer value
+    def abtoull(self, stringval):
+        number = ''
+        units = ''
+        tokens = re.match('(\d*)(\.?)(\d*)(\D+)', stringval).groups()
+        if len(tokens) > 1:
+            number = ''.join(tokens[:-1])
+            units = tokens[-1].lower()
+        else:
+            return int(stringval)  # TODO: print error? unknown unit string
+        factor = None
+        if units != '':
+            if units == 'b':
+                factor = 1
+            elif units == 'kb' or units == 'k':
+                factor = 1024
+            elif units == 'mb' or units == 'm':
+                factor = 1024 * 1024
+            elif units == 'gb' or units == 'g':
+                factor = 1024 * 1024 * 1024
+            elif units == 'tb' or units == 't':
+                factor = 1024 * 1024 * 1024 * 1024
+            elif units == 'pb' or units == 'p':
+                factor = 1024 * 1024 * 1024 * 1024 * 1024
+            elif units == 'eb' or units == 'e':
+                factor = 1024 * 1024 * 1024 * 1024 * 1024 * 1024
             else:
-              value = interpolate_variables(part)
-              if top_key != '':
-                if key not in h[top_key][top_value]:
-                  h[top_key][top_value][key] = {}
-                h[top_key][top_value][key][value] = {}
-              else:
-                top_key = key
-                top_value = value
-                if top_key not in h:
-                  h[top_key] = {}
-                if top_value not in h[top_key]:
-                  h[top_key][top_value] = {}
-              first = True
-
-    except Exception as e:
-      # print(e)
-      # print('scr_param: ERROR: Could not open file: '+filename)
-      return {}
-    return h
-
-  def get(self, name):
-    val = os.environ.get(name)
-
-    # if param is set in environment, return that value
-    if name not in self.no_user and val is not None:
-      return interpolate_variables(val)
-
-    # otherwise, check whether we have it defined in our user config file
-    if name not in self.no_user and name in self.usrconf:
-      return list(self.usrconf[name].keys())[0]
-
-    # if param was set by the code, return that value
-    if name in self.appconf:
-      return list(self.appconf[name].keys())[0]
-
-    # otherwise, check whether we have it defined in our system config file
-    if name in self.sysconf:
-      return list(self.sysconf[name].keys())[0]
-
-    # otherwise, check whether its a compile time constant
-    if name in self.compile:
-      return list(self.compile[name].keys())[0]
-
-    return None
-
-  def get_hash(self, name):
-    val = os.environ.get(name)
-
-    # if param is set in environment, return that value
-    if name not in self.no_user and val is not None:
-      h = {}
-      name = interpolate_variables(val)
-      h[name] = {}
-      return h
-
-    # otherwise, check whether we have it defined in our user config file
-    if name not in self.no_user and name in self.usrconf:
-      return self.usrconf[name].copy()
-
-    # otherwise, check whether we have it defined in our system config file
-    if name in self.sysconf:
-      return self.sysconf[name].copy()
-
-    # otherwise, check whether its a compile time constant
-    if name in self.compile:
-      return self.compile[name].copy()
-
-    return None
-
-  # convert byte string like 2kb, 1.5m, 200GB, 1.4T to integer value
-  def abtoull(self, stringval):
-    number = ''
-    units = ''
-    tokens = re.match('(\d*)(\.?)(\d*)(\D+)', stringval).groups()
-    if len(tokens) > 1:
-      number = ''.join(tokens[:-1])
-      units = tokens[-1].lower()
-    else:
-      return int(stringval)  # TODO: print error? unknown unit string
-    factor = None
-    if units != '':
-      if units == 'b':
-        factor = 1
-      elif units == 'kb' or units == 'k':
-        factor = 1024
-      elif units == 'mb' or units == 'm':
-        factor = 1024 * 1024
-      elif units == 'gb' or units == 'g':
-        factor = 1024 * 1024 * 1024
-      elif units == 'tb' or units == 't':
-        factor = 1024 * 1024 * 1024 * 1024
-      elif units == 'pb' or units == 'p':
-        factor = 1024 * 1024 * 1024 * 1024 * 1024
-      elif units == 'eb' or units == 'e':
-        factor = 1024 * 1024 * 1024 * 1024 * 1024 * 1024
-      else:
-        return int(stringval)  # TODO: print error? unknown unit string
-    val = float(number)
-    if factor is not None:
-      val *= factor
-    elif units != '':
-      val = 0.0  # got a units string but couldn't parse it
-    val = int(val)
-    return val
+                return int(stringval)  # TODO: print error? unknown unit string
+        val = float(number)
+        if factor is not None:
+            val *= factor
+        elif units != '':
+            val = 0.0  # got a units string but couldn't parse it
+        val = int(val)
+        return val
 
 
 if __name__ == '__main__':
-  scr_param = SCR_Param()
-  for key in scr_param.compile:
-    print('scr_param.compile[' + key + '] = ' + str(scr_param.compile[key]))
+    scr_param = SCR_Param()
+    for key in scr_param.compile:
+        print('scr_param.compile[' + key + '] = ' +
+              str(scr_param.compile[key]))

--- a/scripts/python/scrjob/scr_postrun.py
+++ b/scripts/python/scrjob/scr_postrun.py
@@ -9,8 +9,8 @@
 import os, sys
 
 if 'scrjob' not in sys.path:
-  sys.path.insert(0, '/'.join(os.path.realpath(__file__).split('/')[:-2]))
-  import scrjob
+    sys.path.insert(0, '/'.join(os.path.realpath(__file__).split('/')[:-2]))
+    import scrjob
 
 import argparse
 from scrjob.postrun import postrun
@@ -20,39 +20,39 @@ from scrjob.resmgrs import AutoResourceManager
 from scrjob.launchers import AutoJobLauncher
 
 if __name__ == '__main__':
-  parser = argparse.ArgumentParser(add_help=False,
-                                   argument_default=argparse.SUPPRESS,
-                                   prog='scr_postrun')
-  parser.add_argument('-h',
-                      '--help',
-                      action='store_true',
-                      help='Show this help message and exit.')
-  parser.add_argument('-j',
-                      '--joblauncher',
-                      type=str,
-                      help='Required: Specify the job launcher.')
-  parser.add_argument('-p',
-                      '--prefix',
-                      metavar='<dir>',
-                      type=str,
-                      default=None,
-                      help='Specify the prefix directory.')
-  parser.add_argument('-v',
-                      '--verbose',
-                      action='store_true',
-                      default=False,
-                      help='Verbose output.')
-  args = vars(parser.parse_args())
+    parser = argparse.ArgumentParser(add_help=False,
+                                     argument_default=argparse.SUPPRESS,
+                                     prog='scr_postrun')
+    parser.add_argument('-h',
+                        '--help',
+                        action='store_true',
+                        help='Show this help message and exit.')
+    parser.add_argument('-j',
+                        '--joblauncher',
+                        type=str,
+                        help='Required: Specify the job launcher.')
+    parser.add_argument('-p',
+                        '--prefix',
+                        metavar='<dir>',
+                        type=str,
+                        default=None,
+                        help='Specify the prefix directory.')
+    parser.add_argument('-v',
+                        '--verbose',
+                        action='store_true',
+                        default=False,
+                        help='Verbose output.')
+    args = vars(parser.parse_args())
 
-  if 'help' in args or 'joblauncher' not in args:
-    parser.print_help()
-    sys.exit(0)
-  else:
-    scr_env = SCR_Env(prefix=args['prefix'])
-    scr_env.resmgr = AutoResourceManager()
-    scr_env.param = SCR_Param()
-    scr_env.launcher = AutoJobLauncher(args['joblauncher'])
-    ret = postrun(prefix_dir=args['prefix'],
-                  scr_env=scr_env,
-                  verbose=args['verbose'])
-    sys.exit(ret)
+    if 'help' in args or 'joblauncher' not in args:
+        parser.print_help()
+        sys.exit(0)
+    else:
+        scr_env = SCR_Env(prefix=args['prefix'])
+        scr_env.resmgr = AutoResourceManager()
+        scr_env.param = SCR_Param()
+        scr_env.launcher = AutoJobLauncher(args['joblauncher'])
+        ret = postrun(prefix_dir=args['prefix'],
+                      scr_env=scr_env,
+                      verbose=args['verbose'])
+        sys.exit(ret)

--- a/scripts/python/scrjob/scr_prerun.py
+++ b/scripts/python/scrjob/scr_prerun.py
@@ -5,8 +5,8 @@
 import os, sys
 
 if 'scrjob' not in sys.path:
-  sys.path.insert(0, '/'.join(os.path.realpath(__file__).split('/')[:-2]))
-  import scrjob
+    sys.path.insert(0, '/'.join(os.path.realpath(__file__).split('/')[:-2]))
+    import scrjob
 
 import argparse
 from datetime import datetime
@@ -16,8 +16,9 @@ from scrjob.scr_test_runtime import SCR_Test_Runtime
 from scrjob.scr_environment import SCR_Env
 from scrjob.resmgrs import AutoResourceManager
 
+
 def scr_prerun(scr_env=None):
-  """this script is called after initialization to ensure verify the environment
+    """this script is called after initialization to ensure verify the environment
 
   Prerun Operations
   -----------------
@@ -30,80 +31,80 @@ def scr_prerun(scr_env=None):
   int   0 - no error
         1 - error
   """
-  # bail out if not enabled
-  val = os.environ.get('SCR_ENABLE')
-  if val == '0':
+    # bail out if not enabled
+    val = os.environ.get('SCR_ENABLE')
+    if val == '0':
+        return 0
+
+    if scr_env is None or scr_env.resmgr is None:
+        print('scr_prerun: ERROR: Unknown environment')
+        return 1
+
+    start_time = datetime.now()
+    start_secs = int(time())
+    print('scr_prerun: Started: ' + str(start_time))
+
+    # check that we have all the runtime dependences we need
+    if SCR_Test_Runtime(scr_env.resmgr.get_prerun_tests()) != 0:
+        print('scr_prerun: exit code: 1')
+        return 1
+
+    # create the .scr subdirectory in the prefix directory
+    dir_scr = scr_env.dir_scr()
+    os.makedirs(dir_scr, exist_ok=True)
+
+    # TODO: It would be nice to clear the cache and control directories
+    # here in preparation for the run.  However, a simple rm -rf is too
+    # dangerous, since it's too easy to accidentally specify the wrong
+    # base directory.
+    #
+    # For now, we just keep this script around as a place holder.
+
+    # clear any existing flush or nodes files
+    # NOTE: we *do not* clear the halt file, since the user may have
+    # requested the job to halt
+    # remove files: ${pardir}/.scr/{flush.scr,nodes.scr}
+    try:
+        os.remove(os.path.join(dir_scr, 'flush.scr'))
+    except:  # error on doesn't exist / etc ...
+        pass
+
+    try:
+        os.remove(os.path.join(dir_scr, 'nodes.scr'))
+    except:
+        pass
+
+    # report timing info
+    end_time = datetime.now()
+    run_secs = int(time()) - start_secs
+    print('scr_prerun: Ended: ' + str(end_time))
+    print('scr_prerun: secs: ' + str(run_secs))
+
+    # report exit code and exit
+    print('scr_prerun: exit code: 0')
     return 0
-
-  if scr_env is None or scr_env.resmgr is None:
-    print('scr_prerun: ERROR: Unknown environment')
-    return 1
-
-  start_time = datetime.now()
-  start_secs = int(time())
-  print('scr_prerun: Started: ' + str(start_time))
-
-  # check that we have all the runtime dependences we need
-  if SCR_Test_Runtime(scr_env.resmgr.get_prerun_tests()) != 0:
-    print('scr_prerun: exit code: 1')
-    return 1
-
-  # create the .scr subdirectory in the prefix directory
-  dir_scr = scr_env.dir_scr()
-  os.makedirs(dir_scr, exist_ok=True)
-
-  # TODO: It would be nice to clear the cache and control directories
-  # here in preparation for the run.  However, a simple rm -rf is too
-  # dangerous, since it's too easy to accidentally specify the wrong
-  # base directory.
-  #
-  # For now, we just keep this script around as a place holder.
-
-  # clear any existing flush or nodes files
-  # NOTE: we *do not* clear the halt file, since the user may have
-  # requested the job to halt
-  # remove files: ${pardir}/.scr/{flush.scr,nodes.scr}
-  try:
-    os.remove(os.path.join(dir_scr, 'flush.scr'))
-  except:  # error on doesn't exist / etc ...
-    pass
-
-  try:
-    os.remove(os.path.join(dir_scr, 'nodes.scr'))
-  except:
-    pass
-
-  # report timing info
-  end_time = datetime.now()
-  run_secs = int(time()) - start_secs
-  print('scr_prerun: Ended: ' + str(end_time))
-  print('scr_prerun: secs: ' + str(run_secs))
-
-  # report exit code and exit
-  print('scr_prerun: exit code: 0')
-  return 0
 
 
 if __name__ == '__main__':
-  parser = argparse.ArgumentParser(add_help=False,
-                                   argument_default=argparse.SUPPRESS,
-                                   prog='scr_prerun')
-  parser.add_argument('-h',
-                      '--help',
-                      action='store_true',
-                      help='Show this help message and exit.')
-  parser.add_argument('-p',
-                      '--prefix',
-                      metavar='<dir>',
-                      type=str,
-                      default=None,
-                      help='Specify the prefix directory.')
-  args = vars(parser.parse_args())
+    parser = argparse.ArgumentParser(add_help=False,
+                                     argument_default=argparse.SUPPRESS,
+                                     prog='scr_prerun')
+    parser.add_argument('-h',
+                        '--help',
+                        action='store_true',
+                        help='Show this help message and exit.')
+    parser.add_argument('-p',
+                        '--prefix',
+                        metavar='<dir>',
+                        type=str,
+                        default=None,
+                        help='Specify the prefix directory.')
+    args = vars(parser.parse_args())
 
-  if 'help' in args:
-    parser.print_help()
-  else:
-    scr_env = SCR_Env(prefix=args['prefix'])
-    scr_env.resmgr = AutoResourceManager()
-    ret = scr_prerun(scr_env=scr_env)
-    sys.exit(ret)
+    if 'help' in args:
+        parser.print_help()
+    else:
+        scr_env = SCR_Env(prefix=args['prefix'])
+        scr_env.resmgr = AutoResourceManager()
+        ret = scr_prerun(scr_env=scr_env)
+        sys.exit(ret)

--- a/scripts/python/scrjob/scr_run.py
+++ b/scripts/python/scrjob/scr_run.py
@@ -9,8 +9,8 @@
 import os, sys
 
 if 'scrjob' not in sys.path:
-  sys.path.insert(0, '/'.join(os.path.realpath(__file__).split('/')[:-2]))
-  import scrjob
+    sys.path.insert(0, '/'.join(os.path.realpath(__file__).split('/')[:-2]))
+    import scrjob
 
 from datetime import datetime
 from time import time, sleep
@@ -32,37 +32,37 @@ from scrjob.cli import SCRLog
 
 # determine how many nodes are needed
 def nodes_needed(scr_env, nodelist):
-  # if SCR_MIN_NODES is set, use that
-  num_needed = os.environ.get('SCR_MIN_NODES')
-  if num_needed is None or int(num_needed) <= 0:
-    # otherwise, use value in nodes file if one exists
-    num_needed = scr_env.get_runnode_count()
-    if num_needed <= 0:
-      # otherwise, assume we need all nodes in the allocation
-      num_needed = scr_glob_hosts(count=True,
-                                  hosts=nodelist,
-                                  resmgr=scr_env.resmgr)
-      if num_needed is None:
-        # failed all methods to estimate the minimum number of nodes
-        return 0
-  return int(num_needed)
+    # if SCR_MIN_NODES is set, use that
+    num_needed = os.environ.get('SCR_MIN_NODES')
+    if num_needed is None or int(num_needed) <= 0:
+        # otherwise, use value in nodes file if one exists
+        num_needed = scr_env.get_runnode_count()
+        if num_needed <= 0:
+            # otherwise, assume we need all nodes in the allocation
+            num_needed = scr_glob_hosts(count=True,
+                                        hosts=nodelist,
+                                        resmgr=scr_env.resmgr)
+            if num_needed is None:
+                # failed all methods to estimate the minimum number of nodes
+                return 0
+    return int(num_needed)
 
 
 # return number of nodes left in allocation after excluding down nodes
 def nodes_remaining(resmgr, nodelist, down_nodes):
-  num_left = scr_glob_hosts(count=True,
-                            minus=nodelist + ':' + down_nodes,
-                            resmgr=resmgr)
-  if num_left is None:
-    return 0
-  return int(num_left)
+    num_left = scr_glob_hosts(count=True,
+                              minus=nodelist + ':' + down_nodes,
+                              resmgr=resmgr)
+    if num_left is None:
+        return 0
+    return int(num_left)
 
 
 # is there a halt condition instructing us to stop?
 def should_halt(bindir, prefix):
-  argv = [os.path.join(bindir, 'scr_retries_halt'), '--dir', prefix]
-  returncode = runproc(argv=argv)[1]
-  return (returncode == 0)
+    argv = [os.path.join(bindir, 'scr_retries_halt'), '--dir', prefix]
+    returncode = runproc(argv=argv)[1]
+    return (returncode == 0)
 
 
 def scr_run(launcher='',
@@ -70,410 +70,424 @@ def scr_run(launcher='',
             run_cmd='',
             restart_cmd='',
             restart_args=[]):
-  prog = 'scr_' + launcher
+    prog = 'scr_' + launcher
 
-  bindir = scr_const.X_BINDIR
+    bindir = scr_const.X_BINDIR
 
-  val = os.environ.get('SCR_ENABLE')
-  if val == '0':
-    launcher = [launcher]
-    launcher.extend(launcher_args)
-    returncode = runproc(argv=launcher)[1]
-    sys.exit(returncode)
+    val = os.environ.get('SCR_ENABLE')
+    if val == '0':
+        launcher = [launcher]
+        launcher.extend(launcher_args)
+        returncode = runproc(argv=launcher)[1]
+        sys.exit(returncode)
 
-  # turn on verbosity
-  verbose = False
-  val = os.environ.get('SCR_DEBUG')
-  if val is not None and int(val) > 0:
-    verbose = True
+    # turn on verbosity
+    verbose = False
+    val = os.environ.get('SCR_DEBUG')
+    if val is not None and int(val) > 0:
+        verbose = True
 
-  # turn on python function tracing
-  if scr_const.PYFE_TRACE_FUNC == '1' or os.environ.get(
-      'PYFE_TRACE_FUNC') == '1':
-    sys.settrace(tracefunction)
+    # turn on python function tracing
+    if scr_const.PYFE_TRACE_FUNC == '1' or os.environ.get(
+            'PYFE_TRACE_FUNC') == '1':
+        sys.settrace(tracefunction)
 
-  # make a record of start time
-  timestamp = datetime.now()
-  start_secs = int(time())
-  print(prog + ': Started: ' + str(timestamp))
-
-  # get prefix directory
-  prefix = scr_prefix()
-
-  param = SCR_Param()
-
-  # resource manager (SLURM/LSF/ ...) set by argument or compile constant
-  resmgr = AutoResourceManager()
-
-  # launcher contains attributes unique to launcher (srun/jsrun/ ...)
-  launcher = AutoJobLauncher(launcher)
-
-  # env contains general environment infos independent of resmgr/launcher
-  scr_env = SCR_Env(prefix=prefix)
-
-  # give scr_env a pointer to the objects for calling other methods
-  scr_env.param = param
-  scr_env.resmgr = resmgr
-  scr_env.launcher = launcher
-
-  # this may be used by a launcher to store a list of hosts
-  launcher.hostfile = os.path.join(scr_env.dir_scr(), 'hostfile')
-
-  # jobid will come from resource manager.
-  jobid = resmgr.getjobid()
-  user = scr_env.get_user()
-
-  # We need the jobid for logging, and need to be running within an allocation
-  # for operations such as scavenge.  This test serves both purposes.
-  if jobid is None:
-    print(prog + f': ERROR: No valid job ID or not in an allocation.')
-    sys.exit(1)
-
-  # create object to write log messages
-  log = SCRLog(prefix, jobid, user=user, jobstart=start_secs)
-
-  # get the nodeset of this job
-  nodelist = scr_env.get_scr_nodelist()
-  if nodelist is None:
-    nodelist = resmgr.get_job_nodes()
-    if nodelist is None:
-      print(prog + f': ERROR: Could not identify nodeset for job {jobid}')
-      sys.exit(1)
-  nodelist = ','.join(resmgr.expand_hosts(nodelist))
-
-  watchdog = None
-  val = os.environ.get('SCR_WATCHDOG')
-  if val != '1':
-    resmgr.usewatchdog(False)
-  else:
-    resmgr.usewatchdog(True)
-    watchdog = SCR_Watchdog(prefix, scr_env)
-
-  # TODO: define resmgr.prerun() and launcher.prerun() hooks, call from scr_prerun?
-  # run a NOP with srun, other launchers could do any preamble work here
-  launcher.prepareforprerun()
-
-  # make a record of time prerun is started
-  timestamp = datetime.now()
-  print(prog + ': prerun: ' + str(timestamp))
-
-  # test runtime, ensure filepath exists
-  if scr_prerun(scr_env=scr_env) != 0:
-    print(prog + ': ERROR: Command failed: scr_prerun -p ' + prefix)
-    sys.exit(1)
-
-  # look up allocation end time, record in SCR_END_TIME
-  endtime = resmgr.get_scr_end_time()
-  if endtime == 0:
-    if verbose == True:
-      print(prog + ': WARNING: Unable to get end time.')
-  elif endtime == -1:  # no end time / limit
-    pass
-  #else:
-  os.environ['SCR_END_TIME'] = str(endtime)
-
-  # determine number of times to run application
-  runs = os.environ.get('SCR_RUNS')
-  if runs is None:
-    runs = os.environ.get('SCR_RETRIES')
-    if runs is None:
-      runs = 0
-    else:
-      runs = int(runs)
-    runs += 1
-  else:
-    runs = int(runs)
-
-  # totalruns printed when runs are exhausted
-  totalruns = str(runs)
-
-  # the run loop breaks when runs hits zero (or some other conditions)
-  # we can protect against an invalid input for number of runs here
-  if runs < 1:
-    runs = 1
-
-  # enter the run loop
-  down_nodes = ''
-  attempts = 0
-  while True:
-    # once we mark a node as bad, leave it as bad (even if it comes back healthy)
-    # TODO: This hacks around the problem of accidentally deleting a checkpoint set during distribute
-    #       when a relaunch lands on previously down nodes, which are healthy again.
-    #       A better way would be to remember the last set used, or to provide a utility to run on *all*
-    #       nodes to distribute files (also useful for defragging the machine) -- for now this works.
-    keep_down = down_nodes
-
-    # set "first run" flag, let individual tests decide how to handle that
-    first_run = (attempts == 0)
-
-    # are there enough nodes to continue?
-    down_nodes = list_down_nodes(free=first_run,
-                                 nodeset_down=down_nodes,
-                                 scr_env=scr_env)
-
-    # list_down_nodes returns 0 for none, 1 for error
-    # could handle an error here, or just continue
-    if type(down_nodes) is int:
-      down_nodes = ''
-    # a comma separated string of down nodes is returned otherwise
-    else: #if down_nodes != '':
-      # print the reason for the down nodes, and log them
-      # when reason == True a string formatted for printing will be returned
-      printstring = list_down_nodes(reason=True,
-                      free=first_run,
-                      nodeset_down=down_nodes,
-                      runtime_secs='0',
-                      scr_env=scr_env,
-                      log=log)
-      print(printstring)
-
-      # if this is the first run, we hit down nodes right off the bat, make a record of them
-      if first_run:
-        start_secs = int(time())
-        print('SCR: Failed node detected: JOBID=' + jobid +
-              ' ATTEMPT=0 TIME=' + str(start_secs) +
-              ' NNODES=-1 RUNTIME=0 FAILED=' + down_nodes)
-
-      # determine how many nodes are needed
-      num_needed = nodes_needed(scr_env, nodelist)
-      if num_needed <= 0:
-        print(prog + ': ERROR: Unable to determine number of nodes needed')
-        break
-
-      # determine number of nodes remaining in allocation
-      num_left = nodes_remaining(resmgr, nodelist, down_nodes)
-
-      # check that we have enough nodes after excluding down nodes
-      if num_left < num_needed:
-        print(prog + ': (Nodes remaining=' + str(num_left) +
-              ') < (Nodes needed=' + str(num_needed) + '), ending run.')
-        break
-
-    launch_cmd = launcher_args.copy()
-    if run_cmd != '':
-      launch_cmd.append(run_cmd)
-
-    # If restarting and restart_cmd is defined,
-    # Run scr_have_restart on all nodes to rebuild checkpoint
-    # and identify most recent checkpoint name.
-    # Then replace SCR_CKPT_NAME with restart name in user's restart command.
-    if restart_cmd != '':
-      argv = [launcher]
-      argv.extend(launcher_args)
-      argv.append(os.path.join(bindir, 'scr_have_restart'))
-      restart_name = runproc(argv=argv, getstdout=True)[0]
-      if restart_name is not None and restart_name != '':
-        restart_name = restart_name.strip()
-        my_restart_cmd = re.sub('SCR_CKPT_NAME', restart_name, restart_cmd)
-        launch_cmd = launcher_args.copy()
-        launch_cmd.extend(my_restart_cmd.split(' '))
-
-    # make a record of when each run is started
-    attempts += 1
+    # make a record of start time
     timestamp = datetime.now()
     start_secs = int(time())
-    log.event('RUN_START', note='run=' + str(attempts))
-    print(prog + ': RUN ' + str(attempts) + ': ' + str(timestamp))
+    print(prog + ': Started: ' + str(timestamp))
 
-    # launch the job, make sure we include the script node and exclude down nodes
-    print(prog + ': Launching ' + str(launch_cmd))
-    proc, jobstep = launcher.launchruncmd(up_nodes=nodelist,
-                                      down_nodes=down_nodes,
-                                      launcher_args=launch_cmd)
-    if watchdog is None:
-      (finished, success) = launcher.waitonprocess(proc)
+    # get prefix directory
+    prefix = scr_prefix()
+
+    param = SCR_Param()
+
+    # resource manager (SLURM/LSF/ ...) set by argument or compile constant
+    resmgr = AutoResourceManager()
+
+    # launcher contains attributes unique to launcher (srun/jsrun/ ...)
+    launcher = AutoJobLauncher(launcher)
+
+    # env contains general environment infos independent of resmgr/launcher
+    scr_env = SCR_Env(prefix=prefix)
+
+    # give scr_env a pointer to the objects for calling other methods
+    scr_env.param = param
+    scr_env.resmgr = resmgr
+    scr_env.launcher = launcher
+
+    # this may be used by a launcher to store a list of hosts
+    launcher.hostfile = os.path.join(scr_env.dir_scr(), 'hostfile')
+
+    # jobid will come from resource manager.
+    jobid = resmgr.getjobid()
+    user = scr_env.get_user()
+
+    # We need the jobid for logging, and need to be running within an allocation
+    # for operations such as scavenge.  This test serves both purposes.
+    if jobid is None:
+        print(prog + f': ERROR: No valid job ID or not in an allocation.')
+        sys.exit(1)
+
+    # create object to write log messages
+    log = SCRLog(prefix, jobid, user=user, jobstart=start_secs)
+
+    # get the nodeset of this job
+    nodelist = scr_env.get_scr_nodelist()
+    if nodelist is None:
+        nodelist = resmgr.get_job_nodes()
+        if nodelist is None:
+            print(prog +
+                  f': ERROR: Could not identify nodeset for job {jobid}')
+            sys.exit(1)
+    nodelist = ','.join(resmgr.expand_hosts(nodelist))
+
+    watchdog = None
+    val = os.environ.get('SCR_WATCHDOG')
+    if val != '1':
+        resmgr.usewatchdog(False)
     else:
-      print(prog + ': Entering watchdog method')
-      # watchdog returned error or a watcher process was launched
-      if watchdog.watchproc(proc, jobstep) != 0:
-        print(prog + ': Error launching watchdog')
-        (finished, success) = launcher.waitonprocess(proc)
-      # else the watchdog returned because the process has finished/been killed
-      else:
-        #TODO: verify this really works for case where watchproc() returns 0 / succeeds
-        (finished, success) = launcher.waitonprocess(proc)
+        resmgr.usewatchdog(True)
+        watchdog = SCR_Watchdog(prefix, scr_env)
 
-    #print('Process has finished or has been terminated.')
+    # TODO: define resmgr.prerun() and launcher.prerun() hooks, call from scr_prerun?
+    # run a NOP with srun, other launchers could do any preamble work here
+    launcher.prepareforprerun()
 
-    end_secs = int(time())
-    run_secs = end_secs - start_secs
+    # make a record of time prerun is started
+    timestamp = datetime.now()
+    print(prog + ': prerun: ' + str(timestamp))
 
-    # log stats on the latest run attempt
-    log.event('RUN_END', note='run=' + str(attempts), secs=str(run_secs))
+    # test runtime, ensure filepath exists
+    if scr_prerun(scr_env=scr_env) != 0:
+        print(prog + ': ERROR: Command failed: scr_prerun -p ' + prefix)
+        sys.exit(1)
 
-    # check for and log any down nodes
-    # logging happens within list_down_nodes
-    # a string formatted for printing is returned when reason == True
-    printstring = list_down_nodes(reason=True,
-                    nodeset_down=keep_down,
-                    runtime_secs=str(run_secs),
-                    scr_env=scr_env,
-                    log=log)
-    print(printstring)
+    # look up allocation end time, record in SCR_END_TIME
+    endtime = resmgr.get_scr_end_time()
+    if endtime == 0:
+        if verbose == True:
+            print(prog + ': WARNING: Unable to get end time.')
+    elif endtime == -1:  # no end time / limit
+        pass
+    #else:
+    os.environ['SCR_END_TIME'] = str(endtime)
 
-    # decrement retry counter
-    runs -= 1
-    if runs == 0:
-      print(prog + ': ' + totalruns + ' launches exhausted, ending run.')
-      break
+    # determine number of times to run application
+    runs = os.environ.get('SCR_RUNS')
+    if runs is None:
+        runs = os.environ.get('SCR_RETRIES')
+        if runs is None:
+            runs = 0
+        else:
+            runs = int(runs)
+        runs += 1
+    else:
+        runs = int(runs)
 
-    # is there a halt condition instructing us to stop?
-    if should_halt(bindir, prefix):
-      print(prog + ': Halt condition detected, ending run.')
-      break
+    # totalruns printed when runs are exhausted
+    totalruns = str(runs)
 
-    ##### Reduce this sleep time when testing scripts #####
-    # give nodes a chance to clean up
-    sleep(60)
+    # the run loop breaks when runs hits zero (or some other conditions)
+    # we can protect against an invalid input for number of runs here
+    if runs < 1:
+        runs = 1
 
-    # check for halt condition again after sleep
-    if should_halt(bindir, prefix):
-      print(prog + ': Halt condition detected, ending run.')
-      break
+    # enter the run loop
+    down_nodes = ''
+    attempts = 0
+    while True:
+        # once we mark a node as bad, leave it as bad (even if it comes back healthy)
+        # TODO: This hacks around the problem of accidentally deleting a checkpoint set during distribute
+        #       when a relaunch lands on previously down nodes, which are healthy again.
+        #       A better way would be to remember the last set used, or to provide a utility to run on *all*
+        #       nodes to distribute files (also useful for defragging the machine) -- for now this works.
+        keep_down = down_nodes
 
-  # make a record of time postrun is started
-  timestamp = datetime.now()
-  print(prog + ': postrun: ' + str(timestamp))
+        # set "first run" flag, let individual tests decide how to handle that
+        first_run = (attempts == 0)
 
-  # scavenge files from cache to parallel file system
-  if postrun(prefix_dir=prefix, scr_env=scr_env, verbose=verbose,
-             log=log) != 0:
-    print(prog + ': ERROR: Command failed: scr_postrun -p ' + prefix)
+        # are there enough nodes to continue?
+        down_nodes = list_down_nodes(free=first_run,
+                                     nodeset_down=down_nodes,
+                                     scr_env=scr_env)
 
-  # make a record of end time
-  timestamp = datetime.now()
-  print(prog + ': Ended: ' + str(timestamp))
+        # list_down_nodes returns 0 for none, 1 for error
+        # could handle an error here, or just continue
+        if type(down_nodes) is int:
+            down_nodes = ''
+        # a comma separated string of down nodes is returned otherwise
+        else:  #if down_nodes != '':
+            # print the reason for the down nodes, and log them
+            # when reason == True a string formatted for printing will be returned
+            printstring = list_down_nodes(reason=True,
+                                          free=first_run,
+                                          nodeset_down=down_nodes,
+                                          runtime_secs='0',
+                                          scr_env=scr_env,
+                                          log=log)
+            print(printstring)
 
-  if finished == True and success == True:
-    returncode = 0
-  else:
-    returncode = 1
+            # if this is the first run, we hit down nodes right off the bat, make a record of them
+            if first_run:
+                start_secs = int(time())
+                print('SCR: Failed node detected: JOBID=' + jobid +
+                      ' ATTEMPT=0 TIME=' + str(start_secs) +
+                      ' NNODES=-1 RUNTIME=0 FAILED=' + down_nodes)
 
-  sys.exit(returncode)
+            # determine how many nodes are needed
+            num_needed = nodes_needed(scr_env, nodelist)
+            if num_needed <= 0:
+                print(prog +
+                      ': ERROR: Unable to determine number of nodes needed')
+                break
+
+            # determine number of nodes remaining in allocation
+            num_left = nodes_remaining(resmgr, nodelist, down_nodes)
+
+            # check that we have enough nodes after excluding down nodes
+            if num_left < num_needed:
+                print(prog + ': (Nodes remaining=' + str(num_left) +
+                      ') < (Nodes needed=' + str(num_needed) +
+                      '), ending run.')
+                break
+
+        launch_cmd = launcher_args.copy()
+        if run_cmd != '':
+            launch_cmd.append(run_cmd)
+
+        # If restarting and restart_cmd is defined,
+        # Run scr_have_restart on all nodes to rebuild checkpoint
+        # and identify most recent checkpoint name.
+        # Then replace SCR_CKPT_NAME with restart name in user's restart command.
+        if restart_cmd != '':
+            argv = [launcher]
+            argv.extend(launcher_args)
+            argv.append(os.path.join(bindir, 'scr_have_restart'))
+            restart_name = runproc(argv=argv, getstdout=True)[0]
+            if restart_name is not None and restart_name != '':
+                restart_name = restart_name.strip()
+                my_restart_cmd = re.sub('SCR_CKPT_NAME', restart_name,
+                                        restart_cmd)
+                launch_cmd = launcher_args.copy()
+                launch_cmd.extend(my_restart_cmd.split(' '))
+
+        # make a record of when each run is started
+        attempts += 1
+        timestamp = datetime.now()
+        start_secs = int(time())
+        log.event('RUN_START', note='run=' + str(attempts))
+        print(prog + ': RUN ' + str(attempts) + ': ' + str(timestamp))
+
+        # launch the job, make sure we include the script node and exclude down nodes
+        print(prog + ': Launching ' + str(launch_cmd))
+        proc, jobstep = launcher.launchruncmd(up_nodes=nodelist,
+                                              down_nodes=down_nodes,
+                                              launcher_args=launch_cmd)
+        if watchdog is None:
+            (finished, success) = launcher.waitonprocess(proc)
+        else:
+            print(prog + ': Entering watchdog method')
+            # watchdog returned error or a watcher process was launched
+            if watchdog.watchproc(proc, jobstep) != 0:
+                print(prog + ': Error launching watchdog')
+                (finished, success) = launcher.waitonprocess(proc)
+            # else the watchdog returned because the process has finished/been killed
+            else:
+                #TODO: verify this really works for case where watchproc() returns 0 / succeeds
+                (finished, success) = launcher.waitonprocess(proc)
+
+        #print('Process has finished or has been terminated.')
+
+        end_secs = int(time())
+        run_secs = end_secs - start_secs
+
+        # log stats on the latest run attempt
+        log.event('RUN_END', note='run=' + str(attempts), secs=str(run_secs))
+
+        # check for and log any down nodes
+        # logging happens within list_down_nodes
+        # a string formatted for printing is returned when reason == True
+        printstring = list_down_nodes(reason=True,
+                                      nodeset_down=keep_down,
+                                      runtime_secs=str(run_secs),
+                                      scr_env=scr_env,
+                                      log=log)
+        print(printstring)
+
+        # decrement retry counter
+        runs -= 1
+        if runs == 0:
+            print(prog + ': ' + totalruns + ' launches exhausted, ending run.')
+            break
+
+        # is there a halt condition instructing us to stop?
+        if should_halt(bindir, prefix):
+            print(prog + ': Halt condition detected, ending run.')
+            break
+
+        ##### Reduce this sleep time when testing scripts #####
+        # give nodes a chance to clean up
+        sleep(60)
+
+        # check for halt condition again after sleep
+        if should_halt(bindir, prefix):
+            print(prog + ': Halt condition detected, ending run.')
+            break
+
+    # make a record of time postrun is started
+    timestamp = datetime.now()
+    print(prog + ': postrun: ' + str(timestamp))
+
+    # scavenge files from cache to parallel file system
+    if postrun(prefix_dir=prefix, scr_env=scr_env, verbose=verbose,
+               log=log) != 0:
+        print(prog + ': ERROR: Command failed: scr_postrun -p ' + prefix)
+
+    # make a record of end time
+    timestamp = datetime.now()
+    print(prog + ': Ended: ' + str(timestamp))
+
+    if finished == True and success == True:
+        returncode = 0
+    else:
+        returncode = 1
+
+    sys.exit(returncode)
+
 
 def print_usage(launcher=''):
-  available_launchers = '[' + '/'.join(valid_launchers) + ']'
-  print('USAGE:')
-  # the original parsing in SLURM/scr_run.in combines all [launcher args]
-  # (no matter whether they appear in the front or at the end)
-  # the usage printing looks like you could define/usr different launcher args
-  if launcher == '':
-    launcher = available_launchers
+    available_launchers = '[' + '/'.join(valid_launchers) + ']'
+    print('USAGE:')
+    # the original parsing in SLURM/scr_run.in combines all [launcher args]
+    # (no matter whether they appear in the front or at the end)
+    # the usage printing looks like you could define/usr different launcher args
+    if launcher == '':
+        launcher = available_launchers
+        print(
+            'scr_run <launcher> [' + launcher +
+            ' args] [-rc|--run-cmd=<run_command>] [-rs|--restart-cmd=<restart_command>] ['
+            + launcher + ' args]')
+        print('<launcher>: The job launcher to use, one of ' + launcher)
+    else:
+        print(
+            'scr_' + launcher + ' [' + launcher +
+            ' args] [-rc|--run-cmd=<run_command>] [-rs|--restart-cmd=<restart_command>] ['
+            + launcher + ' args]')
+    print('<run_command>: The command to run when no restart file is present')
     print(
-        'scr_run <launcher> [' + launcher +
-        ' args] [-rc|--run-cmd=<run_command>] [-rs|--restart-cmd=<restart_command>] ['
-        + launcher + ' args]')
-    print('<launcher>: The job launcher to use, one of ' + launcher)
-  else:
+        '<restart_command>: The command to run when a restart file is present')
+    print('')
+    print('The invoked command will be \'' + launcher + ' [' + launcher +
+          ' args] [run_command]\' when no restart file is present')
+    print('The invoked command will be \'' + launcher + ' [' + launcher +
+          ' args] [restart_command]\' when a restart file is present')
     print(
-        'scr_' + launcher + ' [' + launcher +
-        ' args] [-rc|--run-cmd=<run_command>] [-rs|--restart-cmd=<restart_command>] ['
-        + launcher + ' args]')
-  print('<run_command>: The command to run when no restart file is present')
-  print('<restart_command>: The command to run when a restart file is present')
-  print('')
-  print('The invoked command will be \'' + launcher + ' [' + launcher +
-        ' args] [run_command]\' when no restart file is present')
-  print('The invoked command will be \'' + launcher + ' [' + launcher +
-        ' args] [restart_command]\' when a restart file is present')
-  print(
-      'If the string \"SCR_CKPT_NAME\" appears in the restart command, it will be replaced by the name'
-  )
-  print('presented to SCR when the most recent checkpoint was written.')
-  print('')
-  print(
-      'If no restart command is specified, the run command will always be used'
-  )
-  print('If no commands are specified, the ' + launcher +
-        ' arguments will be passed directly to ' + launcher +
-        ' in all circumstances')
-  print('If no run command is specified, but a restart command is specified,')
-  print('then the restart command will be appended to the ' + launcher +
-        ' arguments when a restart file is present.')
+        'If the string \"SCR_CKPT_NAME\" appears in the restart command, it will be replaced by the name'
+    )
+    print('presented to SCR when the most recent checkpoint was written.')
+    print('')
+    print(
+        'If no restart command is specified, the run command will always be used'
+    )
+    print('If no commands are specified, the ' + launcher +
+          ' arguments will be passed directly to ' + launcher +
+          ' in all circumstances')
+    print(
+        'If no run command is specified, but a restart command is specified,')
+    print('then the restart command will be appended to the ' + launcher +
+          ' arguments when a restart file is present.')
+
 
 valid_launchers = ['aprun', 'flux', 'jsrun', 'lrun', 'mpirun', 'srun']
+
+
 def validate_launcher(launcher):
-  if launcher not in valid_launchers:
-    print(f'invalid launcher {launcher} not in {valid_launchers}')
-    print_usage()
-    sys.exit(1)
+    if launcher not in valid_launchers:
+        print(f'invalid launcher {launcher} not in {valid_launchers}')
+        print_usage()
+        sys.exit(1)
+
 
 def parseargs(argv, launcher=''):
-  starti = 0
-  if launcher == '':
-    launcher = argv[0]
-    starti = 1
-  validate_launcher(launcher)
-  launcher_args = []
-  run_cmd = ''
-  restart_cmd = ''
-  restart_args = []
-  # position starts at zero to parse args
-  position = 0
-  for i in range(starti, len(argv)):
-    # pos ->       0                           1                                   2                     3
-    # ['+launcher+' args] [-rc|--run-cmd=<run_command>] [-rs|--restart-cmd=<restart_command>] ['+launcher+' args]')
-    # haven't gotten to run command yet
-    if position == 0:
-      # run command is next (or here if we have an '=')
-      if argv[i].startswith('-rc') or argv[i].startswith('--run-cmd'):
-        if '=' in argv[i]:
-          run_cmd = argv[i][argv[i].find('=') + 1:]  # take after the equals
-        else:
-          position = 1
-      # no run command but got to the restart command
-      elif argv[i].startswith('-rs') or argv[i].startswith('--restart-cmd'):
-        if '=' in argv[i]:
-          restart_cmd = argv[i][argv[i].find('=') +
-                                1:]  # take after the equals
-          position = 3  # final args
-        else:
-          position = 2
-      # these are launcher args before the run command
-      else:
-        launcher_args.append(argv[i])
-    # position is 1, we are expecting the run command
-    elif position == 1:
-      run_cmd = argv[i]
-      position = 0
-    # expecting the restart command
-    elif position == 2:
-      restart_cmd = argv[i]
-      position = 3
-    # final launcher args
-    elif position == 3:
-      if argv[i].startswith('-rc') or argv[i].startswith('--run-cmd'):
-        if '=' in argv[i]:
-          run_cmd = argv[i][argv[i].find('=') + 1:]  # take after the equals
-          position = 0
-        else:
-          position = 1
-      # these are trailing restart args
-      else:
-        restart_args.append(argv[i])
-  return launcher, launcher_args, run_cmd, restart_cmd, restart_args
+    starti = 0
+    if launcher == '':
+        launcher = argv[0]
+        starti = 1
+    validate_launcher(launcher)
+    launcher_args = []
+    run_cmd = ''
+    restart_cmd = ''
+    restart_args = []
+    # position starts at zero to parse args
+    position = 0
+    for i in range(starti, len(argv)):
+        # pos ->       0                           1                                   2                     3
+        # ['+launcher+' args] [-rc|--run-cmd=<run_command>] [-rs|--restart-cmd=<restart_command>] ['+launcher+' args]')
+        # haven't gotten to run command yet
+        if position == 0:
+            # run command is next (or here if we have an '=')
+            if argv[i].startswith('-rc') or argv[i].startswith('--run-cmd'):
+                if '=' in argv[i]:
+                    run_cmd = argv[i][argv[i].find('=') +
+                                      1:]  # take after the equals
+                else:
+                    position = 1
+            # no run command but got to the restart command
+            elif argv[i].startswith('-rs') or argv[i].startswith(
+                    '--restart-cmd'):
+                if '=' in argv[i]:
+                    restart_cmd = argv[i][argv[i].find('=') +
+                                          1:]  # take after the equals
+                    position = 3  # final args
+                else:
+                    position = 2
+            # these are launcher args before the run command
+            else:
+                launcher_args.append(argv[i])
+        # position is 1, we are expecting the run command
+        elif position == 1:
+            run_cmd = argv[i]
+            position = 0
+        # expecting the restart command
+        elif position == 2:
+            restart_cmd = argv[i]
+            position = 3
+        # final launcher args
+        elif position == 3:
+            if argv[i].startswith('-rc') or argv[i].startswith('--run-cmd'):
+                if '=' in argv[i]:
+                    run_cmd = argv[i][argv[i].find('=') +
+                                      1:]  # take after the equals
+                    position = 0
+                else:
+                    position = 1
+            # these are trailing restart args
+            else:
+                restart_args.append(argv[i])
+    return launcher, launcher_args, run_cmd, restart_cmd, restart_args
 
 
 # argparse doesn't handle parsing of mixed positionals
 # there is a parse_intermixed_args which requires python 3.7 which may work
 # I'm just going to skip the argparse
 if __name__ == '__main__':
-  # just printing help, print the help and exit
-  if len(sys.argv) < 3 or '-h' in sys.argv[1:] or '--help' in sys.argv[1:]:
-    print_usage()
-  elif not any(
-      arg.startswith('-rc') or arg.startswith('--run-cmd')
-      or arg.startswith('-rs') or arg.startswith('--restart-cmd')
-      for arg in sys.argv):
-    # then we were called with: scr_run launcher [args]
-    launcher=sys.argv[1]
-    validate_launcher(launcher)
-    scr_run(launcher, launcher_args=sys.argv[2:])
-  else:
-    launcher, launcher_args, run_cmd, restart_cmd, restart_args = parseargs(
-        sys.argv[1:])
-    #if launcher=='flux', remove 'mini' 'submit' 'run' from front of args
-    scr_run(launcher_args=launcher_args,
-            run_cmd=run_cmd,
-            restart_cmd=restart_cmd,
-            restart_args=restart_args)
+    # just printing help, print the help and exit
+    if len(sys.argv) < 3 or '-h' in sys.argv[1:] or '--help' in sys.argv[1:]:
+        print_usage()
+    elif not any(
+            arg.startswith('-rc') or arg.startswith('--run-cmd')
+            or arg.startswith('-rs') or arg.startswith('--restart-cmd')
+            for arg in sys.argv):
+        # then we were called with: scr_run launcher [args]
+        launcher = sys.argv[1]
+        validate_launcher(launcher)
+        scr_run(launcher, launcher_args=sys.argv[2:])
+    else:
+        launcher, launcher_args, run_cmd, restart_cmd, restart_args = parseargs(
+            sys.argv[1:])
+        #if launcher=='flux', remove 'mini' 'submit' 'run' from front of args
+        scr_run(launcher_args=launcher_args,
+                run_cmd=run_cmd,
+                restart_cmd=restart_cmd,
+                restart_args=restart_args)

--- a/scripts/python/scrjob/scr_scavenge.py
+++ b/scripts/python/scrjob/scr_scavenge.py
@@ -6,8 +6,8 @@
 import os, sys
 
 if 'scrjob' not in sys.path:
-  sys.path.insert(0, '/'.join(os.path.realpath(__file__).split('/')[:-2]))
-  import scrjob
+    sys.path.insert(0, '/'.join(os.path.realpath(__file__).split('/')[:-2]))
+    import scrjob
 
 import argparse
 from time import time
@@ -29,7 +29,7 @@ def scr_scavenge(nodeset_job=None,
                  verbose=False,
                  scr_env=None,
                  log=None):
-  """This script is invoked to perform a scavenge operation
+    """This script is invoked to perform a scavenge operation
 
   scr_scavenge.py is a wrapper to gather values and arrange parameters needed for
   a scavenge operation.
@@ -42,170 +42,172 @@ def scr_scavenge(nodeset_job=None,
   This script returns 1 if a needed value or parameter could not be determined,
   and returns 0 otherwise
   """
-  # check that we have a nodeset for the job and directories to read from / write to
-  if nodeset_job is None or dataset_id is None or cntldir is None or prefixdir is None:
-    return 1
+    # check that we have a nodeset for the job and directories to read from / write to
+    if nodeset_job is None or dataset_id is None or cntldir is None or prefixdir is None:
+        return 1
 
-  bindir = scr_const.X_BINDIR
+    bindir = scr_const.X_BINDIR
 
-  # TODO: need to be able to set these defaults via config settings somehow
-  # for now just hardcode the values
+    # TODO: need to be able to set these defaults via config settings somehow
+    # for now just hardcode the values
 
-  if scr_env is None:
-    scr_env = SCR_Env(prefix=prefixdir)
-  if scr_env.param is None:
-    scr_env.param = SCR_Param()
-  if scr_env.resmgr is None:
-    scr_env.resmgr = AutoResourceManager()
-  if scr_env.launcher is None:
-    scr_env.launcher = AutoJobLauncher()
-  # lookup buffer size and crc flag via scr_param
-  param = scr_env.param
+    if scr_env is None:
+        scr_env = SCR_Env(prefix=prefixdir)
+    if scr_env.param is None:
+        scr_env.param = SCR_Param()
+    if scr_env.resmgr is None:
+        scr_env.resmgr = AutoResourceManager()
+    if scr_env.launcher is None:
+        scr_env.launcher = AutoJobLauncher()
+    # lookup buffer size and crc flag via scr_param
+    param = scr_env.param
 
-  buf_size = os.environ.get('SCR_FILE_BUF_SIZE')
-  if buf_size is None:
-    buf_size = str(1024 * 1024)
+    buf_size = os.environ.get('SCR_FILE_BUF_SIZE')
+    if buf_size is None:
+        buf_size = str(1024 * 1024)
 
-  crc_flag = os.environ.get('SCR_CRC_ON_FLUSH')
-  if crc_flag is None:
-    crc_flag = '--crc'
-  elif crc_flag == '0':
-    crc_flag = ''
+    crc_flag = os.environ.get('SCR_CRC_ON_FLUSH')
+    if crc_flag is None:
+        crc_flag = '--crc'
+    elif crc_flag == '0':
+        crc_flag = ''
 
-  start_time = int(time())
+    start_time = int(time())
 
-  # tag output files with jobid
-  jobid = scr_env.resmgr.getjobid()
-  if jobid is None:
-    print('scr_scavenge: ERROR: Could not determine jobid.')
-    return 1
+    # tag output files with jobid
+    jobid = scr_env.resmgr.getjobid()
+    if jobid is None:
+        print('scr_scavenge: ERROR: Could not determine jobid.')
+        return 1
 
-  # build the output filenames
-  dset_dir = scr_env.dir_dset(dataset_id)
-  output = os.path.join(dset_dir, 'scr_scavenge.pdsh.o' + jobid)
-  error = os.path.join(dset_dir, 'scr_scavenge.pdsh.e' + jobid)
+    # build the output filenames
+    dset_dir = scr_env.dir_dset(dataset_id)
+    output = os.path.join(dset_dir, 'scr_scavenge.pdsh.o' + jobid)
+    error = os.path.join(dset_dir, 'scr_scavenge.pdsh.e' + jobid)
 
-  if verbose:
-    print('scr_scavenge: nodeset_up =   ' + nodeset_up)
-    print('scr_scavenge: nodeset_down = ' + nodeset_down)
-
-  # format up and down nodesets for the scavenge command
-  nodeset_up, nodeset_down = scr_env.resmgr.get_scavenge_nodelists(
-      upnodes=nodeset_up, downnodes=nodeset_down)
-
-  if verbose:
-    print('scr_scavenge: upnodes =          ' + nodeset_up)
-    print('scr_scavenge: downnodes_spaced = ' + nodeset_down)
-
-  # log the start of the scavenge operation
-  if log:
-    log.event('SCAVENGE_START', dset=dataset_id)
-
-  print('scr_scavenge: ' + str(int(time())))
-  # have the launcher class gather files via pdsh or clustershell
-  consoleout = scr_env.launcher.scavenge_files(prog=bindir + '/scr_copy',
-                                               upnodes=nodeset_up,
-                                               downnodes_spaced=nodeset_down,
-                                               cntldir=cntldir,
-                                               dataset_id=dataset_id,
-                                               prefixdir=prefixdir,
-                                               buf_size=buf_size,
-                                               crc_flag=crc_flag)
-
-  # print outputs to screen
-  try:
-    os.makedirs('/'.join(output.split('/')[:-1]), exist_ok=True)
-    with open(output, 'w') as outfile:
-      outfile.write(consoleout[0])
     if verbose:
-      print('scr_scavenge: stdout: cat ' + output)
-      print(consoleout[0])
-  except Exception as e:
-    print(str(e))
-    print('scr_scavenge: ERROR: Unable to write stdout to \"' + output + '\"')
-  try:
-    with open(error, 'w') as outfile:
-      outfile.write(consoleout[1])
+        print('scr_scavenge: nodeset_up =   ' + nodeset_up)
+        print('scr_scavenge: nodeset_down = ' + nodeset_down)
+
+    # format up and down nodesets for the scavenge command
+    nodeset_up, nodeset_down = scr_env.resmgr.get_scavenge_nodelists(
+        upnodes=nodeset_up, downnodes=nodeset_down)
+
     if verbose:
-      print('scr_scavenge: stderr: cat ' + error)
-      print(consoleout[1])
-  except Exception as e:
-    print(str(e))
-    print('scr_scavenge: ERROR: Unable to write stderr to \"' + error + '\"')
+        print('scr_scavenge: upnodes =          ' + nodeset_up)
+        print('scr_scavenge: downnodes_spaced = ' + nodeset_down)
 
-  # TODO: if we knew the total bytes, we could register a transfer here in addition to an event
-  # get a timestamp for logging timing values
-  end_time = int(time())
-  diff_time = end_time - start_time
-  if log:
-    log.event('SCAVENGE_END', dset=dataset_id, secs=diff_time)
+    # log the start of the scavenge operation
+    if log:
+        log.event('SCAVENGE_START', dset=dataset_id)
 
-  return 0
+    print('scr_scavenge: ' + str(int(time())))
+    # have the launcher class gather files via pdsh or clustershell
+    consoleout = scr_env.launcher.scavenge_files(prog=bindir + '/scr_copy',
+                                                 upnodes=nodeset_up,
+                                                 downnodes_spaced=nodeset_down,
+                                                 cntldir=cntldir,
+                                                 dataset_id=dataset_id,
+                                                 prefixdir=prefixdir,
+                                                 buf_size=buf_size,
+                                                 crc_flag=crc_flag)
+
+    # print outputs to screen
+    try:
+        os.makedirs('/'.join(output.split('/')[:-1]), exist_ok=True)
+        with open(output, 'w') as outfile:
+            outfile.write(consoleout[0])
+        if verbose:
+            print('scr_scavenge: stdout: cat ' + output)
+            print(consoleout[0])
+    except Exception as e:
+        print(str(e))
+        print('scr_scavenge: ERROR: Unable to write stdout to \"' + output +
+              '\"')
+    try:
+        with open(error, 'w') as outfile:
+            outfile.write(consoleout[1])
+        if verbose:
+            print('scr_scavenge: stderr: cat ' + error)
+            print(consoleout[1])
+    except Exception as e:
+        print(str(e))
+        print('scr_scavenge: ERROR: Unable to write stderr to \"' + error +
+              '\"')
+
+    # TODO: if we knew the total bytes, we could register a transfer here in addition to an event
+    # get a timestamp for logging timing values
+    end_time = int(time())
+    diff_time = end_time - start_time
+    if log:
+        log.event('SCAVENGE_END', dset=dataset_id, secs=diff_time)
+
+    return 0
 
 
 if __name__ == '__main__':
-  parser = argparse.ArgumentParser(add_help=False,
-                                   argument_default=argparse.SUPPRESS,
-                                   prog='scr_scavenge')
-  parser.add_argument('-h',
-                      '--help',
-                      action='store_true',
-                      help='Show this help message and exit.')
-  parser.add_argument('-v',
-                      '--verbose',
-                      action='store_true',
-                      default=False,
-                      help='Verbose output.')
-  parser.add_argument('-j',
-                      '--jobset',
-                      metavar='<nodeset>',
-                      type=str,
-                      default=None,
-                      help='Specify the nodeset.')
-  parser.add_argument('-u',
-                      '--up',
-                      metavar='<nodeset>',
-                      type=str,
-                      default=None,
-                      help='Specify up nodes.')
-  parser.add_argument('-d',
-                      '--down',
-                      metavar='<nodeset>',
-                      type=str,
-                      default=None,
-                      help='Specify down nodes.')
-  parser.add_argument('-i',
-                      '--id',
-                      metavar='<id>',
-                      type=str,
-                      default=None,
-                      help='Specify the dataset id.')
-  parser.add_argument('-f',
-                      '--from',
-                      metavar='<dir>',
-                      type=str,
-                      default=None,
-                      help='The control directory.')
-  parser.add_argument('-t',
-                      '--to',
-                      metavar='<dir>',
-                      type=str,
-                      default=None,
-                      help='The prefix directory.')
-  args = vars(parser.parse_args())
-  if 'help' in args:
-    parser.print_help()
-  elif args['jobset'] is None or args['id'] is None or args[
-      'from'] is None or args['to'] is None:
-    parser.print_help()
-    print('Required arguments: --jobset --id --from --to')
-  else:
-    ret = scr_scavenge(nodeset_job=args['jobset'],
-                       nodeset_up=args['up'],
-                       nodeset_down=args['down'],
-                       dataset_id=args['id'],
-                       cntldir=args['from'],
-                       prefixdir=args['to'],
-                       verbose=args['verbose'],
-                       scr_env=None)
-    print('scr_scavenge returned ' + str(ret))
+    parser = argparse.ArgumentParser(add_help=False,
+                                     argument_default=argparse.SUPPRESS,
+                                     prog='scr_scavenge')
+    parser.add_argument('-h',
+                        '--help',
+                        action='store_true',
+                        help='Show this help message and exit.')
+    parser.add_argument('-v',
+                        '--verbose',
+                        action='store_true',
+                        default=False,
+                        help='Verbose output.')
+    parser.add_argument('-j',
+                        '--jobset',
+                        metavar='<nodeset>',
+                        type=str,
+                        default=None,
+                        help='Specify the nodeset.')
+    parser.add_argument('-u',
+                        '--up',
+                        metavar='<nodeset>',
+                        type=str,
+                        default=None,
+                        help='Specify up nodes.')
+    parser.add_argument('-d',
+                        '--down',
+                        metavar='<nodeset>',
+                        type=str,
+                        default=None,
+                        help='Specify down nodes.')
+    parser.add_argument('-i',
+                        '--id',
+                        metavar='<id>',
+                        type=str,
+                        default=None,
+                        help='Specify the dataset id.')
+    parser.add_argument('-f',
+                        '--from',
+                        metavar='<dir>',
+                        type=str,
+                        default=None,
+                        help='The control directory.')
+    parser.add_argument('-t',
+                        '--to',
+                        metavar='<dir>',
+                        type=str,
+                        default=None,
+                        help='The prefix directory.')
+    args = vars(parser.parse_args())
+    if 'help' in args:
+        parser.print_help()
+    elif args['jobset'] is None or args['id'] is None or args[
+            'from'] is None or args['to'] is None:
+        parser.print_help()
+        print('Required arguments: --jobset --id --from --to')
+    else:
+        ret = scr_scavenge(nodeset_job=args['jobset'],
+                           nodeset_up=args['up'],
+                           nodeset_down=args['down'],
+                           dataset_id=args['id'],
+                           cntldir=args['from'],
+                           prefixdir=args['to'],
+                           verbose=args['verbose'],
+                           scr_env=None)
+        print('scr_scavenge returned ' + str(ret))

--- a/scripts/python/scrjob/scr_srun.py
+++ b/scripts/python/scrjob/scr_srun.py
@@ -5,32 +5,33 @@
 import os, sys
 
 if 'scrjob' not in sys.path:
-  sys.path.insert(0, '/'.join(os.path.realpath(__file__).split('/')[:-2]))
-  import scrjob
+    sys.path.insert(0, '/'.join(os.path.realpath(__file__).split('/')[:-2]))
+    import scrjob
 
 from scrjob.scr_run import *
 
 if __name__ == '__main__':
-  """scr_srun.py calls scr_run.py with the launcher 'srun'
+    """scr_srun.py calls scr_run.py with the launcher 'srun'
 
   These commands are equivalent:
     scr_run.py srun <launcher args> <launch cmd> <cmd args>
     scr_srun.py <launcher args> <launch cmd> <cmd args>
   """
-  # just printing help, print the help and exit
-  if len(sys.argv) < 3 or '-h' in sys.argv[1:] or '--help' in sys.argv[1:]:
-    print_usage('srun')
-  elif not any(
-      arg.startswith('-h') or arg.startswith('--help') or arg.startswith('-rc')
-      or arg.startswith('--run-cmd') or arg.startswith('-rs')
-      or arg.startswith('--restart-cmd') for arg in sys.argv):
-    # then we were called with: scr_srun [launcher args]
-    scr_run(launcher='srun', launcher_args=sys.argv[1:])
-  else:
-    launcher, launcher_args, run_cmd, restart_cmd, restart_args = parseargs(
-        sys.argv[1:], launcher='srun')
-    scr_run(launcher='srun',
-            launcher_args=launcher_args,
-            run_cmd=run_cmd,
-            restart_cmd=restart_cmd,
-            restart_args=restart_args)
+    # just printing help, print the help and exit
+    if len(sys.argv) < 3 or '-h' in sys.argv[1:] or '--help' in sys.argv[1:]:
+        print_usage('srun')
+    elif not any(
+            arg.startswith('-h') or arg.startswith('--help')
+            or arg.startswith('-rc') or arg.startswith('--run-cmd')
+            or arg.startswith('-rs') or arg.startswith('--restart-cmd')
+            for arg in sys.argv):
+        # then we were called with: scr_srun [launcher args]
+        scr_run(launcher='srun', launcher_args=sys.argv[1:])
+    else:
+        launcher, launcher_args, run_cmd, restart_cmd, restart_args = parseargs(
+            sys.argv[1:], launcher='srun')
+        scr_run(launcher='srun',
+                launcher_args=launcher_args,
+                run_cmd=run_cmd,
+                restart_cmd=restart_cmd,
+                restart_args=restart_args)

--- a/scripts/python/scrjob/scr_test_runtime.py
+++ b/scripts/python/scrjob/scr_test_runtime.py
@@ -5,8 +5,8 @@
 import os, sys
 
 if 'scrjob' not in sys.path:
-  sys.path.insert(0, '/'.join(os.path.realpath(__file__).split('/')[:-2]))
-  import scrjob
+    sys.path.insert(0, '/'.join(os.path.realpath(__file__).split('/')[:-2]))
+    import scrjob
 
 from scrjob import scr_const
 from scrjob.scr_common import runproc
@@ -14,8 +14,9 @@ from scrjob.resmgrs import AutoResourceManager
 
 ### TODO: Configuration of which test methods to use
 
+
 class SCR_Test_Runtime:
-  """SCR_Test_Runtime class contains methods to determine whether we should launch with SCR
+    """SCR_Test_Runtime class contains methods to determine whether we should launch with SCR
 
   This class contains methods to test the environment, to ensure SCR will be able to function.
   These tests are called in scr_prerun.py, immediately after checking if scr is enabled.
@@ -44,8 +45,9 @@ class SCR_Test_Runtime:
   0 - PASS
   1 - FAIL
   """
-  def __new__(cls, tests=[]):
-    """This method collects the return codes of all static methods declared in SCR_Test_Runtime
+
+    def __new__(cls, tests=[]):
+        """This method collects the return codes of all static methods declared in SCR_Test_Runtime
 
     This method receives a list.
       Each element is a string and is the name of a method of the SCR_Test_Runtime class
@@ -58,47 +60,48 @@ class SCR_Test_Runtime:
       This method returns 0 if all tests succeed,
       Otherwise this method returns the 1, indicating a test has failed.
     """
-    #tests = [
-    #    attr for attr in dir(SCR_Test_Runtime) if not attr.startswith('__')
-    #    and callable(getattr(SCR_Test_Runtime, attr))
-    #]
-    rc = []
-    for test in tests:
-      try:
-        testmethod = getattr(SCR_Test_Runtime, test)
-        if callable(testmethod):
-          rc.append(testmethod())
-        else:
-          print('SCR_Test_Runtime: ERROR: ' + test + ' is defined but is not a test method.')
-      except AttributeError as e:
-        print('SCR_Test_Runtime: ERROR: ' + test + ' is not defined.')
-        print('dir(SCR_Test_Runtime)='+str(dir(SCR_Test_Runtime)))
-      except Exception as e:
-        # Could set an error code . . .
-        print('scr_test_runtime: ERROR: Exception in test ' + test)
-        print(e)
-    return 1 if 1 in rc else 0
+        #tests = [
+        #    attr for attr in dir(SCR_Test_Runtime) if not attr.startswith('__')
+        #    and callable(getattr(SCR_Test_Runtime, attr))
+        #]
+        rc = []
+        for test in tests:
+            try:
+                testmethod = getattr(SCR_Test_Runtime, test)
+                if callable(testmethod):
+                    rc.append(testmethod())
+                else:
+                    print('SCR_Test_Runtime: ERROR: ' + test +
+                          ' is defined but is not a test method.')
+            except AttributeError as e:
+                print('SCR_Test_Runtime: ERROR: ' + test + ' is not defined.')
+                print('dir(SCR_Test_Runtime)=' + str(dir(SCR_Test_Runtime)))
+            except Exception as e:
+                # Could set an error code . . .
+                print('scr_test_runtime: ERROR: Exception in test ' + test)
+                print(e)
+        return 1 if 1 in rc else 0
 
-  @staticmethod
-  def check_clustershell():
-    """This method tests if the ClusterShell module is available
+    @staticmethod
+    def check_clustershell():
+        """This method tests if the ClusterShell module is available
 
     This test will return failure if the option USE_CLUSTERSHELL
     enables ClusterShell and the module is not available.
     """
-    if scr_const.USE_CLUSTERSHELL == '1':
-      try:
-        import ClusterShell
-      except:
-        print(
-            'scr_test_runtime: ERROR: Unable to import Clustershell as indicated by scr_const.py'
-        )
-        return 1
-    return 0
+        if scr_const.USE_CLUSTERSHELL == '1':
+            try:
+                import ClusterShell
+            except:
+                print(
+                    'scr_test_runtime: ERROR: Unable to import Clustershell as indicated by scr_const.py'
+                )
+                return 1
+        return 0
 
-  @staticmethod
-  def check_pdsh():
-    """This method tests the validity of the pdsh command
+    @staticmethod
+    def check_pdsh():
+        """This method tests the validity of the pdsh command
 
     The pdsh executable, whose path is determined by scr_const.PDSH_EXE,
     is used in the Joblauncher.parallel_exec method to execute a command
@@ -108,39 +111,41 @@ class SCR_Test_Runtime:
 
     If ClusterShell is enabled, this test does not apply.
     """
-    if scr_const.USE_CLUSTERSHELL == '1':
-      return 0
-    pdsh = scr_const.PDSH_EXE
-    ### TODO: Validate pdsh command through some other means for some resmgrs?
-    ### there was an issue reported with this.
-    # I added a parameter to runproc, shell=False (default False)
-    #  when passing shell=True to runproc it will shlex.quote the command
-    #  it will turn ['which', 'pdsh'] into -> "bash -c \"which pdsh\""
-    #  this is what the command looked like in the original scripts
-    # This worked for me in both SLURM and LSF.
-    ###
-    # From subprocess.Popen docs, it appears Python 3.59+ all return the same values.
-    # Return value of None indicates the program is still running (it will not be with the above call)
-    # A negative return value (POSIX only) indicates the process was terminated by that signal.
-    # (  -9 indicates the process received signal 9  )
-    # Otherwise, the return value should be the return value of the process.
-    # This should typically be 0 for success, and nonzero for failure
-    ### This test may not work everywhere
-    argv = ['which', pdsh]
-    returncode = runproc(argv=argv, shell=True)[1]
-    if returncode != 0:
-      print('scr_test_runtime: ERROR: \'which ' + pdsh + '\' failed')
-      print('scr_test_runtime: ERROR: Problem using pdsh, see README for help')
-      return 1
-    return 0
+        if scr_const.USE_CLUSTERSHELL == '1':
+            return 0
+        pdsh = scr_const.PDSH_EXE
+        ### TODO: Validate pdsh command through some other means for some resmgrs?
+        ### there was an issue reported with this.
+        # I added a parameter to runproc, shell=False (default False)
+        #  when passing shell=True to runproc it will shlex.quote the command
+        #  it will turn ['which', 'pdsh'] into -> "bash -c \"which pdsh\""
+        #  this is what the command looked like in the original scripts
+        # This worked for me in both SLURM and LSF.
+        ###
+        # From subprocess.Popen docs, it appears Python 3.59+ all return the same values.
+        # Return value of None indicates the program is still running (it will not be with the above call)
+        # A negative return value (POSIX only) indicates the process was terminated by that signal.
+        # (  -9 indicates the process received signal 9  )
+        # Otherwise, the return value should be the return value of the process.
+        # This should typically be 0 for success, and nonzero for failure
+        ### This test may not work everywhere
+        argv = ['which', pdsh]
+        returncode = runproc(argv=argv, shell=True)[1]
+        if returncode != 0:
+            print('scr_test_runtime: ERROR: \'which ' + pdsh + '\' failed')
+            print(
+                'scr_test_runtime: ERROR: Problem using pdsh, see README for help'
+            )
+            return 1
+        return 0
 
 
 if __name__ == '__main__':
-  """Call sys.exit(result) When this is called as a standalone script
+    """Call sys.exit(result) When this is called as a standalone script
 
   This provides a compact illustration of usage of the test methods in scr_prerun.
   """
-  resmgr = AutoResourceManager()
-  tests = resmgr.get_prerun_tests()
-  ret = SCR_Test_Runtime(tests)
-  sys.exit(ret)
+    resmgr = AutoResourceManager()
+    tests = resmgr.get_prerun_tests()
+    ret = SCR_Test_Runtime(tests)
+    sys.exit(ret)

--- a/scripts/python/setup.py
+++ b/scripts/python/setup.py
@@ -10,15 +10,14 @@ setup(
     author='LLNL',
     author_email='pao@llnl.gov',
     license='BSD 3-clause + addendum',
-    packages=find_packages(), #['scrjob'],
-    install_requires=[#'mpi4py>=2.0',
-                      #'numpy',
-                      ],
-
+    packages=find_packages(),  #['scrjob'],
+    install_requires=[  #'mpi4py>=2.0',
+        #'numpy',
+    ],
     classifiers=[
         #'Intended Audience :: Science/Research',
-        #'License :: OSI Approved :: BSD License',  
-        #'Operating System :: POSIX :: Linux',        
+        #'License :: OSI Approved :: BSD License',
+        #'Operating System :: POSIX :: Linux',
         #'Programming Language :: Python :: 3',
     ],
 )

--- a/scripts/python/tests/test_flush_file.py
+++ b/scripts/python/tests/test_flush_file.py
@@ -5,7 +5,7 @@
 #   salloc -N1 -ppdebug
 #
 # Within allocation, run test_api with following settings:
-#   
+#
 #   export SCR_CACHE_BYPASS=0
 #   export SCR_CACHE_SIZE=6
 #   export SCR_FLUSH=6
@@ -35,6 +35,7 @@ print('latest: 6')
 print('--------------------------------------------------------')
 
 import os, sys, time
+
 sys.path.insert(0, '/'.join(os.path.realpath(__file__).split('/')[:-2]))
 import scrjob
 from scrjob.cli import SCRFlushFile
@@ -43,24 +44,24 @@ time.sleep(2)
 
 pwd = os.getcwd()
 if __name__ == '__main__' and len(sys.argv) == 2:
-  pwd = sys.argv[1]
+    pwd = sys.argv[1]
 ff = SCRFlushFile(pwd)
 
 dsets = ff.list_dsets_output()
 print('output:', dsets)
 for d in dsets:
-  name = ff.name(d)
-  needflush = ff.need_flush(d)
-  location = ff.location(d)
-  print(d, name, needflush, location)
+    name = ff.name(d)
+    needflush = ff.need_flush(d)
+    location = ff.location(d)
+    print(d, name, needflush, location)
 
 dsets = ff.list_dsets_ckpt()
 print('ckpt:', dsets)
 for d in dsets:
-  name = ff.name(d)
-  needflush = ff.need_flush(d)
-  location = ff.location(d)
-  print(d, name, needflush, location)
+    name = ff.name(d)
+    needflush = ff.need_flush(d)
+    location = ff.location(d)
+    print(d, name, needflush, location)
 
 print('latest:', ff.latest())
 

--- a/scripts/python/tests/test_launch.py
+++ b/scripts/python/tests/test_launch.py
@@ -4,6 +4,7 @@
 # --nodes=2 --ntasks=2 --cores-per-task=1
 
 import os, sys
+
 sys.path.insert(0, '/'.join(os.path.realpath(__file__).split('/')[:-2]))
 import scrjob
 
@@ -19,116 +20,120 @@ from scrjob.resmgrs import AutoResourceManager
 from scrjob.scr_param import SCR_Param
 from scrjob.scr_glob_hosts import scr_glob_hosts
 
+
 # return number of nodes left in allocation after excluding down nodes
 def nodes_remaining(resmgr, nodelist, down_nodes):
-  num_left = scr_glob_hosts(count=True,
-                            minus=nodelist + ':' + down_nodes,
-                            resmgr=resmgr)
-  if num_left is None:
-    return 0
-  return int(num_left)
+    num_left = scr_glob_hosts(count=True,
+                              minus=nodelist + ':' + down_nodes,
+                              resmgr=resmgr)
+    if num_left is None:
+        return 0
+    return int(num_left)
+
 
 # determine how many nodes are needed
 def nodes_needed(scr_env, nodelist):
-  # if SCR_MIN_NODES is set, use that
-  num_needed = os.environ.get('SCR_MIN_NODES')
-  if num_needed is None or int(num_needed) <= 0:
-    # otherwise, use value in nodes file if one exists
-    num_needed = scr_env.get_runnode_count()
-    if num_needed <= 0:
-      # otherwise, assume we need all nodes in the allocation
-      num_needed = scr_glob_hosts(count=True,
-                                  hosts=nodelist,
-                                  resmgr=scr_env.resmgr)
-      if num_needed is None:
-        # failed all methods to estimate the minimum number of nodes
-        return 0
-  return int(num_needed)
+    # if SCR_MIN_NODES is set, use that
+    num_needed = os.environ.get('SCR_MIN_NODES')
+    if num_needed is None or int(num_needed) <= 0:
+        # otherwise, use value in nodes file if one exists
+        num_needed = scr_env.get_runnode_count()
+        if num_needed <= 0:
+            # otherwise, assume we need all nodes in the allocation
+            num_needed = scr_glob_hosts(count=True,
+                                        hosts=nodelist,
+                                        resmgr=scr_env.resmgr)
+            if num_needed is None:
+                # failed all methods to estimate the minimum number of nodes
+                return 0
+    return int(num_needed)
 
 
 def dolaunch(launcher, launch_cmd):
-  verbose = True
-  bindir = scr_const.X_BINDIR
-  prefix = scr_prefix()
-  param = SCR_Param()
-  resmgr = AutoResourceManager()
-  launcher = AutoJobLauncher(launcher)
-  scr_env = SCR_Env(prefix=prefix)
-  scr_env.param = param
-  scr_env.resmgr = resmgr
-  scr_env.launcher = launcher
-  jobid = resmgr.getjobid()
-  user = scr_env.get_user()
-  launcher.hostfile = os.path.join(scr_env.dir_scr(), 'hostfile')
-  print('jobid = ' + str(jobid))
-  print('user = ' + str(user))
-  # get the nodeset of this job
-  nodelist = scr_env.get_scr_nodelist()
-  if nodelist is None:
-    nodelist = resmgr.get_job_nodes()
+    verbose = True
+    bindir = scr_const.X_BINDIR
+    prefix = scr_prefix()
+    param = SCR_Param()
+    resmgr = AutoResourceManager()
+    launcher = AutoJobLauncher(launcher)
+    scr_env = SCR_Env(prefix=prefix)
+    scr_env.param = param
+    scr_env.resmgr = resmgr
+    scr_env.launcher = launcher
+    jobid = resmgr.getjobid()
+    user = scr_env.get_user()
+    launcher.hostfile = os.path.join(scr_env.dir_scr(), 'hostfile')
+    print('jobid = ' + str(jobid))
+    print('user = ' + str(user))
+    # get the nodeset of this job
+    nodelist = scr_env.get_scr_nodelist()
     if nodelist is None:
-      nodelist = ''
-  nodelist = ','.join(resmgr.expand_hosts(nodelist))
-  print('nodelist = ' + str(nodelist))
-  watchdog = SCR_Watchdog(prefix, scr_env)
-  print('calling prepareforprerun . . .')
-  launcher.prepareforprerun()
-  print('returned from prepareforprerun')
-  if scr_prerun(scr_env=scr_env) != 0:
-    print('testing: ERROR: Command failed: scr_prerun -p ' + prefix)
-    print('This would terminate run')
-  else:
-    print('prerun returned success')
-  endtime = resmgr.get_scr_end_time()
-  print('endtime = ' + str(endtime))
-  if endtime == 0:
-    print('testing : WARNING: Unable to get end time.')
-  elif endtime == -1:  # no end time / limit
-    print('testing : get_scr_end_time returned no end time / limit')
-  else:
-    print('testing : get_scr_end_time returned ' + str(endtime))
-  down_nodes = list_down_nodes(free=True,
-                               nodeset_down='',
-                               scr_env=scr_env)
-  if type(down_nodes) is int:
-    print('there were no downnodes from list_down_nodes')
-    down_nodes = ''
-  else:
-    print('there were downnodes returned from list_down_nodes')
-    print('down_nodes = ' + str(down_nodes))
-    # print the reason for the down nodes, and log them
-    # when reason == True a string formatted for printing will be returned
-    printstring = list_down_nodes(reason=True,
-                    free=True,
-                    nodeset_down=down_nodes,
-                    runtime_secs='0',
-                    scr_env=scr_env,
-                    log=None)
-    print(printstring)
-  num_needed = nodes_needed(scr_env, nodelist)
-  print('num_needed = ' + str(num_needed))
-  num_left = nodes_remaining(resmgr, nodelist, down_nodes)
-  print('num_left = ' + str(num_left))
-  print('testing: Launching ' + str(launch_cmd))
-  proc, jobstep = launcher.launchruncmd(up_nodes=nodelist,
-                                    down_nodes=down_nodes,
-                                    launcher_args=launch_cmd)
-  print('type(proc) = ' + str(type(proc)) + ', type(jobstep) = ' + str(type(jobstep)))
-  print('proc = ' + str(proc))
-  print('pid = ' + str(jobstep))
-  print('testing : Entering watchdog method')
-  success = False
-  if watchdog.watchproc(proc, jobstep) != 0:
-    print('watchdog.watchproc returned nonzero')
-    print('calling launcher.waitonprocess . . .')
-    (finished, success) = launcher.waitonprocess(proc)
-  else:
-    print('watchdog returned zero and didn\'t launch another process')
-    print('this means the process is terminated')
-  print(f'Process has finished or has been terminated with success == {success}.')
+        nodelist = resmgr.get_job_nodes()
+        if nodelist is None:
+            nodelist = ''
+    nodelist = ','.join(resmgr.expand_hosts(nodelist))
+    print('nodelist = ' + str(nodelist))
+    watchdog = SCR_Watchdog(prefix, scr_env)
+    print('calling prepareforprerun . . .')
+    launcher.prepareforprerun()
+    print('returned from prepareforprerun')
+    if scr_prerun(scr_env=scr_env) != 0:
+        print('testing: ERROR: Command failed: scr_prerun -p ' + prefix)
+        print('This would terminate run')
+    else:
+        print('prerun returned success')
+    endtime = resmgr.get_scr_end_time()
+    print('endtime = ' + str(endtime))
+    if endtime == 0:
+        print('testing : WARNING: Unable to get end time.')
+    elif endtime == -1:  # no end time / limit
+        print('testing : get_scr_end_time returned no end time / limit')
+    else:
+        print('testing : get_scr_end_time returned ' + str(endtime))
+    down_nodes = list_down_nodes(free=True, nodeset_down='', scr_env=scr_env)
+    if type(down_nodes) is int:
+        print('there were no downnodes from list_down_nodes')
+        down_nodes = ''
+    else:
+        print('there were downnodes returned from list_down_nodes')
+        print('down_nodes = ' + str(down_nodes))
+        # print the reason for the down nodes, and log them
+        # when reason == True a string formatted for printing will be returned
+        printstring = list_down_nodes(reason=True,
+                                      free=True,
+                                      nodeset_down=down_nodes,
+                                      runtime_secs='0',
+                                      scr_env=scr_env,
+                                      log=None)
+        print(printstring)
+    num_needed = nodes_needed(scr_env, nodelist)
+    print('num_needed = ' + str(num_needed))
+    num_left = nodes_remaining(resmgr, nodelist, down_nodes)
+    print('num_left = ' + str(num_left))
+    print('testing: Launching ' + str(launch_cmd))
+    proc, jobstep = launcher.launchruncmd(up_nodes=nodelist,
+                                          down_nodes=down_nodes,
+                                          launcher_args=launch_cmd)
+    print('type(proc) = ' + str(type(proc)) + ', type(jobstep) = ' +
+          str(type(jobstep)))
+    print('proc = ' + str(proc))
+    print('pid = ' + str(jobstep))
+    print('testing : Entering watchdog method')
+    success = False
+    if watchdog.watchproc(proc, jobstep) != 0:
+        print('watchdog.watchproc returned nonzero')
+        print('calling launcher.waitonprocess . . .')
+        (finished, success) = launcher.waitonprocess(proc)
+    else:
+        print('watchdog returned zero and didn\'t launch another process')
+        print('this means the process is terminated')
+    print(
+        f'Process has finished or has been terminated with success == {success}.'
+    )
+
 
 if __name__ == '__main__':
-  if len(sys.argv) < 3:
-    print('Usage: ' + sys.argv[0] + ' <launcher> <launcher_args>')
-    sys.exit(0)
-  dolaunch(sys.argv[1], sys.argv[2:])
+    if len(sys.argv) < 3:
+        print('Usage: ' + sys.argv[0] + ' <launcher> <launcher_args>')
+        sys.exit(0)
+    dolaunch(sys.argv[1], sys.argv[2:])

--- a/scripts/python/tests/test_log.py
+++ b/scripts/python/tests/test_log.py
@@ -14,14 +14,19 @@ print('--------------------------------------------------------')
 print('We should get a file at .scr/log with contents like:')
 print('')
 print('2021-07-23T12:15:36: host=quartz1, jobid=7155341, event=test_event')
-print('2021-07-23T12:15:46: host=quartz1, jobid=7155341, event=test_event2, note=\"note2\", dset=100, name=\"ckpt.100\", secs=30.000000')
+print(
+    '2021-07-23T12:15:46: host=quartz1, jobid=7155341, event=test_event2, note=\"note2\", dset=100, name=\"ckpt.100\", secs=30.000000'
+)
 print('')
-print('Because of the sleep(10), the last entry should be about 10 seconds later')
+print(
+    'Because of the sleep(10), the last entry should be about 10 seconds later'
+)
 print('--------------------------------------------------------')
 
 import os, sys
 from datetime import datetime
 import time
+
 sys.path.insert(0, '/'.join(os.path.realpath(__file__).split('/')[:-2]))
 import scrjob
 from scrjob.scr_env import SCR_Env
@@ -46,14 +51,19 @@ datestring = str(datetime.now())
 print('current timestamp =', timestamp, ' (', datestring, ')')
 log.event('test_event')
 time.sleep(10)
-log.event('test_event2', dset=100, name='ckpt.100', note='note2', start=int(time.time()), secs=30)
+log.event('test_event2',
+          dset=100,
+          name='ckpt.100',
+          note='note2',
+          start=int(time.time()),
+          secs=30)
 
 try:
-  with open('.scr/log','r') as infile:
-    contents = infile.read()
-    print('cat .scr/log')
-    print(contents)
+    with open('.scr/log', 'r') as infile:
+        contents = infile.read()
+        print('cat .scr/log')
+        print(contents)
 except:
-  print('Error opening and reading .scr/log')
+    print('Error opening and reading .scr/log')
 
 time.sleep(2)

--- a/scripts/python/tests/test_pdsh.py
+++ b/scripts/python/tests/test_pdsh.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python3
 
 import os, sys
+
 sys.path.insert(0, '/'.join(os.path.realpath(__file__).split('/')[:-2]))
 import scrjob
 
@@ -18,110 +19,110 @@ from scrjob.resmgrs import AutoResourceManager
 from scrjob.scr_param import SCR_Param
 from scrjob.scr_glob_hosts import scr_glob_hosts
 
+
 # return number of nodes left in allocation after excluding down nodes
 def nodes_remaining(resmgr, nodelist, down_nodes):
-  num_left = scr_glob_hosts(count=True,
-                            minus=nodelist + ':' + down_nodes,
-                            resmgr=resmgr)
-  if num_left is None:
-    return 0
-  return int(num_left)
+    num_left = scr_glob_hosts(count=True,
+                              minus=nodelist + ':' + down_nodes,
+                              resmgr=resmgr)
+    if num_left is None:
+        return 0
+    return int(num_left)
+
 
 # determine how many nodes are needed
 def nodes_needed(scr_env, nodelist):
-  # if SCR_MIN_NODES is set, use that
-  num_needed = os.environ.get('SCR_MIN_NODES')
-  if num_needed is None or int(num_needed) <= 0:
-    # otherwise, use value in nodes file if one exists
-    num_needed = scr_env.get_runnode_count()
-    if num_needed <= 0:
-      # otherwise, assume we need all nodes in the allocation
-      num_needed = scr_glob_hosts(count=True,
-                                  hosts=nodelist,
-                                  resmgr=scr_env.resmgr)
-      if num_needed is None:
-        # failed all methods to estimate the minimum number of nodes
-        return 0
-  return int(num_needed)
+    # if SCR_MIN_NODES is set, use that
+    num_needed = os.environ.get('SCR_MIN_NODES')
+    if num_needed is None or int(num_needed) <= 0:
+        # otherwise, use value in nodes file if one exists
+        num_needed = scr_env.get_runnode_count()
+        if num_needed <= 0:
+            # otherwise, assume we need all nodes in the allocation
+            num_needed = scr_glob_hosts(count=True,
+                                        hosts=nodelist,
+                                        resmgr=scr_env.resmgr)
+            if num_needed is None:
+                # failed all methods to estimate the minimum number of nodes
+                return 0
+    return int(num_needed)
 
 
 def getpdshout(launcher, launch_cmd):
-  verbose = True
-  bindir = scr_const.X_BINDIR
-  prefix = scr_prefix()
-  param = SCR_Param()
-  resmgr = AutoResourceManager()
-  launcher = AutoJobLauncher(launcher)
-  scr_env = SCR_Env(prefix=prefix)
-  scr_env.param = param
-  scr_env.resmgr = resmgr
-  scr_env.launcher = launcher
-  jobid = resmgr.getjobid()
-  user = scr_env.get_user()
-  print('jobid = ' + str(jobid))
-  print('user = ' + str(user))
-  # get the nodeset of this job
-  nodelist = scr_env.get_scr_nodelist()
-  if nodelist is None:
-    nodelist = resmgr.get_job_nodes()
+    verbose = True
+    bindir = scr_const.X_BINDIR
+    prefix = scr_prefix()
+    param = SCR_Param()
+    resmgr = AutoResourceManager()
+    launcher = AutoJobLauncher(launcher)
+    scr_env = SCR_Env(prefix=prefix)
+    scr_env.param = param
+    scr_env.resmgr = resmgr
+    scr_env.launcher = launcher
+    jobid = resmgr.getjobid()
+    user = scr_env.get_user()
+    print('jobid = ' + str(jobid))
+    print('user = ' + str(user))
+    # get the nodeset of this job
+    nodelist = scr_env.get_scr_nodelist()
     if nodelist is None:
-      nodelist = ''
-  nodelist = ','.join(resmgr.expand_hosts(nodelist))
-  print('nodelist = ' + str(nodelist))
-  resmgr.usewatchdog(True)
-  watchdog = SCR_Watchdog(prefix, scr_env)
-  if launcher == 'srun':
-    print('calling prepareforprerun . . .')
-    launcher.prepareforprerun()
-    print('returned from prepareforprerun')
-  if scr_prerun(scr_env=scr_env) != 0:
-    print('testing: ERROR: Command failed: scr_prerun -p ' + prefix)
-    print('This would terminate run')
-  else:
-    print('prerun returned success')
-  endtime = resmgr.get_scr_end_time()
-  print('endtime = ' + str(endtime))
-  if endtime == 0:
-    print('testing : WARNING: Unable to get end time.')
-  elif endtime == -1:  # no end time / limit
-    print('testing : get_scr_end_time returned no end time / limit')
-  else:
-    print('testing : get_scr_end_time returned ' + str(endtime))
-  down_nodes = list_down_nodes(free=True,
-                               nodeset_down='',
-                               scr_env=scr_env)
-  if type(down_nodes) is int:
-    print('there were no downnodes from list_down_nodes')
-    down_nodes = ''
-  else:
-    print('there were downnodes returned from list_down_nodes')
-    print('down_nodes = ' + str(down_nodes))
-    # print the reason for the down nodes, and log them
-    # when reason == True a string formatted for printing will be returned
-    printstring = list_down_nodes(reason=True,
-                    free=first_run,
-                    nodeset_down=down_nodes,
-                    runtime_secs='0',
-                    scr_env=scr_env,
-                    log=log)
-    print(printstring)
-  num_needed = nodes_needed(scr_env, nodelist)
-  print('num_needed = ' + str(num_needed))
-  num_left = nodes_remaining(resmgr, nodelist, down_nodes)
-  print('num_left = ' + str(num_left))
-  print('testing: Getting output from: ' + str(launch_cmd))
-  output = launcher.parallel_exec(argv=launch_cmd,
-                                  runnodes=nodelist)
-  print('###\n# stdout:')
-  print(output[0][0])
-  print('###\n# stderr:')
-  print(output[0][1])
-  print('###\n# Execution return code: ' + str(output[1]))
-  print('\nTest pdshout concluded.')
-  sleep(2)
+        nodelist = resmgr.get_job_nodes()
+        if nodelist is None:
+            nodelist = ''
+    nodelist = ','.join(resmgr.expand_hosts(nodelist))
+    print('nodelist = ' + str(nodelist))
+    resmgr.usewatchdog(True)
+    watchdog = SCR_Watchdog(prefix, scr_env)
+    if launcher == 'srun':
+        print('calling prepareforprerun . . .')
+        launcher.prepareforprerun()
+        print('returned from prepareforprerun')
+    if scr_prerun(scr_env=scr_env) != 0:
+        print('testing: ERROR: Command failed: scr_prerun -p ' + prefix)
+        print('This would terminate run')
+    else:
+        print('prerun returned success')
+    endtime = resmgr.get_scr_end_time()
+    print('endtime = ' + str(endtime))
+    if endtime == 0:
+        print('testing : WARNING: Unable to get end time.')
+    elif endtime == -1:  # no end time / limit
+        print('testing : get_scr_end_time returned no end time / limit')
+    else:
+        print('testing : get_scr_end_time returned ' + str(endtime))
+    down_nodes = list_down_nodes(free=True, nodeset_down='', scr_env=scr_env)
+    if type(down_nodes) is int:
+        print('there were no downnodes from list_down_nodes')
+        down_nodes = ''
+    else:
+        print('there were downnodes returned from list_down_nodes')
+        print('down_nodes = ' + str(down_nodes))
+        # print the reason for the down nodes, and log them
+        # when reason == True a string formatted for printing will be returned
+        printstring = list_down_nodes(reason=True,
+                                      free=first_run,
+                                      nodeset_down=down_nodes,
+                                      runtime_secs='0',
+                                      scr_env=scr_env,
+                                      log=log)
+        print(printstring)
+    num_needed = nodes_needed(scr_env, nodelist)
+    print('num_needed = ' + str(num_needed))
+    num_left = nodes_remaining(resmgr, nodelist, down_nodes)
+    print('num_left = ' + str(num_left))
+    print('testing: Getting output from: ' + str(launch_cmd))
+    output = launcher.parallel_exec(argv=launch_cmd, runnodes=nodelist)
+    print('###\n# stdout:')
+    print(output[0][0])
+    print('###\n# stderr:')
+    print(output[0][1])
+    print('###\n# Execution return code: ' + str(output[1]))
+    print('\nTest pdshout concluded.')
+    sleep(2)
+
 
 if __name__ == '__main__':
-  if len(sys.argv) < 3:
-    print('Usage: ' + sys.argv[0] + ' <launcher> <launcher_args>')
-    sys.exit(0)
-  getpdshout(sys.argv[1], sys.argv[2:])
+    if len(sys.argv) < 3:
+        print('Usage: ' + sys.argv[0] + ' <launcher> <launcher_args>')
+        sys.exit(0)
+    getpdshout(sys.argv[1], sys.argv[2:])

--- a/scripts/python/tests/test_rm.py
+++ b/scripts/python/tests/test_rm.py
@@ -23,6 +23,7 @@ print('--------------------------------------------------------')
 
 import os, sys
 import time
+
 sys.path.insert(0, '/'.join(os.path.realpath(__file__).split('/')[:-2]))
 import scrjob
 from scrjob.resmgrs import AutoResourceManager
@@ -42,7 +43,7 @@ print("endsecs:", endtime)
 now = int(time.time())
 secs = endtime - now
 if secs < 0:
-  secs = 0
+    secs = 0
 print("now:", now, "end:", endtime, "secs left:", secs)
 
 time.sleep(2)

--- a/scripts/python/tests/test_scr_index.py
+++ b/scripts/python/tests/test_scr_index.py
@@ -5,7 +5,7 @@
 #   salloc -N1 -ppdebug
 #
 # Within allocation, run test_api with following settings:
-#   
+#
 #   export SCR_CACHE_BYPASS=0
 #   export SCR_CACHE_SIZE=6
 #   export SCR_FLUSH=6
@@ -25,6 +25,7 @@ print('True')
 print('--------------------------------------------------------')
 
 import os, sys, time
+
 sys.path.insert(0, '/'.join(os.path.realpath(__file__).split('/')[:-2]))
 import scrjob
 from scrjob.cli import SCRIndex

--- a/scripts/python/tests/test_watchdog.py
+++ b/scripts/python/tests/test_watchdog.py
@@ -23,93 +23,101 @@ from scrjob.scr_param import SCR_Param
 from scrjob.scr_environment import SCR_Env
 from scrjob.scr_watchdog import SCR_Watchdog
 
+
 def checkfiletimes():
-  good = True
-  i = 0
-  while True:
-    try:
-      filename = 'outrank' + str(i)
-      with open(filename,'r') as infile:
-        contents = infile.readlines()
-        # the 'last' line will be blank
-        lastline = contents[-2].strip()
+    good = True
+    i = 0
+    while True:
         try:
-          timeval = int(lastline)
-          elapsed = int(time.time()) - timeval
-          print('Rank', str(i), 'elapsed time:', str(elapsed))
-          if elapsed < 45:
-            good = False
-        except Exception as e:
-          print(e)
-          print('Error converting \"' + lastline + '\" to an integer.')
-      i += 1
-    except:
-      print('Unable to open file for rank', str(i))
-      print('(this is expected when the rank goes out of bounds.)')
-      break
-  return good
+            filename = 'outrank' + str(i)
+            with open(filename, 'r') as infile:
+                contents = infile.readlines()
+                # the 'last' line will be blank
+                lastline = contents[-2].strip()
+                try:
+                    timeval = int(lastline)
+                    elapsed = int(time.time()) - timeval
+                    print('Rank', str(i), 'elapsed time:', str(elapsed))
+                    if elapsed < 45:
+                        good = False
+                except Exception as e:
+                    print(e)
+                    print('Error converting \"' + lastline +
+                          '\" to an integer.')
+            i += 1
+        except:
+            print('Unable to open file for rank', str(i))
+            print('(this is expected when the rank goes out of bounds.)')
+            break
+    return good
+
 
 def testwatchdog(launcher, launcher_args):
-  timeout = 15
-  os.environ['SCR_WATCHDOG_TIMEOUT'] = '15'
-  os.environ['SCR_WATCHDOG_TIMEOUT_PFS'] = '15'
-  scr_env = SCR_Env()
-  param = SCR_Param()
-  rm = AutoResourceManager()
-  launcher = AutoJobLauncher(launcher)
-  prefix = scr_env.get_prefix()
-  scr_env.param = param
-  scr_env.launcher = launcher
-  nodelist = rm.get_job_nodes()
-  down_nodes = rm.get_downnodes()
-  watchdog = SCR_Watchdog(prefix, scr_env)
+    timeout = 15
+    os.environ['SCR_WATCHDOG_TIMEOUT'] = '15'
+    os.environ['SCR_WATCHDOG_TIMEOUT_PFS'] = '15'
+    scr_env = SCR_Env()
+    param = SCR_Param()
+    rm = AutoResourceManager()
+    launcher = AutoJobLauncher(launcher)
+    prefix = scr_env.get_prefix()
+    scr_env.param = param
+    scr_env.launcher = launcher
+    nodelist = rm.get_job_nodes()
+    down_nodes = rm.get_downnodes()
+    watchdog = SCR_Watchdog(prefix, scr_env)
 
-  if down_nodes is None:
-    down_nodes = {}
+    if down_nodes is None:
+        down_nodes = {}
 
-  print('Nodelist = ' + str(nodelist))
-  print('Down nodes = ' + str(down_nodes))
-  down_nodes = list(down_nodes.keys())
+    print('Nodelist = ' + str(nodelist))
+    print('Down nodes = ' + str(down_nodes))
+    down_nodes = list(down_nodes.keys())
 
-  print('Launching command ' + ' '.join(launcher_args))
-  proc, jobstep = launcher.launchruncmd(up_nodes=nodelist,
-                                    down_nodes=down_nodes,
-                                    launcher_args=launcher_args)
+    print('Launching command ' + ' '.join(launcher_args))
+    proc, jobstep = launcher.launchruncmd(up_nodes=nodelist,
+                                          down_nodes=down_nodes,
+                                          launcher_args=launcher_args)
 
-  if proc is None or jobstep is None:
-    print('Error launching the sleeper process!')
-    return
+    if proc is None or jobstep is None:
+        print('Error launching the sleeper process!')
+        return
 
-  #if watchdog is None: proc.communicate(timeout=None)
-  #else:
+    #if watchdog is None: proc.communicate(timeout=None)
+    #else:
 
-  print('Each launched sleeper process will output the posix time every 5 seconds.')
-  print('Calling watchdog watchprocess . . .')
-  if watchdog.watchproc(proc, jobstep) != 0:
-    print('The watchdog failed to start')
-    print('Waiting for the original process for 15 seconds')
-    (finished, success) = launcher.waitonprocess(proc=proc,timeout=timeout)
-    if finished == True:
-      print('The process is still running, asking the launcher to kill it . . .')
-      launcher.scr_kill_jobstep(jobstep=jobstep)
+    print(
+        'Each launched sleeper process will output the posix time every 5 seconds.'
+    )
+    print('Calling watchdog watchprocess . . .')
+    if watchdog.watchproc(proc, jobstep) != 0:
+        print('The watchdog failed to start')
+        print('Waiting for the original process for 15 seconds')
+        (finished, success) = launcher.waitonprocess(proc=proc,
+                                                     timeout=timeout)
+        if finished == True:
+            print(
+                'The process is still running, asking the launcher to kill it . . .'
+            )
+            launcher.scr_kill_jobstep(jobstep=jobstep)
 
-  print('The process has now been terminated')
-  print('Sleeping for 45 seconds before checking the output files . . .')
-  time.sleep(45)
-  print('Examining files named in the manner \"outrank%d\"')
-  if checkfiletimes():
-    print('The results of the test appear good')
-  else:
-    print('It appears the processes may still be running')
+    print('The process has now been terminated')
+    print('Sleeping for 45 seconds before checking the output files . . .')
+    time.sleep(45)
+    print('Examining files named in the manner \"outrank%d\"')
+    if checkfiletimes():
+        print('The results of the test appear good')
+    else:
+        print('It appears the processes may still be running')
 
-  print('Watchdog test concluded')
+    print('Watchdog test concluded')
 
 
 if __name__ == '__main__':
-  # requiring a launcher at a minimum, perhaps without arguments.
-  if len(sys.argv)<2:
-    print('ERROR: Invalid usage')
-    print('Usage: test_watchdog.py <launcher> <launcher_args>')
-    print('   Ex: test_watchdog.py srun -n1 -N1')
-    sys.exit(1)
-  testwatchdog(sys.argv[1], sys.argv[2:])
+    # requiring a launcher at a minimum, perhaps without arguments.
+    if len(sys.argv) < 2:
+        print('ERROR: Invalid usage')
+        print('Usage: test_watchdog.py <launcher> <launcher_args>')
+        print('   Ex: test_watchdog.py srun -n1 -N1')
+        sys.exit(1)
+    testwatchdog(sys.argv[1], sys.argv[2:])


### PR DESCRIPTION
Run ``yapf`` on all python files to apply consistent formatting.

https://github.com/google/yapf

Commands used to format files:
```
#!/bin/bash
  
python3 -m venv --system-site-packages env
source env/bin/activate
pip install --upgrade pip
pip install yapf

yapf -i python/*.py python/*.py.in
yapf -i scripts/python/setup.py
find scripts/python/scrjob -regex '.*\.py' -print | xargs yapf -i
find scripts/python/scrjob -regex '.*\.py\.in' -print | xargs yapf -i
find scripts/python/tests -regex '.*\.py' -print | xargs yapf -i
```