### PR TITLE
use ISO time format in scr_halt

### DIFF
--- a/doc/rst/users/halt.rst
+++ b/doc/rst/users/halt.rst
@@ -59,15 +59,14 @@ Halt before or after a specified time
 It is possible to instruct an SCR job to halt *after* a specified time using
 the :code:`--after` option.
 The job will halt on its first successful checkpoint after the specified time.
-For example, you can instruct a job to halt after "12:00pm today" via::
+The time must be specified in ISO format, for example::
 
-  scr_halt --after '12:00pm today'
+  scr_halt --after '2023-07-04T21:00:00'
 
 It is also possible to instruct a job to halt *before* a specified time
-using the :code:`--before` option.
-For example, you can instruct a job to halt before "8:30am tomorrow" via::
+using the :code:`--before` option, for example::
 
-  scr_halt --before '8:30am tomorrow'
+  scr_halt --before '2023-07-04T21:00:00'
 
 For the "halt before" condition to be effective,
 one must also set the :code:`SCR_HALT_SECONDS` parameter.
@@ -177,15 +176,15 @@ Combine, list, change, and unset halt conditions
 
 It is possible to specify multiple halt conditions.
 To do so, simply list each condition in the same :code:`scr_halt` command or issue several commands.
-For example, to instruct a job to halt after 10 checkpoints or before "8:30am tomorrow",
+For example, to instruct a job to halt after 10 checkpoints or before a certain time,
 which ever comes earlier, you could issue the following command::
 
-  scr_halt --checkpoints 10 --before '8:30am tomorrow'
+  scr_halt --checkpoints 10 --before '2023-07-04T21:00:00'
 
 The following sequence also works::
 
   scr_halt --checkpoints 10
-  scr_halt --before '8:30am tomorrow'
+  scr_halt --before '2023-07-04T21:00:00'
 
 You may list the current settings in the halt file with the :code:`--list` option, e.g.,::
 

--- a/doc/rst/users/run.rst
+++ b/doc/rst/users/run.rst
@@ -4,16 +4,15 @@ Run a job
 =========
 
 In addition to the SCR library,
-one may optionally include SCR commands in their job script.
+one may optionally include SCR commands in a job script.
 These commands are most useful on systems where failures are common.
 The SCR commands prepare the cache, scavenge files from cache to the parallel file system,
 and check that the scavenged dataset is complete among other things.
-The commands also automate the process of relaunching a job after failure.
+The commands also automate the process of relaunching a job after failure,
+including logic to detect to exclude failed nodes.
 
-These commands are located in the :code:`/bin` directory where SCR is installed.
-There are numerous SCR commands.
-Any command not mentioned in this document is
-not intended to be executed by users.
+There are several SCR commands,
+most of which are located in the :code:`/bin` directory where SCR is installed.
 
 For best performance, one should:
 1) inform the batch system that the allocation should remain available even after a failure
@@ -24,18 +23,18 @@ Supported platforms
 -------------------
 
 At the time of this writing, SCR supports specific combinations of resource managers and job launchers.
-The descriptions for using SCR in this section apply to 
+The descriptions for using SCR in this section apply to
 these specific configurations,
 however the following description is helpful to understand
 how to run SCR on any system.
-Please contact us for help in porting SCR to other platforms. 
+Please contact us for help in porting SCR to other platforms.
 (See Section :ref:`sec-contact` for contact information).
 
 Jobs and job steps
 ------------------
 First, we differentiate between a *job allocation* and a *job step*.
-Our terminology originates from the SLURM resource manager, but 
-the principles apply generally across SCR-supported resource managers.
+Our terminology originates from the SLURM resource manager, but
+the concepts apply generally across other resource managers.
 
 When a job is scheduled resources on a system,
 the batch script executes inside of a job allocation.
@@ -43,22 +42,24 @@ The job allocation consists of a set of nodes, a time limit, and a job id.
 The job id can be obtained by executing the :code:`squeue` command
 on SLURM, the :code:`apstat` command on ALPS, and the :code:`bjobs` command on LSF.
 
-Within a job allocation, a user may run one or more job steps,
-each of which is invoked by a call to :code:`srun` on SLURM, :code:`aprun` on ALPS, or :code:`mpirun` on LSF.
+Within a job allocation, a user may run one or more job steps.
+One runs a job step using :code:`srun` on SLURM, :code:`aprun` on ALPS, or :code:`jsrun` on LSF.
 Each job step is assigned its own step id.
-On SLURM, within each job allocation, job step ids start at 0 and increment with each issued job step.
+
+On SLURM, job step ids start at 0 and increment with each issued job step.
 Job step ids can be obtained by passing the :code:`-s` option to :code:`squeue`.
 A fully qualified name of a SLURM job step consists of: :code:`jobid.stepid`.
 For instance, the name :code:`1234.5` refers to step id 5 of job id 1234.
-On ALPS, each job step within an allocation has a unique id that can be obtained
+
+On ALPS, each job step has a unique id that can be obtained
 through :code:`apstat`.
 
 Tolerating node failures
 ------------------------
 
 Before running an SCR job, it is recommended to configure the job allocation to withstand node failures.
-By default, most resource managers terminate the job allocation if a node fails,
-however SCR requires the job allocation to remain active in order to restart the job or to scavenge files.
+By default, most resource managers terminate the job allocation if a node fails.
+SCR requires the job allocation to remain active in order to restart the job or to scavenge files.
 To enable the job allocation to continue past node failures,
 one must specify the appropriate flags from the table below.
 
@@ -73,27 +74,50 @@ SLURM batch script :code:`#SBATCH --no-kill`
 SLURM interactive  :code:`salloc --no-kill ...`
 ================== ================================================================
 
-The SCR wrapper script
-----------------------
+The SCR wrapper scripts
+-----------------------
 The easiest way to integrate SCR into a batch script is to set some environment variables
 and to replace the job run command with an SCR wrapper script.
-The SCR wrapper script includes logic to restart an application within an job allocation,
-and it scavenges files from cache to the parallel file system at the end of an allocation.::
 
-  SLURM:  scr_srun [srun_options]  <prog> [prog_args ...]
-  ALPS:   scr_aprun [aprun_options] <prog> [prog_args ...]
-  LSF:    scr_mpirun [mpirun_options] <prog> [prog_args ...]
+Example bash job scripts are located in the :code:`share/examples` directory of an SCR installation.::
 
-The SCR wrapper script must run from within a job allocation.
-Internally, the command must know the prefix directory.
-By default, it uses the current working directory.
-One may specify a different prefix directory by setting the :code:`SCR_PREFIX` parameter.
+  SLURM:  scr_srun.sh [srun_options]  <prog> [prog_args ...]
+  SLURM:  scr_srun_loop.sh [srun_options]  <prog> [prog_args ...]
+  LSF:    scr_jsrun.sh [jsrun_options] <prog> [prog_args ...]
+  LSF:    scr_jsrun_loop.sh [jsrun_options] <prog> [prog_args ...]
+
+The scripts are customized for different resource managers.
+They include the resource manager flag one needs to set to tolerate node failures.
+They call :code:`scr_prerun` to prepare an allocation before starting a run,
+and they call :code:`scr_postrun` to scavange any cached datasets after the run completes.
+
+The scripts whose name ends with :code:`_loop` additionally include logic to relaunch
+a failed job up to some fixed number of times within the allocation.
+Between launches, the scripts call :code:`scr_list_down_nodes` to detect and avoid failed nodes.
+One may allocate spare nodes when using these scripts.
+
+These job scripts serve as templates that one can modify as needed.
+However, they can often be used as drop in replacements for the launch command in an existing job script.
+
+In addition to the example bash job scripts, an :code:`scr_run` command is in the :code:`/bin' directory of an SCR installation.
+This is a python script that, like the bash scripts, executes :code:`scr_prerun`, :code:`scr_postrun`,
+and it optionally relaunches a run after detecting and excluding any failed nodes.
+When using :code:`scr_run`, one must specify the job launcher as the first argument::
+
+  SLURM: scr_run srun [srun_options]  <prog> [prog_args ...]
+  LSF:   scr_run jsrun [jsrun_options]  <prog> [prog_args ...]
+
+All wrapper scripts must run from within a job allocation.
+The commands must know the SCR prefix directory.
+By default, this is assumed to be the current working directory.
+For the :code:`scr_run` script,
+one may specify a different prefix directory by setting the :code:`SCR_PREFIX` parameter.
 
 It is recommended to set the :code:`SCR_HALT_SECONDS`
 parameter so that the job allocation does not expire before
 datasets can be flushed (Section :ref:`sec-halt`).
 
-By default, the SCR wrapper script does not restart an application after the first job step exits.
+By default, the :code:`scr_run` script does not restart an application after the first job step exits.
 To automatically restart a job step within the current allocation,
 set the :code:`SCR_RUNS` environment variable to the maximum number of runs to attempt.
 For an unlimited number of attempts, set this variable to :code:`-1`.
@@ -101,42 +125,84 @@ For an unlimited number of attempts, set this variable to :code:`-1`.
 After a job step exits, the wrapper script checks whether it should restart the job.
 If so, the script sleeps for some time to give nodes in the allocation a chance to clean up.
 Then it checks that there are sufficient healthy nodes remaining in the allocation.
-By default, the wrapper script assumes the next run requires the same number of nodes as the previous run,
+By default, the script assumes the next run requires the same number of nodes as the previous run,
 which is recorded in a file written by the SCR library.
 If this file cannot be read, the command assumes the application requires all nodes in the allocation.
 Alternatively, one may override these heuristics and precisely specify the number of nodes needed
 by setting the :code:`SCR_MIN_NODES` environment variable to the number of required nodes.
 
-For applications that cannot invoke the SCR wrapper script as described here,
+For applications that cannot invoke the SCR wrapper scripts as described here,
 one should examine the logic contained within the script and duplicate the necessary parts
 in the job batch script.
 In particular, one should invoke :code:`scr_postrun` for scavenge support.
 
-Example batch script for using SCR restart capability
------------------------------------------------------
+Example batch script for using scavenge, but no restart
+-------------------------------------------------------
 
-An example SLURM batch script with :code:`scr_srun` is shown below
+An example SLURM batch script with :code:`scr_srun.sh` is shown below
+
+.. code-block:: bash
+
+  #!/bin/bash
+  #SBATCH --no-kill
+
+  # specify where datasets should be written
+  export SCR_PREFIX=/parallel/file/system/username/run1
+
+  # instruct SCR to flush to the file system every 20 checkpoints
+  export SCR_FLUSH=20
+
+  # halt if there is less than an hour remaining (3600 seconds)
+  export SCR_HALT_SECONDS=3600
+
+  # run the job with scr_srun
+  scr_run.sh -n512 -N64 ./my_job
+
+Example batch script for using scavenge and restart
+---------------------------------------------------
+
+An example SLURM batch script with :code:`scr_srun_loop.sh` is shown below
+
+.. code-block:: bash
+
+  #!/bin/bash
+  #SBATCH --no-kill
+
+  # specify where datasets should be written
+  export SCR_PREFIX=/parallel/file/system/username/run1
+
+  # instruct SCR to flush to the file system every 20 checkpoints
+  export SCR_FLUSH=20
+
+  # halt if there is less than an hour remaining (3600 seconds)
+  export SCR_HALT_SECONDS=3600
+
+  # run the job with scr_srun
+  scr_run_loop.sh -n512 -N64 ./my_job
+
+Example SLURM batch script with :code:`scr_run` using scavenge and restart
+--------------------------------------------------------------------------
 
 .. code-block:: bash
 
   #!/bin/bash
   #SBATCH --no-kill
   #SBATCH --nodes 66
-  
+
   # above, tell SLURM to not kill the job allocation upon a node failure
   # also note that the job requested 2 spares -- it uses 64 nodes but allocated 66
-  
+
   # specify where datasets should be written
   export SCR_PREFIX=/parallel/file/system/username/run1
-  
+
   # instruct SCR to flush to the file system every 20 checkpoints
   export SCR_FLUSH=20
-  
+
   # halt if there is less than an hour remaining (3600 seconds)
   export SCR_HALT_SECONDS=3600
-  
+
   # attempt to run the job up to 3 times
   export SCR_RUNS=3
-  
+
   # run the job with scr_srun
-  scr_srun -n512 -N64 ./my_job
+  scr_run srun -n512 -N64 ./my_job

--- a/scripts/python/commands/scr_halt.py
+++ b/scripts/python/commands/scr_halt.py
@@ -6,15 +6,43 @@ import sys
 sys.path.insert(0, '@X_LIBEXECDIR@/python')
 
 import os
+import re
+import datetime
 import argparse
 
-from scrjob.parsetime import parsetime
 from scrjob.cli.scr_halt_cntl import SCRHaltFile
+
+
+def parsetime(timestr):
+    re_ts_full = re.compile(r'(\d\d\d\d)-(\d\d)-(\d\d)T(\d\d):(\d\d):(\d\d)$')
+    m = re_ts_full.match(timestr)
+    if m:
+        year  = int(m.groups(0)[0])
+        month = int(m.groups(0)[1])
+        day   = int(m.groups(0)[2])
+        hours = int(m.groups(0)[3])
+        mins  = int(m.groups(0)[4])
+        secs  = int(m.groups(0)[5])
+        dt = datetime.datetime(year=year, month=month, day=day, hour=hours, minute=mins, second=secs)
+        return int(dt.timestamp())
+
+    #re_ts_24hr = re.compile(r'^(\d\d):(\d\d):(\d\d)$')
+    #m = re_ts_24hr.match(timestr)
+    #if m:
+    #    hours = int(m.groups(0)[0])
+    #    mins  = int(m.groups(0)[1])
+    #    secs  = int(m.groups(0)[2])
+    #    dt = datetime.datetime.now()
+    #    dt = dt.replace(hour=hours, minute=mins, second=secs)
+    #    return int(dt.timestamp())
+
+    raise RuntimeError(f"Unsupported time format: '{timestr}'")
+
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(
         epilog=
-        'TIME arguments are parsed using parsetime.py,\nand t may be specified in one of many formats.\nExamples include \'12pm\', \'yesterday noon\', \'12/25 15:30:33\', and so on.\nIf no directory is specified, the current working directory is used.'
+        'TIME arguments must be ISO format YYYY-MM-DDTHH:MM:SS in the current time zone.\nIf no directory is specified, the current working directory is used.'
     )
 
     # when prefixes are unambiguous then also adding shortcodes isn't necessary

--- a/scripts/python/tests/runtest.sh
+++ b/scripts/python/tests/runtest.sh
@@ -253,8 +253,8 @@ echo ""
 echo "check that scr_halt.py seems to work"
 sleep 2
 ${scrbin}/scr_halt --list $(pwd)
-${scrbin}/scr_halt --before '3pm today' $(pwd)
-${scrbin}/scr_halt --after '4pm today' $(pwd)
+${scrbin}/scr_halt --before '2100-07-04T21:00:00' $(pwd)
+${scrbin}/scr_halt --after '2100-07-04T21:00:00' $(pwd)
 ${scrbin}/scr_halt --seconds 1200 $(pwd)
 sleep 1
 ${scrbin}/scr_halt --unset-before $(pwd)

--- a/testing/TESTING.csh
+++ b/testing/TESTING.csh
@@ -136,8 +136,8 @@ unsetenv SCR_EXCLUDE_NODES
 
 # check that scr_halt seems to work
 ${scrbin}/scr_halt --list `pwd`; sleep 5
-${scrbin}/scr_halt --before '3pm today' `pwd`; sleep 5
-${scrbin}/scr_halt --after '4pm today' `pwd`; sleep 5
+${scrbin}/scr_halt --before '2100-07-04T21:00:00' `pwd`; sleep 5
+${scrbin}/scr_halt --after '2100-07-04T21:00:00' `pwd`; sleep 5
 ${scrbin}/scr_halt --seconds 1200 `pwd`; sleep 5
 ${scrbin}/scr_halt --unset-before `pwd`; sleep 5
 ${scrbin}/scr_halt --unset-after `pwd`; sleep 5

--- a/testing/TESTING.sh
+++ b/testing/TESTING.sh
@@ -144,8 +144,8 @@ unset SCR_EXCLUDE_NODES
 
 # check that scr_halt seems to work
 ${scrbin}/scr_halt --list `pwd`; sleep 5
-${scrbin}/scr_halt --before '3pm today' `pwd`; sleep 5
-${scrbin}/scr_halt --after '4pm today' `pwd`; sleep 5
+${scrbin}/scr_halt --before '2100-07-04T21:00:00' `pwd`; sleep 5
+${scrbin}/scr_halt --after '2100-07-04T21:00:00' `pwd`; sleep 5
 ${scrbin}/scr_halt --seconds 1200 `pwd`; sleep 5
 ${scrbin}/scr_halt --unset-before `pwd`; sleep 5
 ${scrbin}/scr_halt --unset-after `pwd`; sleep 5


### PR DESCRIPTION
- Simplifies the ``scr_halt`` command to only accept timestamps in ISO format, like ``2023-07-04T21:00:00``.
- Updates documentation to describe example job batch scripts, like ``scr_srun.sh`` and ``scr_srun_loop.sh``