### PR TITLE
python: run docformatter

### DIFF
--- a/python/scr.py.in
+++ b/python/scr.py.in
@@ -1,4 +1,4 @@
-""" Implements an interface around the SCR C library.
+"""Implements an interface around the SCR C library.
 
 This module implements a python interface around the SCR C API.
 This documentation describes specifics about the python interface.
@@ -189,35 +189,35 @@ def _pystr(val):
 def config(conf):
     """Query, set, or unset an SCR configuration parameter.
 
-  Must be called before init().
+    Must be called before init().
 
-  To query a value, provide the name of the parameter, e.g.,:
-      scr.config("SCR_DEBUG")
+    To query a value, provide the name of the parameter, e.g.,:
+        scr.config("SCR_DEBUG")
 
-  To set a value, provide the name and its value as a
-  key=value string, e.g.,:
-      scr.config("SCR_DEBUG=1")
+    To set a value, provide the name and its value as a
+    key=value string, e.g.,:
+        scr.config("SCR_DEBUG=1")
 
-  To unset a value, provide the name without a value, e.g.,:
-      scr.config("SCR_DEBUG=")
+    To unset a value, provide the name without a value, e.g.,:
+        scr.config("SCR_DEBUG=")
 
-  On query, config() returns the current parameter value as a str if set.
-  It returns None otherwise.
+    On query, config() returns the current parameter value as a str if set.
+    It returns None otherwise.
 
-  It returns None when setting or unsetting a parameter.
+    It returns None when setting or unsetting a parameter.
 
-  Maps to SCR_Config in libscr.
+    Maps to SCR_Config in libscr.
 
-  Parameters
-  ----------
-  config : str
-      string to query, set, or unset an SCR configuration parameter
+    Parameters
+    ----------
+    config : str
+        string to query, set, or unset an SCR configuration parameter
 
-  Returns
-  -------
-  str
-      current value of SCR configuration parameter if set
-  """
+    Returns
+    -------
+    str
+        current value of SCR configuration parameter if set
+    """
     val = _libscr.SCR_Config(_cstr(conf))
     if val != _ffi.NULL:
         return _pystr(val)
@@ -227,21 +227,21 @@ def config(conf):
 def init():
     """Initialize the SCR library.
 
-  Must be called before any other SCR method, except config().
-  When restarting a job, this method rebuilds any cached datasets.
-  SCR also identifies and loads the most recent checkpoint.
+    Must be called before any other SCR method, except config().
+    When restarting a job, this method rebuilds any cached datasets.
+    SCR also identifies and loads the most recent checkpoint.
 
-  Maps to SCR_Init in libscr.
+    Maps to SCR_Init in libscr.
 
-  Returns
-  -------
-  None
+    Returns
+    -------
+    None
 
-  Raises
-  ------
-  RuntimeError
-      if SCR_Init returns an error
-  """
+    Raises
+    ------
+    RuntimeError
+        if SCR_Init returns an error
+    """
     rc = _libscr.SCR_Init()
     if rc != _libscr.SCR_SUCCESS:
         raise RuntimeError("SCR_Init failed")
@@ -250,21 +250,21 @@ def init():
 def finalize():
     """Shut down the SCR library.
 
-  Should be called before exiting a program, and no other SCR methods
-  can be called after calling finalize().
-  This enables SCR to flush any cached datasets to the prefix directory.
+    Should be called before exiting a program, and no other SCR methods
+    can be called after calling finalize().
+    This enables SCR to flush any cached datasets to the prefix directory.
 
-  Maps to SCR_Finalize in libscr.
+    Maps to SCR_Finalize in libscr.
 
-  Returns
-  -------
-  None
+    Returns
+    -------
+    None
 
-  Raises
-  ------
-  RuntimeError
-      if SCR_Finalize returns an error
-  """
+    Raises
+    ------
+    RuntimeError
+        if SCR_Finalize returns an error
+    """
     rc = _libscr.SCR_Finalize()
     if rc != _libscr.SCR_SUCCESS:
         raise RuntimeError("SCR_Finalize failed")
@@ -273,37 +273,37 @@ def finalize():
 def route_file(fname):
     """Acquire the SCR path to a given file.
 
-  During a restart phase, returns the path that the calling process must use
-  to open the file named in fname for reading.
+    During a restart phase, returns the path that the calling process must use
+    to open the file named in fname for reading.
 
-  During an output phase, this registers the file names in fname as a member
-  of the current output set, and it returns the path that the calling process
-  must use to open the file.
+    During an output phase, this registers the file names in fname as a member
+    of the current output set, and it returns the path that the calling process
+    must use to open the file.
 
-  Outside of restart and output phases, route_file() returns the same value
-  that is passed in fname unchanged.
+    Outside of restart and output phases, route_file() returns the same value
+    that is passed in fname unchanged.
 
-  The calling process should not create any directories listed in the path
-  returned by route_file().
-  SCR creates all directories as needed.
+    The calling process should not create any directories listed in the path
+    returned by route_file().
+    SCR creates all directories as needed.
 
-  Maps to SCR_Route_file in libscr.
-  
-  Parameters
-  ----------
-  fname : str
-      relative or absolute path to file
+    Maps to SCR_Route_file in libscr.
 
-  Returns
-  -------
-  str
-      path that caller must use to open the file specified in fname
+    Parameters
+    ----------
+    fname : str
+        relative or absolute path to file
 
-  Raises
-  ------
-  RuntimeError
-      if SCR_Route_file returns an error
-  """
+    Returns
+    -------
+    str
+        path that caller must use to open the file specified in fname
+
+    Raises
+    ------
+    RuntimeError
+        if SCR_Route_file returns an error
+    """
     ptr = _ffi.new("char[1024]")
     rc = _libscr.SCR_Route_file(_cstr(fname), ptr)
     if rc != _libscr.SCR_SUCCESS:
@@ -312,27 +312,28 @@ def route_file(fname):
 
 
 def have_restart():
-    """Determines whether SCR has loaded a checkpoint that the application can read.
+    """Determines whether SCR has loaded a checkpoint that the application can
+    read.
 
-  An application does not need to read a checkpoint, even if have_restart()
-  indicates that a checkpoint has been loaded.
+    An application does not need to read a checkpoint, even if have_restart()
+    indicates that a checkpoint has been loaded.
 
-  However, an application must call have_restart() before it is valid to read a
-  checkpoint using the SCR Restart API.
+    However, an application must call have_restart() before it is valid to read a
+    checkpoint using the SCR Restart API.
 
-  Maps to SCR_Have_restart in libscr.
+    Maps to SCR_Have_restart in libscr.
 
-  Returns
-  -------
-  str
-      Returns the name of the loaded checkpoint,
-      or None if no checkpoint was loaded.
+    Returns
+    -------
+    str
+        Returns the name of the loaded checkpoint,
+        or None if no checkpoint was loaded.
 
-  Raises
-  ------
-  RuntimeError
-      if SCR_Have_restart returns an error
-  """
+    Raises
+    ------
+    RuntimeError
+        if SCR_Have_restart returns an error
+    """
     flag_ptr = _ffi.new("int[1]")
     name_ptr = _ffi.new("char[1024]")
     rc = _libscr.SCR_Have_restart(flag_ptr, name_ptr)
@@ -345,21 +346,21 @@ def have_restart():
 def start_restart():
     """Opens a restart phase for reading checkpoint files.
 
-  Can only be called if have_restart() indicates that a
-  checkpoint is loaded.
+    Can only be called if have_restart() indicates that a
+    checkpoint is loaded.
 
-  Maps to SCR_Start_restart in libscr.
+    Maps to SCR_Start_restart in libscr.
 
-  Returns
-  -------
-  str
-      Returns the name of loaded checkpoint.
+    Returns
+    -------
+    str
+        Returns the name of loaded checkpoint.
 
-  Raises
-  ------
-  RuntimeError
-      if SCR_Start_restart returns an error
-  """
+    Raises
+    ------
+    RuntimeError
+        if SCR_Start_restart returns an error
+    """
     ptr = _ffi.new("char[1024]")
     rc = _libscr.SCR_Start_restart(ptr)
     if rc != _libscr.SCR_SUCCESS:
@@ -370,22 +371,22 @@ def start_restart():
 def complete_restart(valid=True):
     """Close a restart phase after reading checkpoint files.
 
-  Each calling process must indicate whether it restarted successfully.
+    Each calling process must indicate whether it restarted successfully.
 
-  Maps to SCR_Complete_restart in libscr.
+    Maps to SCR_Complete_restart in libscr.
 
-  Parameters
-  ----------
-  valid : bool, optional
-      pass True if calling process read restart successfully,
-      False otherwise (default True)
+    Parameters
+    ----------
+    valid : bool, optional
+        pass True if calling process read restart successfully,
+        False otherwise (default True)
 
-  Returns
-  -------
-  bool
-      Returns True if all processes restarted successfully,
-      and False if any process indicated that it failed.
-  """
+    Returns
+    -------
+    bool
+        Returns True if all processes restarted successfully,
+        and False if any process indicated that it failed.
+    """
     rc = _libscr.SCR_Complete_restart(int(valid))
     return rc == _libscr.SCR_SUCCESS
 
@@ -393,24 +394,24 @@ def complete_restart(valid=True):
 def need_checkpoint():
     """Ask SCR whether a checkpoint should be taken.
 
-  It is optional for an application to call need_checkpoint(),
-  and an application is free to ignore the value it returns.
-  This method is provided to guide an application to optimal
-  checkpoint frequencies.
+    It is optional for an application to call need_checkpoint(),
+    and an application is free to ignore the value it returns.
+    This method is provided to guide an application to optimal
+    checkpoint frequencies.
 
-  Maps to SCR_Need_checkpoint in libscr.
+    Maps to SCR_Need_checkpoint in libscr.
 
-  Returns
-  -------
-  bool
-      Returns True if a checkpoint should be taken,
-      and False if a checkpoint is not required.
+    Returns
+    -------
+    bool
+        Returns True if a checkpoint should be taken,
+        and False if a checkpoint is not required.
 
-  Raises
-  ------
-  RuntimeError
-      if SCR_Need_checkpoint returns an error
-  """
+    Raises
+    ------
+    RuntimeError
+        if SCR_Need_checkpoint returns an error
+    """
     ptr = _ffi.new("int[1]")
     rc = _libscr.SCR_Need_checkpoint(ptr)
     if rc != _libscr.SCR_SUCCESS:
@@ -421,41 +422,41 @@ def need_checkpoint():
 def start_output(name, flags):
     """Open an output phase.
 
-  The caller provides the name of the dataset and a set of flags.
-  The flags value is a bitmask of the flag attributes, e.g.,:
+    The caller provides the name of the dataset and a set of flags.
+    The flags value is a bitmask of the flag attributes, e.g.,:
 
-    # indicate that dataset can be used to restart application
-    flags = scr.FLAG_CHECKPOINT
+      # indicate that dataset can be used to restart application
+      flags = scr.FLAG_CHECKPOINT
 
-    # indicate that dataset must be written to prefix directory
-    flags = scr.FLAG_OUTPUT
+      # indicate that dataset must be written to prefix directory
+      flags = scr.FLAG_OUTPUT
 
-    # dataset can be used to restart application but must also be saved
-    flags = scr.FLAG_CHECKPOINT | sr.FLAG_OUTPUT
+      # dataset can be used to restart application but must also be saved
+      flags = scr.FLAG_CHECKPOINT | sr.FLAG_OUTPUT
 
-  One can also sum these values, but be careful to only include
-  each flag once in the sum, e.g.,:
+    One can also sum these values, but be careful to only include
+    each flag once in the sum, e.g.,:
 
-    flags = scr.FLAG_CHECKPOINT + sr.FLAG_OUTPUT
-  
-  Maps to SCR_Start_output in libscr.
+      flags = scr.FLAG_CHECKPOINT + sr.FLAG_OUTPUT
 
-  Parameters
-  ----------
-  name : str
-      name to assign to the dataset to be written
-  flags : int
-      bitmask combination of various FLAG attributes
+    Maps to SCR_Start_output in libscr.
 
-  Returns
-  -------
-  None
+    Parameters
+    ----------
+    name : str
+        name to assign to the dataset to be written
+    flags : int
+        bitmask combination of various FLAG attributes
 
-  Raises
-  ------
-  RuntimeError
-      if SCR_Start_output returns an error
-  """
+    Returns
+    -------
+    None
+
+    Raises
+    ------
+    RuntimeError
+        if SCR_Start_output returns an error
+    """
     rc = _libscr.SCR_Start_output(_cstr(name), int(flags))
     if rc != _libscr.SCR_SUCCESS:
         raise RuntimeError("SCR_Start_output failed")
@@ -464,23 +465,23 @@ def start_output(name, flags):
 def complete_output(valid=True):
     """Close an output phase.
 
-  Each calling process must indicate whether it wrote its portion
-  of the output successfully.
+    Each calling process must indicate whether it wrote its portion
+    of the output successfully.
 
-  Maps to SCR_Complete_output in libscr.
+    Maps to SCR_Complete_output in libscr.
 
-  Parameters
-  ----------
-  valid : bool, optional
-      pass True if calling process wrote its output successfully,
-      False otherwise (default True)
+    Parameters
+    ----------
+    valid : bool, optional
+        pass True if calling process wrote its output successfully,
+        False otherwise (default True)
 
-  Returns
-  -------
-  bool
-      Returns True if all processes wrote their output successfully,
-      and False if any process indicated that it failed.
-  """
+    Returns
+    -------
+    bool
+        Returns True if all processes wrote their output successfully,
+        and False if any process indicated that it failed.
+    """
     rc = _libscr.SCR_Complete_output(int(valid))
     return rc == _libscr.SCR_SUCCESS
 
@@ -488,25 +489,25 @@ def complete_output(valid=True):
 def should_exit():
     """Ask SCR whether the application should exit early.
 
-  This method indicates whether the application should stop early.
-  This condition may arise when the job allocation is about to expire
-  or when instructed to exit through an external command like scr_halt.
+    This method indicates whether the application should stop early.
+    This condition may arise when the job allocation is about to expire
+    or when instructed to exit through an external command like scr_halt.
 
-  Even if stopping early, the application should call finalize().
+    Even if stopping early, the application should call finalize().
 
-  Maps to SCR_Should_exit in libscr.
+    Maps to SCR_Should_exit in libscr.
 
-  Returns
-  -------
-  bool
-      Returns True if the application should exit early,
-      and False otherwise.
+    Returns
+    -------
+    bool
+        Returns True if the application should exit early,
+        and False otherwise.
 
-  Raises
-  ------
-  RuntimeError
-      if SCR_Should_exit returns an error
-  """
+    Raises
+    ------
+    RuntimeError
+        if SCR_Should_exit returns an error
+    """
     ptr = _ffi.new("int[1]")
     rc = _libscr.SCR_Should_exit(ptr)
     if rc != _libscr.SCR_SUCCESS:
@@ -517,34 +518,34 @@ def should_exit():
 def current(name):
     """Indicate from which checkpoint an application restarted.
 
-  It is preferred for an application to restart using the SCR Restart API.
-  However, not all applications can do so.
-  For applications that do not use the SCR Restart API,
-  they may inform SCR about the checkpoint they restarted from by
-  calling current().  Doing so enables SCR to track proper ordering of
-  checkpoints.
+    It is preferred for an application to restart using the SCR Restart API.
+    However, not all applications can do so.
+    For applications that do not use the SCR Restart API,
+    they may inform SCR about the checkpoint they restarted from by
+    calling current().  Doing so enables SCR to track proper ordering of
+    checkpoints.
 
-  The provided name must be a dataset that was created during a previous
-  call to start_output().
+    The provided name must be a dataset that was created during a previous
+    call to start_output().
 
-  Applications that do use the SCR Restart API must not call current().
+    Applications that do use the SCR Restart API must not call current().
 
-  Maps to SCR_Current in libscr.
+    Maps to SCR_Current in libscr.
 
-  Parameters
-  ----------
-  name : str
-      name of dataset that was loaded
+    Parameters
+    ----------
+    name : str
+        name of dataset that was loaded
 
-  Returns
-  -------
-  None
+    Returns
+    -------
+    None
 
-  Raises
-  ------
-  RuntimeError
-      if SCR_Current returns an error
-  """
+    Raises
+    ------
+    RuntimeError
+        if SCR_Current returns an error
+    """
     rc = _libscr.SCR_Current(_cstr(name))
     if rc != _libscr.SCR_SUCCESS:
         raise RuntimeError("SCR_Current failed")
@@ -553,29 +554,29 @@ def current(name):
 def delete(name):
     """Request SCR to delete a dataset.
 
-  SCR deletes all data files associated with the dataset.
-  SCR also deletes any directories up to the prefix directory
-  that become empty after deleting files.
+    SCR deletes all data files associated with the dataset.
+    SCR also deletes any directories up to the prefix directory
+    that become empty after deleting files.
 
-  The provided name must be a dataset that was created during a previous
-  call to start_output().
+    The provided name must be a dataset that was created during a previous
+    call to start_output().
 
-  Maps to SCR_Delete in libscr.
+    Maps to SCR_Delete in libscr.
 
-  Parameters
-  ----------
-  name : str
-      name of dataset to be deleted
+    Parameters
+    ----------
+    name : str
+        name of dataset to be deleted
 
-  Returns
-  -------
-  None
+    Returns
+    -------
+    None
 
-  Raises
-  ------
-  RuntimeError
-      if SCR_Delete returns an error
-  """
+    Raises
+    ------
+    RuntimeError
+        if SCR_Delete returns an error
+    """
     rc = _libscr.SCR_Delete(_cstr(name))
     if rc != _libscr.SCR_SUCCESS:
         raise RuntimeError("SCR_Delete failed")
@@ -584,28 +585,28 @@ def delete(name):
 def drop(name):
     """Inform SCR to forget about a dataset.
 
-  SCR drops information about the named dataset from its internal metadata.
-  However, SCR does not attempt to delete files for that dataset.
+    SCR drops information about the named dataset from its internal metadata.
+    However, SCR does not attempt to delete files for that dataset.
 
-  The provided name must be a dataset that was created during a previous
-  call to start_output().
+    The provided name must be a dataset that was created during a previous
+    call to start_output().
 
-  Maps to SCR_Drop in libscr.
+    Maps to SCR_Drop in libscr.
 
-  Parameters
-  ----------
-  name : str
-      name of dataset to be dropped
+    Parameters
+    ----------
+    name : str
+        name of dataset to be dropped
 
-  Returns
-  -------
-  None
+    Returns
+    -------
+    None
 
-  Raises
-  ------
-  RuntimeError
-      if SCR_Drop returns an error
-  """
+    Raises
+    ------
+    RuntimeError
+        if SCR_Drop returns an error
+    """
     rc = _libscr.SCR_Drop(_cstr(name))
     if rc != _libscr.SCR_SUCCESS:
         raise RuntimeError("SCR_Drop failed")

--- a/scripts/python/scrjob/launchers/__init__.py
+++ b/scripts/python/scrjob/launchers/__init__.py
@@ -1,5 +1,4 @@
-"""
-Job Launcher classes provide an interface to specific launcher programs.
+"""Job Launcher classes provide an interface to specific launcher programs.
 
 The job launcher is determined by:
 * The particular scr_{ }run.py script which is invoked.

--- a/scripts/python/scrjob/launchers/auto.py
+++ b/scripts/python/scrjob/launchers/auto.py
@@ -1,5 +1,4 @@
-"""
-AutoJobLauncher is called to return the appropriate JobLauncher class
+"""AutoJobLauncher is called to return the appropriate JobLauncher class.
 
 This is the class called to obtain an instance of a job launcher.
 

--- a/scripts/python/scrjob/launchers/joblauncher.py
+++ b/scripts/python/scrjob/launchers/joblauncher.py
@@ -5,49 +5,49 @@ from scrjob.scr_common import interpolate_variables
 
 
 class JobLauncher(object):
-    """JobLauncher is the super class for the job launcher family
+    """JobLauncher is the super class for the job launcher family.
 
-  Methods
-  -------
-  Methods whose functionality is not provided or compatible must be overridden.
+    Methods
+    -------
+    Methods whose functionality is not provided or compatible must be overridden.
 
-  launch_run_cmd() should be overridden, and should return a tuple of 2 values.
-  The first value will be passed to waitonprocess().
-  The second value will be passed to kill_jobstep().
+    launch_run_cmd() should be overridden, and should return a tuple of 2 values.
+    The first value will be passed to waitonprocess().
+    The second value will be passed to kill_jobstep().
 
-  launch_run_cmd() may return scr_common.runproc(argv, wait=False) and use the
-  provided waitonprocess() and kill_jobstep() methods
+    launch_run_cmd() may return scr_common.runproc(argv, wait=False) and use the
+    provided waitonprocess() and kill_jobstep() methods
 
-  waitonprocess() returns a tuple of 2 boolean values: (completed, success)
+    waitonprocess() returns a tuple of 2 boolean values: (completed, success)
 
-  Default methods
-  ---------------
-  clustershell_exec()
-    If the constant, USE_CLUSTERSHELL, is not '0', and the module ClusterShell is available,
-    then the clustershell_exec method will be used instead of parallel_exec.
+    Default methods
+    ---------------
+    clustershell_exec()
+      If the constant, USE_CLUSTERSHELL, is not '0', and the module ClusterShell is available,
+      then the clustershell_exec method will be used instead of parallel_exec.
 
-  waitonprocess(), kill_jobstep()
-  These may both be used if the overridden launchcmd method returns scr_common.runproc(argv, wait=False).
-  These each expect the Popen object returned from scr_common.runproc(wait=False).
+    waitonprocess(), kill_jobstep()
+    These may both be used if the overridden launchcmd method returns scr_common.runproc(argv, wait=False).
+    These each expect the Popen object returned from scr_common.runproc(wait=False).
 
-  scavenge_files:
-  If the default argv for the scavenge_files command are compatible,
-  then the default scavenge_files method may be used.
+    scavenge_files:
+    If the default argv for the scavenge_files command are compatible,
+    then the default scavenge_files method may be used.
 
-  Attributes
-  ----------
-  launcher          - string representation of the launcher
-  hostfile          - string location of a writable hostfile, set in scr_run.py: scr_env.dir_scr() + '/hostfile'
-                      this is a file a launcher may use, provided for use in parallel_exec()
-  clustershell_task - Either False or a pointer to the module ClusterShell.Task, if this value is not False
-                      a launcher can use clustershell_exec() rather than parallel_exec().
-  """
+    Attributes
+    ----------
+    launcher          - string representation of the launcher
+    hostfile          - string location of a writable hostfile, set in scr_run.py: scr_env.dir_scr() + '/hostfile'
+                        this is a file a launcher may use, provided for use in parallel_exec()
+    clustershell_task - Either False or a pointer to the module ClusterShell.Task, if this value is not False
+                        a launcher can use clustershell_exec() rather than parallel_exec().
+    """
 
     def __init__(self, launcher=''):
-        """Base class initialization
+        """Base class initialization.
 
-    Call super().__init__() in derived launchers.
-    """
+        Call super().__init__() in derived launchers.
+        """
         self.launcher = launcher
         self.hostfile = ''
         self.clustershell_task = False
@@ -59,26 +59,27 @@ class JobLauncher(object):
                 pass
 
     def waitonprocess(self, proc=None, timeout=None):
-        """This method is called after a jobstep is launched with the return values of launch_run_cmd
+        """This method is called after a jobstep is launched with the return
+        values of launch_run_cmd.
 
-    The base class method may be used when launch_run_cmd returns runproc(argv=argv,wait=False).
-    Override this implementation in any base class whose launch_run_cmd returns a different value,
-    or if there is a different method used to wait on a process (blocking or with a timeout).
-    The timeout will be none (wait until process terminates) or a numeric value indicating seconds.
-    A timeout value will exist when using SCR_Watchdog.
+        The base class method may be used when launch_run_cmd returns runproc(argv=argv,wait=False).
+        Override this implementation in any base class whose launch_run_cmd returns a different value,
+        or if there is a different method used to wait on a process (blocking or with a timeout).
+        The timeout will be none (wait until process terminates) or a numeric value indicating seconds.
+        A timeout value will exist when using SCR_Watchdog.
 
-    Returns
-    -------
-       A tuple containing (completed, success)
-       completed:
-           None -  an exception occurred
-           True -  the process is no longer running
-           False - we waited for the timeout and the process is still running
-       success:
-           None -  the job wasn't found or has not finished, no status
-           True -  the process exited 0
-           False - the process failed (exit code nonzero)
-    """
+        Returns
+        -------
+           A tuple containing (completed, success)
+           completed:
+               None -  an exception occurred
+               True -  the process is no longer running
+               False - we waited for the timeout and the process is still running
+           success:
+               None -  the job wasn't found or has not finished, no status
+               True -  the process exited 0
+               False - the process failed (exit code nonzero)
+        """
         if proc is not None:
             try:
                 proc.communicate(timeout=timeout)
@@ -92,28 +93,29 @@ class JobLauncher(object):
         return (True, proc.returncode)
 
     def prepare_prerun(self):
-        """This method is called (without arguments) before scr_prerun.py
+        """This method is called (without arguments) before scr_prerun.py.
 
-    Any necessary preamble work can be inserted into this method.
-    This method does nothing by default and may be overridden as needed.
-    """
+        Any necessary preamble work can be inserted into this method.
+        This method does nothing by default and may be overridden as
+        needed.
+        """
         pass
 
     def launch_run_cmd(self, up_nodes='', down_nodes='', launcher_args=[]):
-        """This method is called to launch a jobstep
+        """This method is called to launch a jobstep.
 
-    This method must be overridden.
-    Launch a jobstep specified by launcher_args using up_nodes and down_nodes.
+        This method must be overridden.
+        Launch a jobstep specified by launcher_args using up_nodes and down_nodes.
 
-    Returns
-    -------
-    tuple (process, id)
-        When using the provided base class methods: waitonprocess() and kill_jobstep(),
-        return scr_common.runproc(argv, wait=False).
+        Returns
+        -------
+        tuple (process, id)
+            When using the provided base class methods: waitonprocess() and kill_jobstep(),
+            return scr_common.runproc(argv, wait=False).
 
-        The first return value is used as the argument for waiting on the process in launcher.waitonprocess().
-        The second return value is used as the argument to kill a jobstep in launcher.kill_jobstep().
-    """
+            The first return value is used as the argument for waiting on the process in launcher.waitonprocess().
+            The second return value is used as the argument to kill a jobstep in launcher.kill_jobstep().
+        """
         return None, None
 
     #####
@@ -122,24 +124,25 @@ class JobLauncher(object):
     # the sub-resource manager is responsible for ensuring clustershell is available
     ### TODO: different ssh programs may need different parameters added to remove the 'tput: ' from the output
     def clustershell_exec(self, argv=[], runnodes=''):
-        """This method implements the functionality of parallel_exec using clustershell
+        """This method implements the functionality of parallel_exec using
+        clustershell.
 
-    This method may be called from a launcher's parallel_exec if self.clustershell_task is not False.
-    if self.clustershell_task is not False:
-      return self.clustershell_exec(argv, runnodes)
+        This method may be called from a launcher's parallel_exec if self.clustershell_task is not False.
+        if self.clustershell_task is not False:
+          return self.clustershell_exec(argv, runnodes)
 
-    argv is a list of arguments representing the command.
-    runnodes is a comma separated string of nodes which will execute the command.
+        argv is a list of arguments representing the command.
+        runnodes is a comma separated string of nodes which will execute the command.
 
-    The command specified by argv will be ran on the nodes specified by runnodes.
+        The command specified by argv will be ran on the nodes specified by runnodes.
 
-    Returns
-    -------
-    list
-      The return value is: [output, returncode],
-      where output is a list: [stdout, stderr],
-      so the full return value is then: [[stdout, stderr], returncode].
-    """
+        Returns
+        -------
+        list
+          The return value is: [output, returncode],
+          where output is a list: [stdout, stderr],
+          so the full return value is then: [[stdout, stderr], returncode].
+        """
         # launch the task
         task = self.clustershell_task.task_self()
         task.run(' '.join(argv), nodes=runnodes)
@@ -167,18 +170,19 @@ class JobLauncher(object):
 
     # perform a generic pdsh / clustershell command
     def parallel_exec(self, argv=[], runnodes=''):
-        """Job launchers should override this method to run the command in the manner of pdsh
+        """Job launchers should override this method to run the command in the
+        manner of pdsh.
 
-    argv is a list of arguments representing the command.
-    runnodes is a comma separated string of nodes which will execute the command.
+        argv is a list of arguments representing the command.
+        runnodes is a comma separated string of nodes which will execute the command.
 
-    `which pdsh` is defined in scr_const.PDSH_EXE.
-    If self.clustershell_task is not False:
-      return self.clustershell_exec(argv, runnodes).
-    Otherwise:
-      Format pdshcmd as a list using scr_const.PDSH_EXE, the argv, and runnodes.
-      return runproc(argv=pdshcmd, getstdout=True, getstderr=True).
-    """
+        `which pdsh` is defined in scr_const.PDSH_EXE.
+        If self.clustershell_task is not False:
+          return self.clustershell_exec(argv, runnodes).
+        Otherwise:
+          Format pdshcmd as a list using scr_const.PDSH_EXE, the argv, and runnodes.
+          return runproc(argv=pdshcmd, getstdout=True, getstderr=True).
+        """
         if self.clustershell_task is not False:
             return self.clustershell_exec(argv=argv, runnodes=runnodes)
         return [['', ''], 0]
@@ -195,33 +199,34 @@ class JobLauncher(object):
                        prefixdir='',
                        buf_size='',
                        crc_flag=''):
-        """Job launchers may override this method to change the scavenge command
+        """Job launchers may override this method to change the scavenge
+        command.
 
-    The scavenge argv is formed in this method and launched with launcher.parallel_exec().
+        The scavenge argv is formed in this method and launched with launcher.parallel_exec().
 
-    Arguments
-    ---------
-    prog               string, the location of the scr_copy program.
-    upnodes            string, comma separated lists of nodes.
-    downnodes_spaced   string, a space separated string of down nodes.
-    cntldir            string, the control directory path, obtained from SCR_Param.
-    dataset_id         string, the dataset id.
-    prefixdir          string, the prefix directory path.
-    buf_size           string, set by $SCR_FILE_BUF_SIZE.
-      (If undefined, the default value is (1024 * 1024)).
-    crc_flag           string, set by $SCR_CRC_ON_FLUSH.
-      (If undefined, the default value is '--crc').
-      (If '0', crc_flag will be set to '').
-      (Otherwise, this will be the crc_flag to use).
+        Arguments
+        ---------
+        prog               string, the location of the scr_copy program.
+        upnodes            string, comma separated lists of nodes.
+        downnodes_spaced   string, a space separated string of down nodes.
+        cntldir            string, the control directory path, obtained from SCR_Param.
+        dataset_id         string, the dataset id.
+        prefixdir          string, the prefix directory path.
+        buf_size           string, set by $SCR_FILE_BUF_SIZE.
+          (If undefined, the default value is (1024 * 1024)).
+        crc_flag           string, set by $SCR_CRC_ON_FLUSH.
+          (If undefined, the default value is '--crc').
+          (If '0', crc_flag will be set to '').
+          (Otherwise, this will be the crc_flag to use).
 
-    Formats the argv for the scavenge command.
+        Formats the argv for the scavenge command.
 
-    Returns
-    -------
-    list
-          The text output (first element of the list) of launcher.parallel_exec()
-          ['stdout', 'stderr']
-    """
+        Returns
+        -------
+        list
+              The text output (first element of the list) of launcher.parallel_exec()
+              ['stdout', 'stderr']
+        """
         argv = [
             prog, '--cntldir', cntldir, '--id', dataset_id, '--prefix',
             prefixdir, '--buf', buf_size, crc_flag, downnodes_spaced
@@ -232,9 +237,10 @@ class JobLauncher(object):
     def kill_jobstep(self, jobstep=None):
         """Kills task identified by jobstep parameter.
 
-    When launcher.launch_run_cmd() returns scr_common.runproc(argv, wait=False),
-    then this method may be used to send the terminate signal through the Popen object.
-    """
+        When launcher.launch_run_cmd() returns scr_common.runproc(argv,
+        wait=False), then this method may be used to send the terminate
+        signal through the Popen object.
+        """
         if jobstep is not None:
             try:
                 # if jobstep.returncode is None:

--- a/scripts/python/scrjob/list_dir.py
+++ b/scripts/python/scrjob/list_dir.py
@@ -9,26 +9,26 @@ def list_dir(user=None,
              runcmd=None,
              scr_env=None,
              bindir=''):
-    """This method returns info on the SCR control/cache/prefix directories
-  for the current user and jobid
+    """This method returns info on the SCR control/cache/prefix directories for
+    the current user and jobid.
 
-  Required Parameters
-  ----------
-  runcmd     string, 'control' or 'cache'
-  scr_env    class, an instance of SCR_Env with valid references to
-             scr_env.resmgr and scr_env.param
+    Required Parameters
+    ----------
+    runcmd     string, 'control' or 'cache'
+    scr_env    class, an instance of SCR_Env with valid references to
+               scr_env.resmgr and scr_env.param
 
-  Returns
-  -------
-  string
-    A space separated list of directories
+    Returns
+    -------
+    string
+      A space separated list of directories
 
-  Error
-  -----
-    This method will print 'list_dir: INVALID: %s', where %s is an error
-    string representing the error.
-    The method will then return the integer 1
-  """
+    Error
+    -----
+      This method will print 'list_dir: INVALID: %s', where %s is an error
+      string representing the error.
+      The method will then return the integer 1
+    """
     # check that user specified "control" or "cache"
     if runcmd != 'control' and runcmd != 'cache':
         print('list_dir: INVALID: \'control\' or \'cache\' must be specified.')

--- a/scripts/python/scrjob/parsetime.py
+++ b/scripts/python/scrjob/parsetime.py
@@ -8,7 +8,8 @@ import re, sys
 
 
 def print_usage(prog):
-    """this method prints a description of usage of the parsetime method of this script"""
+    """This method prints a description of usage of the parsetime method of
+    this script."""
 
     print('Time parser')
     print('Returns the time between now and the argument.')
@@ -39,14 +40,14 @@ def print_usage(prog):
 
 
 def isleapyear(year):
-    """returns true if a given year is a leap year"""
+    """Returns true if a given year is a leap year."""
     if year % 400 == 0 or (year % 4 == 0 and year % 100 != 0):
         return True
     return False
 
 
 def numdays(current, future):
-    """returns a number of days in the future one weekday is from another"""
+    """Returns a number of days in the future one weekday is from another."""
     # Wednesday to Tuesday
     if future < current:
         # 7 - Wednesday + Tuesday
@@ -56,15 +57,16 @@ def numdays(current, future):
 
 
 def parsetime(timestr):
-    """returns an int( posix time ) from a provided input string
-  
-  Interpreted strings can have relative offsets from the current time.
+    """Returns an int( posix time ) from a provided input string.
 
-  This method will interpret many time strings and attempt to return
-  the number of seconds until a future time.
+    Interpreted strings can have relative offsets from the current time.
 
-  An invalid input will likely return a timedelta of about 24 hours in the future.
-  """
+    This method will interpret many time strings and attempt to return
+    the number of seconds until a future time.
+
+    An invalid input will likely return a timedelta of about 24 hours in
+    the future.
+    """
     weekdays = {
         'mon': 0,
         'tue': 1,
@@ -250,7 +252,7 @@ def parsetime(timestr):
 
 
 if __name__ == '__main__':
-    """this script may be called as main to test output"""
+    """This script may be called as main to test output."""
 
     now = datetime.now()
     #print(now)

--- a/scripts/python/scrjob/postrun.py
+++ b/scripts/python/scrjob/postrun.py
@@ -17,15 +17,16 @@ from scrjob.cli import SCRIndex, SCRFlushFile
 
 
 def postrun(prefix_dir=None, scr_env=None, verbose=False, log=None):
-    """this method is called after all runs has completed, before scr_run.py exits
+    """This method is called after all runs has completed, before scr_run.py
+    exits.
 
-  Determine whether there are datasets to scavenge, and perform scavenge operations
+    Determine whether there are datasets to scavenge, and perform scavenge operations
 
-  Returns
-  -------
-  int     0 on success
-          1 on error
-  """
+    Returns
+    -------
+    int     0 on success
+            1 on error
+    """
     if scr_env is None or scr_env.resmgr is None:
         return 1
 

--- a/scripts/python/scrjob/resmgrs/__init__.py
+++ b/scripts/python/scrjob/resmgrs/__init__.py
@@ -1,5 +1,5 @@
-"""
-Resource Manager classes provide an interface to the resource manager in use.
+"""Resource Manager classes provide an interface to the resource manager in
+use.
 
 The resource manager is determined by:
 * The compile time constant, located in ../scr_const.py

--- a/scripts/python/scrjob/resmgrs/auto.py
+++ b/scripts/python/scrjob/resmgrs/auto.py
@@ -1,5 +1,5 @@
-"""
-AutoResourceManager is called to return the appropriate ResourceManager class
+"""AutoResourceManager is called to return the appropriate ResourceManager
+class.
 
 This is the class called to obtain an instance of a resource manager.
 

--- a/scripts/python/scrjob/resmgrs/pmix.py
+++ b/scripts/python/scrjob/resmgrs/pmix.py
@@ -1,6 +1,4 @@
-'''
-# pmix.py
-# PMIX is a subclass if ResourceManager
+"""# pmix.py # PMIX is a subclass if ResourceManager
 
 import os
 from scrjob import scr_const
@@ -107,4 +105,4 @@ class PMIX(ResourceManager):
     argv.append(downnodes_spaced)
     output = self.parallel_exec(argv=argv,runnodes=self.job_nodes(),use_dshbak=False)[0]
     return output
-'''
+"""

--- a/scripts/python/scrjob/resmgrs/resourcemanager.py
+++ b/scripts/python/scrjob/resmgrs/resourcemanager.py
@@ -5,42 +5,48 @@ from scrjob.resmgrs import Nodetests
 
 
 class ResourceManager(object):
-    """ResourceManager is the super class for the resource manager family
+    """ResourceManager is the super class for the resource manager family.
 
-  Provided Default Methods
-  ------------------------
-  usewatchdog()
-    allows setting of self.use_watchdog and getting its value
+    Provided Default Methods
+    ------------------------
+    usewatchdog()
+      allows setting of self.use_watchdog and getting its value
 
-  If the constant, USE_CLUSTERSHELL, is not '0' and the module ClusterShell is available
-  then ClusterShell.NodeSet will be used for these operations.
+    If the constant, USE_CLUSTERSHELL, is not '0' and the module ClusterShell is available
+    then ClusterShell.NodeSet will be used for these operations.
 
-  Node set methods are provided by this class:
-  compress_hosts()
-    returns a string representing a nodelist in compressed format
-  expand_hosts()
-    returns a list from a nodelist where each element is a unique host
-  diff_hosts()
-    returns the set difference of 2 node lists
-  intersect_hosts()
-    returns the intersection of 2 node lists
-  list_down_nodes_with_reason()
-    returns a dictionary of nodes reported down according to tests in self.nodetests
-  scavenge_nodelists()
-    returns upnodes and downnodes formatted for scr_scavenge
+    Node set methods are provided by this class:
 
-  Other Methods
-  -------------
-  Other methods should be implemented in derived classes as appropriate.
+    compress_hosts()
+      returns a string representing a nodelist in compressed format
 
-  Attributes
-  ----------
-  clustershell_nodeset - Either False or a pointer to the module ClusterShell.NodeSet
-  prefix               - String returned from scr_prefix()
-  resmgr               - String representation of the resource manager
-  use_watchdog         - A boolean indicating whether to use the watchdog method
-  nodetests            - An instance of the Nodetests class
-  """
+    expand_hosts()
+      returns a list from a nodelist where each element is a unique host
+
+    diff_hosts()
+      returns the set difference of 2 node lists
+
+    intersect_hosts()
+      returns the intersection of 2 node lists
+
+    list_down_nodes_with_reason()
+      returns a dictionary of nodes reported down according to tests in self.nodetests
+
+    scavenge_nodelists()
+      returns upnodes and downnodes formatted for scr_scavenge
+
+    Other Methods
+    -------------
+    Other methods should be implemented in derived classes as appropriate.
+
+    Attributes
+    ----------
+    clustershell_nodeset - Either False or a pointer to the module ClusterShell.NodeSet
+    prefix               - String returned from scr_prefix()
+    resmgr               - String representation of the resource manager
+    use_watchdog         - A boolean indicating whether to use the watchdog method
+    nodetests            - An instance of the Nodetests class
+    """
 
     def __init__(self, resmgr='unknown'):
         self.clustershell_nodeset = False
@@ -56,110 +62,111 @@ class ResourceManager(object):
         self.nodetests = Nodetests()
 
     def prerun_tests(self):
-        """This method returns a list of tests to perform during scr_prerun
+        """This method returns a list of tests to perform during scr_prerun.
 
-    Test methods must be defined in the SCR_Test_Runtime class in scr_test_runtime.py.
-    Tests ensure the environment will function with SCR and may vary between environments.
-    See scr_test_runtime.py for more information on tests available and to add additional tests.
+        Test methods must be defined in the SCR_Test_Runtime class in scr_test_runtime.py.
+        Tests ensure the environment will function with SCR and may vary between environments.
+        See scr_test_runtime.py for more information on tests available and to add additional tests.
 
-    Returns
-    -------
-    list
-        A list of strings, where each string is a static method in the SCR_Test_Runtime class
-    """
+        Returns
+        -------
+        list
+            A list of strings, where each string is a static method in the SCR_Test_Runtime class
+        """
         # The check_clustershell method only returns failure when ClusterShell is enabled yet
         # we are unable to import the ClusterShell module, this is a safe test for all managers
         return ['check_clustershell']
 
     def usewatchdog(self, use_scr_watchdog=None):
-        """Set or get the use_scr_watchdog attribute
+        """Set or get the use_scr_watchdog attribute.
 
-    When not using the SCR_Watchdog, a jobstep is launched and waited on.
+        When not using the SCR_Watchdog, a jobstep is launched and waited on.
 
-    When using the SCR_Watchdog, a jobstep is launched and waited on until a timeout.
-    At each timeout, if the process is still running, a check is conducted for
-    the existence of output files. If no new output files exist, it will be assumed
-    that the launched process is hanging and it will be terminated.
+        When using the SCR_Watchdog, a jobstep is launched and waited on until a timeout.
+        At each timeout, if the process is still running, a check is conducted for
+        the existence of output files. If no new output files exist, it will be assumed
+        that the launched process is hanging and it will be terminated.
 
-    Given a boolean parameter, this method will set the use_scr_watchdog attribute.
-    Called without a parameter, the value will be returned.
+        Given a boolean parameter, this method will set the use_scr_watchdog attribute.
+        Called without a parameter, the value will be returned.
 
-    Returns
-    -------
-    bool
-        use_scr_watchdog
-        or None if parameter given and attribute was set
-    """
+        Returns
+        -------
+        bool
+            use_scr_watchdog
+            or None if parameter given and attribute was set
+        """
         if use_scr_watchdog is None:
             return self.use_watchdog
         self.use_watchdog = use_scr_watchdog
 
     def job_id(self):
-        """Return current job allocation id
+        """Return current job allocation id.
 
-    This value is used in logging and is used in building paths for output files.
+        This value is used in logging and is used in building paths for output files.
 
-    Returns
-    -------
-    str
-        job allocation id
-        or None if unknown or error
-    """
+        Returns
+        -------
+        str
+            job allocation id
+            or None if unknown or error
+        """
         return None
 
     def job_nodes(self):
-        """Return compute nodes in the allocation
+        """Return compute nodes in the allocation.
 
-    Each node should be specified once and in order.
+        Each node should be specified once and in order.
 
-    Returns
-    -------
-    str
-        list of allocation compute nodes in string format
-        or None if unknown or error
-    """
+        Returns
+        -------
+        str
+            list of allocation compute nodes in string format
+            or None if unknown or error
+        """
         return None
 
     def down_nodes(self):
-        """Return allocation compute nodes the resource manager identifies as down
+        """Return allocation compute nodes the resource manager identifies as
+        down.
 
-    Some resource managers can report nodes it has determined to be down.
-    The returned list should be a subset of the allocation nodes.
+        Some resource managers can report nodes it has determined to be down.
+        The returned list should be a subset of the allocation nodes.
 
-    Returns
-    -------
-    dict
-        { 'node' : 'reason', ... }
-        dict of down compute nodes, keyed by the node, reason is a description of
-        why a node is down: 'Reported down by resource manager' or 'Excluded by resource manager'
-    """
+        Returns
+        -------
+        dict
+            { 'node' : 'reason', ... }
+            dict of down compute nodes, keyed by the node, reason is a description of
+            why a node is down: 'Reported down by resource manager' or 'Excluded by resource manager'
+        """
         return {}
 
     def end_time(self):
-        """Return expected allocation end time
+        """Return expected allocation end time.
 
-    The end time must be expressed as seconds since
-    the Unix epoch.
+        The end time must be expressed as seconds since
+        the Unix epoch.
 
-    Returns
-    -------
-    int
-        If end time is determined:       end time as secs since Unix epoch
-        If end time is unknown or error: 0
-        If there is no end time:         -1
-    """
+        Returns
+        -------
+        int
+            If end time is determined:       end time as secs since Unix epoch
+            If end time is unknown or error: 0
+            If there is no end time:         -1
+        """
         return 0
 
     def compress_hosts(self, hostnames=[]):
-        """Return hostlist string, where the hostlist is in a compressed form
+        """Return hostlist string, where the hostlist is in a compressed form.
 
-    Input parameter, hostnames, is a list or a comma separated string.
+        Input parameter, hostnames, is a list or a comma separated string.
 
-    Returns
-    -------
-    str
-        comma separated hostlist in compressed form, e.g., 'node[1-4],node7'
-    """
+        Returns
+        -------
+        str
+            comma separated hostlist in compressed form, e.g., 'node[1-4],node7'
+        """
         if type(hostnames) is str:
             hostnames = hostnames.split(',')
         if hostnames is None or len(hostnames) == 0:
@@ -173,13 +180,13 @@ class ResourceManager(object):
     def expand_hosts(self, hostnames=''):
         """Return list of hosts, where each element is a single host.
 
-    Input parameter, hostnames, is a comma separated string or a list.
+        Input parameter, hostnames, is a comma separated string or a list.
 
-    Returns
-    -------
-    list
-        list of expanded hosts, e.g., ['node1','node2','node3']
-    """
+        Returns
+        -------
+        list
+            list of expanded hosts, e.g., ['node1','node2','node3']
+        """
         if type(hostnames) is list:
             hostnames = ','.join(hostnames)
         if hostnames is None or hostnames == '':
@@ -192,15 +199,15 @@ class ResourceManager(object):
         return scr_hostlist.expand(hostnames)
 
     def diff_hosts(self, set1=[], set2=[]):
-        """Return the set difference from 2 host lists
+        """Return the set difference from 2 host lists.
 
-    Input parameters, set1 and set2, are lists or comma separated strings.
+        Input parameters, set1 and set2, are lists or comma separated strings.
 
-    Returns
-    -------
-    list
-        elements of set1 that do not appear in set2
-    """
+        Returns
+        -------
+        list
+            elements of set1 that do not appear in set2
+        """
         if type(set1) is str:
             set1 = set1.split(',')
         if type(set2) is str:
@@ -222,15 +229,15 @@ class ResourceManager(object):
         return scr_hostlist.diff(set1=set1, set2=set2)
 
     def intersect_hosts(self, set1=[], set2=[]):
-        """Return the set intersection of 2 host lists
+        """Return the set intersection of 2 host lists.
 
-    Input parameters, set1 and set2, are lists or comma separated strings.
+        Input parameters, set1 and set2, are lists or comma separated strings.
 
-    Returns
-    -------
-    list
-        elements of set1 that also appear in set2
-    """
+        Returns
+        -------
+        list
+            elements of set1 that also appear in set2
+        """
         if type(set1) is str:
             set1 = set1.split(',')
         if type(set2) is str:
@@ -250,40 +257,41 @@ class ResourceManager(object):
 
     # return a hash to define all unavailable (down or excluded) nodes and reason
     def list_down_nodes_with_reason(self, nodes=[], scr_env=None):
-        """Return down nodes with the reason they are down
+        """Return down nodes with the reason they are down.
 
-    Parameters
-    ----------
-    nodes     a list or a comma separated string
-    scr_env   the SCR_Environment object
+        Parameters
+        ----------
+        nodes     a list or a comma separated string
+        scr_env   the SCR_Environment object
 
-    The Nodetests object from resmgr/nodetests.py contains all tests.
-    The tests which will be performed should be set either:
-      When self.nodetests is instantiated (in init of Nodetests):
-        by constant list in scr_const.py
-        by file input, where the filename is specified in scr_const.py
-      Or manually by adding test names to the self.nodetests.nodetests list
-      in your resource manager's init after super().__init__
+        The Nodetests object from resmgr/nodetests.py contains all tests.
+        The tests which will be performed should be set either:
+          When self.nodetests is instantiated (in init of Nodetests):
+            by constant list in scr_const.py
+            by file input, where the filename is specified in scr_const.py
+          Or manually by adding test names to the self.nodetests.nodetests list
+          in your resource manager's init after super().__init__
 
-    Returns
-    -------
-    dict
-        dictionary of reported down nodes, keyed by node with reasons as values
-    """
+        Returns
+        -------
+        dict
+            dictionary of reported down nodes, keyed by node with reasons as values
+        """
         unavailable = self.nodetests(nodes=nodes, scr_env=scr_env)
         return unavailable
 
     # each scavenge operation needs upnodes and downnodes_spaced
     def scavenge_nodelists(self, upnodes='', downnodes=''):
-        """Return formatted upnodes and downnodes for joblaunchers' scavenge operation
+        """Return formatted upnodes and downnodes for joblaunchers' scavenge
+        operation.
 
-    Input parameters upnodes and downnodes are comma separated strings or lists.
+        Input parameters upnodes and downnodes are comma separated strings or lists.
 
-    Returns
-    -------
-    upnodes     string, a comma separated list of up nodes
-    downnodes   string, a space separated list of down nodes
-    """
+        Returns
+        -------
+        upnodes     string, a comma separated list of up nodes
+        downnodes   string, a space separated list of down nodes
+        """
         if type(upnodes) is list:
             upnodes = ','.join(upnodes)
         if type(downnodes) is list:

--- a/scripts/python/scrjob/scr_common.py
+++ b/scripts/python/scrjob/scr_common.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 
 # scr_common.py
-"""Defines for common methods shared across scripts"""
+"""Defines for common methods shared across scripts."""
 
 import os, sys
 
@@ -16,18 +16,18 @@ from scrjob import scr_const
 
 
 def tracefunction(frame, event, arg):
-    """This method provides a hook for tracing python calls
+    """This method provides a hook for tracing python calls.
 
-  Usage:  sys.settrace(scr_common.tracefunction)
-  Prints: filename:function:linenum -> event
+    Usage:  sys.settrace(scr_common.tracefunction)
+    Prints: filename:function:linenum -> event
 
-  The method below will be called on events as scripts execute.
-  The print message in the try block attempts to print the filename.
-  If the filename could not be obtained, an exception is thrown.
+    The method below will be called on events as scripts execute.
+    The print message in the try block attempts to print the filename.
+    If the filename could not be obtained, an exception is thrown.
 
-  This output is very verbose. Filters could be added for event type,
-  and print messages could be suppressed when the filename is not known.
-  """
+    This output is very verbose. Filters could be added for event type,
+    and print messages could be suppressed when the filename is not known.
+    """
     try:
         print(
             inspect.getfile(frame).split('/')[-1] + ':' +
@@ -40,14 +40,14 @@ def tracefunction(frame, event, arg):
 
 
 def interpolate_variables(varstr):
-    """This method will expand a string, including paths
+    """This method will expand a string, including paths.
 
-  This method allows interpretation of path strings such as:
-  ~ . ../ ../../
+    This method allows interpretation of path strings such as:
+    ~ . ../ ../../
 
-  Environment variables in the string will also be expanded.
-  The input need not be a path.
-  """
+    Environment variables in the string will also be expanded.
+    The input need not be a path.
+    """
     if varstr is None or len(varstr) == 0:
         return ''
     # replace ~ and . symbols from front of path
@@ -68,13 +68,13 @@ def interpolate_variables(varstr):
 
 
 def scr_prefix():
-    """This method will return the prefix for SCR
+    """This method will return the prefix for SCR.
 
-  If the environment variable is not set,
-  it will return the current working directory.
-  Allows the environment variable to contain relative paths by returning
-  the string after passing through interpolate_variables
-  """
+    If the environment variable is not set, it will return the current
+    working directory. Allows the environment variable to contain
+    relative paths by returning the string after passing through
+    interpolate_variables
+    """
     prefix = os.environ.get('SCR_PREFIX')
     if prefix is None:
         return os.getcwd()
@@ -90,44 +90,44 @@ def runproc(argv,
             getstderr=False,
             verbose=False,
             shell=False):
-    """This method will execute a command using subprocess.Popen
+    """This method will execute a command using subprocess.Popen.
 
-  Required argument
-  -----------------
-  argv        a string or a list, the command to be ran
+    Required argument
+    -----------------
+    argv        a string or a list, the command to be ran
 
-  Returns
-  -------
-  tuple       2 values are returned as a tuple, the values depend on optional parameters
-              When getting output (waiting, default):
-                The first return value is the output, the second is the returncode
-                If only getting stdout OR stderr, the first element will be a string
-                If getting stdout AND stderr, the first element will be a list,
-                where the first element of the list is stdout and the second is stderr
-                The return code will be an integer
-              When not getting output, when wait = False:
-                When wait is False, this method immediately returns after calling Popen.
-                The Popen object will be both the first and second return values
-              On ERROR:
-                On error this method returns None, None
-                This has an exception if getstderr is True, then the first return value
-                will contain stderr in the expected position, and the second value will be None
+    Returns
+    -------
+    tuple       2 values are returned as a tuple, the values depend on optional parameters
+                When getting output (waiting, default):
+                  The first return value is the output, the second is the returncode
+                  If only getting stdout OR stderr, the first element will be a string
+                  If getting stdout AND stderr, the first element will be a list,
+                  where the first element of the list is stdout and the second is stderr
+                  The return code will be an integer
+                When not getting output, when wait = False:
+                  When wait is False, this method immediately returns after calling Popen.
+                  The Popen object will be both the first and second return values
+                On ERROR:
+                  On error this method returns None, None
+                  This has an exception if getstderr is True, then the first return value
+                  will contain stderr in the expected position, and the second value will be None
 
-  Optional parameters
-  -------------------
-    All optional parameters are True/False boolean values
-    The parameters getstdout and getstderr require waiting for the program to complete,
-    and should not be used in combination with wait=True
+    Optional parameters
+    -------------------
+      All optional parameters are True/False boolean values
+      The parameters getstdout and getstderr require waiting for the program to complete,
+      and should not be used in combination with wait=True
 
-  wait        If wait is False this method returns the Popen object as both elements of the tuple
-  getstdout   If getstdout is True then this method will include stdout in the first return value
-  getstderr   If getstderr is True then this method will include stderr in the first return value
-  verbose     If verbose is True then this method will print the command to be executed
-  shell       If shell is True, then argv is transformed into -> 'bash -c ' + shlex.quote(argv)
+    wait        If wait is False this method returns the Popen object as both elements of the tuple
+    getstdout   If getstdout is True then this method will include stdout in the first return value
+    getstderr   If getstderr is True then this method will include stderr in the first return value
+    verbose     If verbose is True then this method will print the command to be executed
+    shell       If shell is True, then argv is transformed into -> 'bash -c ' + shlex.quote(argv)
 
-  The shell option is passed into the Popen call, and is supposed to prepend commands (?) with
-    '/bin/sh -c', although when I tried simply using shell=True for 'which pdsh' I had errors.
-  """
+    The shell option is passed into the Popen call, and is supposed to prepend commands (?) with
+      '/bin/sh -c', although when I tried simply using shell=True for 'which pdsh' I had errors.
+    """
     if shell:
         if type(argv) is list:
             argv = ' '.join(argv)
@@ -184,16 +184,17 @@ def runproc(argv,
 # the first subprocess is opened and from there stdout is chained to stdin
 # values returned (returncode/pid/stdout/stderr) will be from the final process
 def pipeproc(argvs, wait=True, getstdout=False, getstderr=False):
-    """This method is an extension of the above runproc method
+    """This method is an extension of the above runproc method.
 
-  This is essentially duplicated code from the runproc.
-   ### TODO : This functionality could be put into runproc, increasing
-    the complexity slightly, or it could be kept separate.
+    This is essentially duplicated code from the runproc.  ### TODO :
+    This functionality could be put into runproc, increasing   the
+    complexity slightly, or it could be kept separate.
 
-  This method will loop through search argv in a list of argvs.
-  The output of each previous 'runproc' will be piped to the next as stdin.
-  Any return values will come from the result of the final Popen command
-  """
+    This method will loop through search argv in a list of argvs. The
+    output of each previous 'runproc' will be piped to the next as
+    stdin. Any return values will come from the result of the final
+    Popen command
+    """
     if len(argvs) < 1:
         return None, None
     if len(argvs) == 1:
@@ -251,13 +252,13 @@ def pipeproc(argvs, wait=True, getstdout=False, getstderr=False):
 def choose_bindir():
     """Determine appropriate location of binaries.
 
-  Testing using "make test" or "make check" must operate based on the contents
-  of the build directory.
+    Testing using "make test" or "make check" must operate based on the
+    contents of the build directory.
 
-  If the script is being run from the install directory, then return X_BINDIR
-  as defined by cmake so installed scripts use installed binaries.  Otherwise,
-  determine the appropriate build directory.
-  """
+    If the script is being run from the install directory, then return
+    X_BINDIR as defined by cmake so installed scripts use installed
+    binaries.  Otherwise, determine the appropriate build directory.
+    """
     # Needed to find binaries in build dir when testing
     parent_of_this_module = '/'.join(
         os.path.realpath(__file__).split('/')[:-1])
@@ -281,21 +282,21 @@ def log(bindir=None,
         event_name=None,
         event_start=None,
         event_secs=None):
-    """This method is a wrapper for commong logging operations
+    """This method is a wrapper for commong logging operations.
 
-  Logging operations call the scr_log_event program with formatted arguments.
+    Logging operations call the scr_log_event program with formatted arguments.
 
-  This method formats an argv, then calls the scr_log_event method.
+    This method formats an argv, then calls the scr_log_event method.
 
-  Parameters
-  ----------
-  All input parameters are optional, with each just extending the log entry
-  Input parameters should (with one exception) be string values
+    Parameters
+    ----------
+    All input parameters are optional, with each just extending the log entry
+    Input parameters should (with one exception) be string values
 
-  event_note   may be a string or a dictionary, if a dictionary is passed then
-               the remaining arguments are duplicated
-               This allows several runproc calls without rebuilding argv each time
-  """
+    event_note   may be a string or a dictionary, if a dictionary is passed then
+                 the remaining arguments are duplicated
+                 This allows several runproc calls without rebuilding argv each time
+    """
     if prefix is None:
         prefix = scr_prefix()
         #print('log: prefix is required')
@@ -333,10 +334,11 @@ def log(bindir=None,
 
 
 if __name__ == '__main__':
-    """This script allows being called as a standalone script
+    """This script allows being called as a standalone script.
 
-  This is meant for testing purposes, to directly call scr_common methods.
-  """
+    This is meant for testing purposes, to directly call scr_common
+    methods.
+    """
     parser = argparse.ArgumentParser(add_help=False,
                                      argument_default=argparse.SUPPRESS,
                                      prog='scr_common')

--- a/scripts/python/scrjob/scr_const.py.in
+++ b/scripts/python/scrjob/scr_const.py.in
@@ -1,9 +1,7 @@
 #! /usr/bin/env python3
 
 # scr_const.py
-"""
-compile time constants
-"""
+"""Compile time constants."""
 
 SCR_CNTL_BASE = '@SCR_CNTL_BASE@'
 SCR_CACHE_BASE = '@SCR_CACHE_BASE@'
@@ -15,9 +13,7 @@ X_BINDIR = '@X_BINDIR@'
 X_LIBDIR = '@X_LIBDIR@'
 PDSH_EXE = '@PDSH_EXE@'
 SCR_RESOURCE_MANAGER = '@SCR_RESOURCE_MANAGER@'
-"""
-PMIX constants
-"""
+"""PMIX constants."""
 CPPR_LDFLAGS = '@CPPR_LDFLAGS@'
 HAVE_LIBCPPR = '@HAVE_LIBCPPR@'
 """
@@ -34,24 +30,18 @@ dir_capacity: remove nodes that fail scr_check_node.py
 SCR_NODE_TESTS = '@SCR_NODE_TESTS@'
 # A file with each line a comma separated list of tests
 SCR_NODE_TESTS_FILE = '@SCR_NODE_TESTS_FILE@'
-"""
-ClusterShell
-"""
+"""ClusterShell."""
 # Enable use of the ClusterShell module, set to '1'
 USE_CLUSTERSHELL = '@USE_CLUSTERSHELL@'
-"""
-Python tracing
-"""
+"""Python tracing."""
 # Very verbose, set to '1'
 PYFE_TRACE_FUNC = '@PYFE_TRACE_FUNC@'
-"""
-Joblauncher scr_kill_jobstep strategy
-"""
+"""Joblauncher scr_kill_jobstep strategy."""
 # Prefer to use job launcher's method to kill a jobstep, e.g., scancel, set to '1'
 USE_JOBLAUNCHER_KILL = '@USE_JOBLAUNCHER_KILL@'
 
 if __name__ == '__main__':
-    """running this script will print compiled values"""
+    """Running this script will print compiled values."""
 
     print('SCR_CNTL_BASE = \"' + SCR_CNTL_BASE + '\"')
     print('SCR_CACHE_BASE = \"' + SCR_CACHE_BASE + '\"')

--- a/scripts/python/scrjob/scr_environment.py
+++ b/scripts/python/scrjob/scr_environment.py
@@ -8,22 +8,22 @@ from scrjob.scr_common import scr_prefix, runproc
 
 
 class SCR_Env:
-    """The SCR_Env class tracks information relating to the environment
+    """The SCR_Env class tracks information relating to the environment.
 
-  This class retrieves information from the environment.
-  This class contains pointers to the active Joblauncher, ResourceManager, and SCR_Param.
+    This class retrieves information from the environment.
+    This class contains pointers to the active Joblauncher, ResourceManager, and SCR_Param.
 
-  References to these other classes should be assigned following instantiation of this class.
+    References to these other classes should be assigned following instantiation of this class.
 
-  Attributes
-  ----------
-  param      - class, a reference to SCR_Param
-  launcher   - class, a reference to Joblauncher
-  resmgr     - class, a reference to ResourceManager
-  prefix     - string, initialized upon init or through scr_prefix()
-  bindir     - string, path to the scr bin directory, scr_const.X_BINDIR
-  nodes_file - string, path to bindir/scr_nodes_file     ### Unused ?
-  """
+    Attributes
+    ----------
+    param      - class, a reference to SCR_Param
+    launcher   - class, a reference to Joblauncher
+    resmgr     - class, a reference to ResourceManager
+    prefix     - string, initialized upon init or through scr_prefix()
+    bindir     - string, path to the scr bin directory, scr_const.X_BINDIR
+    nodes_file - string, path to bindir/scr_nodes_file     ### Unused ?
+    """
 
     def __init__(self, prefix=None):
         # we can keep a reference to the other objects
@@ -41,29 +41,28 @@ class SCR_Env:
         self.nodes_file = os.path.join(bindir, 'scr_nodes_file')
 
     def get_user(self):
-        """Return the username from the environment"""
+        """Return the username from the environment."""
         return os.environ.get('USER')
 
     def get_scr_nodelist(self):
-        """Return the SCR_NODELIST, if set, or None"""
+        """Return the SCR_NODELIST, if set, or None."""
         return os.environ.get('SCR_NODELIST')
 
     def get_prefix(self):
-        """Return the scr prefix"""
+        """Return the scr prefix."""
         return self.prefix
 
     def dir_scr(self):
-        """Return the prefix/.scr directory"""
+        """Return the prefix/.scr directory."""
         return os.path.join(self.prefix, '.scr')
 
     def dir_dset(self, d):
         """Given a dataset id, return the dataset directory within the prefix
-    prefix/.scr/scr.dataset.<id>
-    """
+        prefix/.scr/scr.dataset.<id>"""
         return os.path.join(self.dir_scr(), 'scr.dataset.' + str(d))
 
     def get_runnode_count(self):
-        """Return the number of nodes used in the last run, if known"""
+        """Return the number of nodes used in the last run, if known."""
         argv = [self.nodes_file, '--dir', self.prefix]
         out, returncode = runproc(argv=argv, getstdout=True)
         if returncode == 0:

--- a/scripts/python/scrjob/scr_inspect.py
+++ b/scripts/python/scrjob/scr_inspect.py
@@ -16,14 +16,15 @@ from scrjob.launchers import AutoJobLauncher
 
 
 def scr_inspect(jobnodes=None, up=None, down=None, cntldir=None, scr_env=None):
-    """this method runs scr_inspect_cache on each node using Joblauncher.parallel_exec
+    """This method runs scr_inspect_cache on each node using
+    Joblauncher.parallel_exec.
 
-  Returns
-  -------
-  string   A space separated list of cached datasets which may be able to flush and rebuild
-  
-  On error this method returns the integer 1
-  """
+    Returns
+    -------
+    string   A space separated list of cached datasets which may be able to flush and rebuild
+
+    On error this method returns the integer 1
+    """
     bindir = scr_const.X_BINDIR
     pdsh = scr_const.PDSH_EXE
 

--- a/scripts/python/scrjob/scr_kill_jobstep.py
+++ b/scripts/python/scrjob/scr_kill_jobstep.py
@@ -1,8 +1,6 @@
 #! /usr/bin/env python3
-
-"""
-This script can use the 'scancel' or equivalent command
-to kill a jobstep with the jobstep id supplied via the command line.
+"""This script can use the 'scancel' or equivalent command to kill a jobstep
+with the jobstep id supplied via the command line.
 
 This requires specifying both the joblauncher and a jobstep id.
 """

--- a/scripts/python/scrjob/scr_list_dir.py
+++ b/scripts/python/scrjob/scr_list_dir.py
@@ -16,12 +16,13 @@ from scrjob.scr_param import SCR_Param
 from scrjob.resmgrs import AutoResourceManager
 
 if __name__ == '__main__':
-    """this is an external driver for the internal list_dir method
+    """This is an external driver for the internal list_dir method.
 
-  This script is for stand-alone purposes and is not used within other scripts
+    This script is for stand-alone purposes and is not used within other
+    scripts
 
-  This script can be used to test the list_dir method of list_dir.py
-  """
+    This script can be used to test the list_dir method of list_dir.py
+    """
     parser = argparse.ArgumentParser(add_help=False,
                                      argument_default=argparse.SUPPRESS,
                                      prog='scr_list_dir')

--- a/scripts/python/scrjob/scr_prerun.py
+++ b/scripts/python/scrjob/scr_prerun.py
@@ -18,19 +18,20 @@ from scrjob.resmgrs import AutoResourceManager
 
 
 def scr_prerun(scr_env=None):
-    """this script is called after initialization to ensure verify the environment
+    """This script is called after initialization to ensure verify the
+    environment.
 
-  Prerun Operations
-  -----------------
-  Call SCR_Test_Runtime with a list of tests provided by the resmgr
-  Ensures the .scr directory exists
-  Remove existing flush or nodes files
+    Prerun Operations
+    -----------------
+    Call SCR_Test_Runtime with a list of tests provided by the resmgr
+    Ensures the .scr directory exists
+    Remove existing flush or nodes files
 
-  Returns
-  -------
-  int   0 - no error
-        1 - error
-  """
+    Returns
+    -------
+    int   0 - no error
+          1 - error
+    """
     # bail out if not enabled
     val = os.environ.get('SCR_ENABLE')
     if val == '0':

--- a/scripts/python/scrjob/scr_scavenge.py
+++ b/scripts/python/scrjob/scr_scavenge.py
@@ -29,19 +29,20 @@ def scr_scavenge(nodeset_job=None,
                  verbose=False,
                  scr_env=None,
                  log=None):
-    """This script is invoked to perform a scavenge operation
+    """This script is invoked to perform a scavenge operation.
 
-  scr_scavenge.py is a wrapper to gather values and arrange parameters needed for
-  a scavenge operation.
+    scr_scavenge.py is a wrapper to gather values and arrange parameters
+    needed for a scavenge operation.
 
-  When ready, the scavenge parameters are passed to the Joblauncher class to perform
-  the scavenge operation.
+    When ready, the scavenge parameters are passed to the Joblauncher
+    class to perform the scavenge operation.
 
-  The output of the scavenge operation is both written to file and printed to screen.
+    The output of the scavenge operation is both written to file and
+    printed to screen.
 
-  This script returns 1 if a needed value or parameter could not be determined,
-  and returns 0 otherwise
-  """
+    This script returns 1 if a needed value or parameter could not be
+    determined, and returns 0 otherwise
+    """
     # check that we have a nodeset for the job and directories to read from / write to
     if nodeset_job is None or dataset_id is None or cntldir is None or prefixdir is None:
         return 1

--- a/scripts/python/scrjob/scr_srun.py
+++ b/scripts/python/scrjob/scr_srun.py
@@ -11,12 +11,12 @@ if 'scrjob' not in sys.path:
 from scrjob.scr_run import *
 
 if __name__ == '__main__':
-    """scr_srun.py calls scr_run.py with the launcher 'srun'
+    """scr_srun.py calls scr_run.py with the launcher 'srun'.
 
-  These commands are equivalent:
-    scr_run.py srun <launcher args> <launch cmd> <cmd args>
-    scr_srun.py <launcher args> <launch cmd> <cmd args>
-  """
+    These commands are equivalent:
+      scr_run.py srun <launcher args> <launch cmd> <cmd args>
+      scr_srun.py <launcher args> <launch cmd> <cmd args>
+    """
     # just printing help, print the help and exit
     if len(sys.argv) < 3 or '-h' in sys.argv[1:] or '--help' in sys.argv[1:]:
         print_usage('srun')

--- a/scripts/python/scrjob/scr_test_runtime.py
+++ b/scripts/python/scrjob/scr_test_runtime.py
@@ -16,50 +16,52 @@ from scrjob.resmgrs import AutoResourceManager
 
 
 class SCR_Test_Runtime:
-    """SCR_Test_Runtime class contains methods to determine whether we should launch with SCR
+    """SCR_Test_Runtime class contains methods to determine whether we should
+    launch with SCR.
 
-  This class contains methods to test the environment, to ensure SCR will be able to function.
-  These tests are called in scr_prerun.py, immediately after checking if scr is enabled.
-  Not all methods are appropriate to test in every environment.
-  Additional test methods may be added to this class to integrate into the pre-run tests.
-  Test methods should run without arguments and return an integer representing PASS / FAIL.
+    This class contains methods to test the environment, to ensure SCR will be able to function.
+    These tests are called in scr_prerun.py, immediately after checking if scr is enabled.
+    Not all methods are appropriate to test in every environment.
+    Additional test methods may be added to this class to integrate into the pre-run tests.
+    Test methods should run without arguments and return an integer representing PASS / FAIL.
 
-  We could receive a list of applicable tests through:
-    A configuration file.
-    A compile constant (scr_const.py).
-    Environment variables.
-    Querying the ResourceManager and/or Joblauncher classes.
+    We could receive a list of applicable tests through:
+      A configuration file.
+      A compile constant (scr_const.py).
+      Environment variables.
+      Querying the ResourceManager and/or Joblauncher classes.
 
-  Currently the ResourceManager is queried, which aligns with the original bash/perl scripts.
+    Currently the ResourceManager is queried, which aligns with the original bash/perl scripts.
 
-  Each test in the list, that is a callable method in this class, will be called during scr_prerun.
-  If any indicated test fails then scr_prerun will fail.
+    Each test in the list, that is a callable method in this class, will be called during scr_prerun.
+    If any indicated test fails then scr_prerun will fail.
 
-  This class is currently a 'static' class, not intended to be instantiated.
-  The __new__ method is used to launch the tests, this method returns the success value.
-  Methods other than `__new__` should be decorated with `@staticmethod`.
+    This class is currently a 'static' class, not intended to be instantiated.
+    The __new__ method is used to launch the tests, this method returns the success value.
+    Methods other than `__new__` should be decorated with `@staticmethod`.
 
-  Test Return Values
-  ------------------
-  Each test should return an integer:
-  0 - PASS
-  1 - FAIL
-  """
+    Test Return Values
+    ------------------
+    Each test should return an integer:
+    0 - PASS
+    1 - FAIL
+    """
 
     def __new__(cls, tests=[]):
-        """This method collects the return codes of all static methods declared in SCR_Test_Runtime
+        """This method collects the return codes of all static methods declared
+        in SCR_Test_Runtime.
 
-    This method receives a list.
-      Each element is a string and is the name of a method of the SCR_Test_Runtime class
+        This method receives a list.
+          Each element is a string and is the name of a method of the SCR_Test_Runtime class
 
-    Returns
-    -------
-      This method returns an integer.
-      This method does not return an instance of a class.
+        Returns
+        -------
+          This method returns an integer.
+          This method does not return an instance of a class.
 
-      This method returns 0 if all tests succeed,
-      Otherwise this method returns the 1, indicating a test has failed.
-    """
+          This method returns 0 if all tests succeed,
+          Otherwise this method returns the 1, indicating a test has failed.
+        """
         #tests = [
         #    attr for attr in dir(SCR_Test_Runtime) if not attr.startswith('__')
         #    and callable(getattr(SCR_Test_Runtime, attr))
@@ -84,11 +86,11 @@ class SCR_Test_Runtime:
 
     @staticmethod
     def check_clustershell():
-        """This method tests if the ClusterShell module is available
+        """This method tests if the ClusterShell module is available.
 
-    This test will return failure if the option USE_CLUSTERSHELL
-    enables ClusterShell and the module is not available.
-    """
+        This test will return failure if the option USE_CLUSTERSHELL
+        enables ClusterShell and the module is not available.
+        """
         if scr_const.USE_CLUSTERSHELL == '1':
             try:
                 import ClusterShell
@@ -101,16 +103,18 @@ class SCR_Test_Runtime:
 
     @staticmethod
     def check_pdsh():
-        """This method tests the validity of the pdsh command
+        """This method tests the validity of the pdsh command.
 
-    The pdsh executable, whose path is determined by scr_const.PDSH_EXE,
-    is used in the Joblauncher.parallel_exec method to execute a command
-    in parallel on multiple nodes and retrieve each node's output and return code.
+        The pdsh executable, whose path is determined by
+        scr_const.PDSH_EXE, is used in the Joblauncher.parallel_exec
+        method to execute a command in parallel on multiple nodes and
+        retrieve each node's output and return code.
 
-    This test will return failure if we are unable to confirm PDSH_EXE is valid.
+        This test will return failure if we are unable to confirm
+        PDSH_EXE is valid.
 
-    If ClusterShell is enabled, this test does not apply.
-    """
+        If ClusterShell is enabled, this test does not apply.
+        """
         if scr_const.USE_CLUSTERSHELL == '1':
             return 0
         pdsh = scr_const.PDSH_EXE
@@ -141,10 +145,11 @@ class SCR_Test_Runtime:
 
 
 if __name__ == '__main__':
-    """Call sys.exit(result) When this is called as a standalone script
+    """Call sys.exit(result) When this is called as a standalone script.
 
-  This provides a compact illustration of usage of the test methods in scr_prerun.
-  """
+    This provides a compact illustration of usage of the test methods in
+    scr_prerun.
+    """
     resmgr = AutoResourceManager()
     tests = resmgr.get_prerun_tests()
     ret = SCR_Test_Runtime(tests)

--- a/scripts/python/scrjob/scr_watchdog.py
+++ b/scripts/python/scrjob/scr_watchdog.py
@@ -8,35 +8,35 @@ from scrjob.cli import SCRFlushFile
 
 
 class SCR_Watchdog:
-    """This class attempts to detect hanging applications in order to avoid wasting allocations
+    """This class attempts to detect hanging applications in order to avoid
+    wasting allocations.
 
-  Use of the SCR_Watchdog requires 3 configuration variables to be set:
-  SCR_WATCHDOG=1               The watchdog must be enabled (set to '1')
-  We must also have an expected time (in seconds) to check for existence of checkpoint files.
-  For example:
-  SCR_WATCHDOG_TIMEOUT=300     An expected time where we should see a new in-system checkpoint.
-  SCR_WATCHDOG_TIMEOUT_PFS=900 An expected time where we should see a new write to the PFS.
+    Use of the SCR_Watchdog requires 3 configuration variables to be set:
+    SCR_WATCHDOG=1               The watchdog must be enabled (set to '1')
+    We must also have an expected time (in seconds) to check for existence of checkpoint files.
+    For example:
+    SCR_WATCHDOG_TIMEOUT=300     An expected time where we should see a new in-system checkpoint.
+    SCR_WATCHDOG_TIMEOUT_PFS=900 An expected time where we should see a new write to the PFS.
 
-  If the SCR_Watchdog is enabled, and timeouts are set, then we will monitor for progress
-  following the launch of a jobstep.
+    If the SCR_Watchdog is enabled, and timeouts are set, then we will monitor for progress
+    following the launch of a jobstep.
 
-  Normally, we would ask the Joblauncher class to wait until a launched jobstep terminates.
-  The SCR_Watchdog will ask the Joblauncher class to wait with a timeout value.
-  The Joblauncher will return 0 if the jobstep is no longer running, and 1 if it is running.
-  Each time the Joblauncher indicates the jobstep is still running, we will check for progress.
-  If no progress has been made, we will ask the Joblauncher to terminate the jobstep.
-  If progress has been made, we will ask the Joblauncher to again wait with a timeout.
-  """
+    Normally, we would ask the Joblauncher class to wait until a launched jobstep terminates.
+    The SCR_Watchdog will ask the Joblauncher class to wait with a timeout value.
+    The Joblauncher will return 0 if the jobstep is no longer running, and 1 if it is running.
+    Each time the Joblauncher indicates the jobstep is still running, we will check for progress.
+    If no progress has been made, we will ask the Joblauncher to terminate the jobstep.
+    If progress has been made, we will ask the Joblauncher to again wait with a timeout.
+    """
 
     def __init__(self, prefix, scr_env):
-        """
-    The SCR_Watchdog class is instantiated once, before any jobstep is ever launched,
-    if SCR_Watchdog is enabled.
+        """The SCR_Watchdog class is instantiated once, before any jobstep is
+        ever launched, if SCR_Watchdog is enabled.
 
-    Set timeout values from the environment.
-    Copy the reference to the Joblauncher from the SCR_Env class.
-    Instantiate an instance of SCRFlushFile using the provided prefix for later checking.
-    """
+        Set timeout values from the environment. Copy the reference to
+        the Joblauncher from the SCR_Env class. Instantiate an instance
+        of SCRFlushFile using the provided prefix for later checking.
+        """
         self.timeout = scr_env.param.get('SCR_WATCHDOG_TIMEOUT')
         self.timeout_pfs = scr_env.param.get('SCR_WATCHDOG_TIMEOUT_PFS')
 
@@ -47,8 +47,8 @@ class SCR_Watchdog:
             self.scr_flush_file = SCRFlushFile(prefix)
 
     def watchfiles(self, proc, jobstep):
-        """This is an internal method
-    In this method the SCR_Watchdog loops, periodically checking for activity."""
+        """This is an internal method In this method the SCR_Watchdog loops,
+        periodically checking for activity."""
         timeToSleep = self.timeout
         lastCheckpoint = None
         lastCheckpointLoc = None
@@ -89,19 +89,19 @@ class SCR_Watchdog:
         return 0
 
     def watchproc(self, watched_process=None, jobstep=None):
-        """watchproc is the method called after launcher.launch_run_cmd()
+        """Watchproc is the method called after launcher.launch_run_cmd()
 
-    Parameters
-    ----------
-    watched_process - The reference needed for a Joblauncher to wait on a process.
-    jobstep         - The reference needed for a Joblauncher to terminate a jobstep.
+        Parameters
+        ----------
+        watched_process - The reference needed for a Joblauncher to wait on a process.
+        jobstep         - The reference needed for a Joblauncher to terminate a jobstep.
 
-    Returns
-    -------
-    int
-       0 - Indicates the jobstep is no longer running, regardless of reason for termination.
-       1 - Indicates the SCR_Watchdog could not be initialized.
-    """
+        Returns
+        -------
+        int
+           0 - Indicates the jobstep is no longer running, regardless of reason for termination.
+           1 - Indicates the SCR_Watchdog could not be initialized.
+        """
         if watched_process is None or jobstep is None:
             print('scr_watchdog: ERROR: No process to watch.')
             return 1


### PR DESCRIPTION
The ``yapf`` formatter indents docstrings with 2 spaces, which is a bit ugly.  After searching for a config change via ``yapf``, I came across this issue:

https://github.com/google/yapf/issues/60

which points to ``docformatter``:

https://pypi.org/project/docformatter/

So we can run ``yapf`` to do most formatting, then follow that with ``docformatter`` to clean up the docstrings.

Here are the updated set of commands:
```
python3 -m venv --system-site-packages env
source env/bin/activate

pip install --upgrade pip
pip install yapf
pip install --upgrade docformatter

yapf -i python/*.py python/*.py.in
yapf -i scripts/python/setup.py
find scripts/python/scrjob -regex '.*\.py' -print | xargs yapf -i
find scripts/python/scrjob -regex '.*\.py\.in' -print | xargs yapf -i
find scripts/python/tests -regex '.*\.py' -print | xargs yapf -i

docformatter --in-place python/*.py python/*.py.in
docformatter --in-place scripts/python/setup.py
find scripts/python/scrjob -regex '.*\.py' -print | xargs docformatter --in-place
find scripts/python/scrjob -regex '.*\.py\.in' -print | xargs docformatter --in-place
find scripts/python/tests -regex '.*\.py' -print | xargs docformatter --in-place
```