### PR TITLE
Remove early build of er that may have been placed in here for debugg…

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -71,51 +71,6 @@ mkdir -p install
 
 cd deps
 
-pushd er
-  if [ $build_dev -eq 0 ] ; then
-    git checkout v0.2.0
-  fi
-  rm -rf build
-  mkdir -p build
-  pushd build
-    cmake \
-      ${shared_flags} \
-      -DCMAKE_BUILD_TYPE=$buildtype \
-      -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR \
-      .. && \
-    make ${make_verbose} -j `nproc` && \
-    make ${make_verbose} install
-    if [ $? -ne 0 ]; then
-      echo "failed to configure, build, or install er"
-      exit 1
-    fi
-  popd
-popd
-exit 0
-
-#pushd redset
-##  if [ $build_dev -eq 0 ] ; then
-##    git checkout v0.2.0
-##  fi
-#  rm -rf build
-#  mkdir -p build
-#  pushd build
-#    cmake \
-#      ${shared_flags} \
-#      -DCMAKE_BUILD_TYPE=$buildtype \
-#      -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR \
-#      -DENABLE_PTHREADS=OFF \
-#      .. && \
-#    make ${make_verbose} -j `nproc` && \
-#    make ${make_verbose} install
-#    if [ $? -ne 0 ]; then
-#      echo "failed to configure, build, or install redset"
-#      exit 1
-#    fi
-#  popd
-#popd
-#exit 0
-
 lwgrp=lwgrp-1.0.5
 dtcmp=dtcmp-1.1.4
 pdsh=pdsh-2.34


### PR DESCRIPTION
…ing purposes?

The current version of the bootstrap file no longer works on generating new builds.  It appears that this file may have been accidentally committed with the last push.  @adammoody , do you agree?  cc: @kathrynmohror 