### PR TITLE
add --min-nodes to scr_should_exit command

### DIFF
--- a/scripts/jobscripts/scr_jsrun_loop.sh
+++ b/scripts/jobscripts/scr_jsrun_loop.sh
@@ -57,17 +57,13 @@ while [ 1 ] ; do
     # launch the job, excluding any down nodes
     jsrun $exclude "$@"
 
+    # reduce number of remaining run attempts
+    runs=$(($runs - 1))
+
     # check whether we should stop running
-    ${scrbin}/scr_should_exit -p $scr_prefix $verbose
+    ${scrbin}/scr_should_exit -p $scr_prefix --runs $runs $verbose
     if [ $? == 0 ] ; then
         echo "Halt condition detected, ending run."
-        break
-    fi
-
-    # any retry attempts left?
-    runs=$(($runs - 1))
-    if [ $runs -le 0 ] ; then
-        echo "Runs exhausted, ending run."
         break
     fi
 

--- a/scripts/jobscripts/scr_srun_loop.sh
+++ b/scripts/jobscripts/scr_srun_loop.sh
@@ -57,17 +57,13 @@ while [ 1 ] ; do
     # launch the job, excluding any down nodes
     srun $exclude "$@"
 
+    # reduce number of remaining run attempts
+    runs=$(($runs - 1))
+
     # check whether we should stop running
-    ${scrbin}/scr_should_exit -p $scr_prefix $verbose
+    ${scrbin}/scr_should_exit -p $scr_prefix --runs $runs $verbose
     if [ $? == 0 ] ; then
         echo "Halt condition detected, ending run."
-        break
-    fi
-
-    # any retry attempts left?
-    runs=$(($runs - 1))
-    if [ $runs -le 0 ] ; then
-        echo "Runs exhausted, ending run."
         break
     fi
 

--- a/scripts/python/commands/scr_should_exit.py
+++ b/scripts/python/commands/scr_should_exit.py
@@ -31,6 +31,11 @@ if __name__ == '__main__':
                         type=str,
                         default=None,
                         help='Specify list of down nodes.')
+    parser.add_argument('--min-nodes',
+                        metavar='<N>',
+                        type=int,
+                        default=None,
+                        help='Required number of nodes to run.')
     parser.add_argument('-v',
                         '--verbose',
                         action='store_true',
@@ -45,5 +50,8 @@ if __name__ == '__main__':
     if args.down:
         down_nodes = hostlist.expand_hosts(args.down)
 
-    if not should_exit(jobenv, down_nodes=down_nodes, verbose=args.verbose):
+    if not should_exit(jobenv,
+                       down_nodes=down_nodes,
+                       min_nodes=args.min_nodes,
+                       verbose=args.verbose):
         sys.exit(1)

--- a/scripts/python/commands/scr_should_exit.py
+++ b/scripts/python/commands/scr_should_exit.py
@@ -36,6 +36,11 @@ if __name__ == '__main__':
                         type=int,
                         default=None,
                         help='Required number of nodes to run.')
+    parser.add_argument('--runs',
+                        metavar='<N>',
+                        type=int,
+                        default=None,
+                        help='Number of runs remaining.')
     parser.add_argument('-v',
                         '--verbose',
                         action='store_true',
@@ -54,4 +59,16 @@ if __name__ == '__main__':
                        down_nodes=down_nodes,
                        min_nodes=args.min_nodes,
                        verbose=args.verbose):
+        # No need to exit detected yet.
+
+        # TODO: change the SCR library to update a run counter in the halt file
+        # Job should exit if given --runs=0.
+        # This seems a bit trivial, but it does simplify the user's job script.
+        # We check this last, since it's better to report other halt conditions if set.
+        if args.runs == 0:
+            if args.verbose:
+                print(f'runs_remaining=0')
+            sys.exit(0)
+
+        # use exit code 1 to indicate that job does not need to stop
         sys.exit(1)


### PR DESCRIPTION
This adds a ``--min-nodes`` option to the ``scr_should_exit`` command, which enables a user to specify the required number of nodes to continue running in an allocation in which they may have spare nodes.  By default, the command refers to ``$SCR_MIN_NODES`` if set.  Otherwise, it tries to read the ``.scr/nodes.scr`` file to use the number of nodes from the previous run.  Finally, it assumes all nodes in the allocation are required.  This new option overrides those other mechanisms.

This adds a ``--runs`` option to the ``scr_should_exit`` command.  This is a temporary option, which simplifies the example job scripts.  Ultimately, it would be nice to update the SCR library to support this logic instead.  For example, SCR could read the halt file during ``SCR_Init`` and update any "runs remaining" value, similar to how it decrements the checkpoints remaining value.  At that point, this temporary option could be dropped.