### PR TITLE
Docs: update to latest doc deps

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -4,29 +4,29 @@
 #
 #    pip-compile --output-file=doc/new_requirements.txt --strip-extras doc/requirements.in
 #
-alabaster==0.7.13
+alabaster==0.7.16
     # via sphinx
-babel==2.13.1
+babel==2.14.0
     # via sphinx
-certifi==2023.7.22
+certifi==2023.11.17
     # via requests
-charset-normalizer==3.3.1
+charset-normalizer==3.3.2
     # via requests
-docutils==0.18.1
+docutils==0.20.1
     # via
     #   sphinx
     #   sphinx-rtd-theme
-idna==3.4
+idna==3.6
     # via requests
 imagesize==1.4.1
     # via sphinx
-jinja2==3.1.2
+jinja2==3.1.3
     # via sphinx
 markupsafe==2.1.3
     # via jinja2
 packaging==23.2
     # via sphinx
-pygments==2.16.1
+pygments==2.17.2
     # via sphinx
 requests==2.31.0
     # via sphinx
@@ -42,23 +42,23 @@ sphinx==7.2.6
     #   sphinxcontrib-jquery
     #   sphinxcontrib-qthelp
     #   sphinxcontrib-serializinghtml
-sphinx-rtd-theme==1.3.0
+sphinx-rtd-theme==2.0.0
     # via -r doc/requirements.in
-sphinxcontrib-applehelp==1.0.7
+sphinxcontrib-applehelp==1.0.8
     # via sphinx
-sphinxcontrib-devhelp==1.0.5
+sphinxcontrib-devhelp==1.0.6
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.4
+sphinxcontrib-htmlhelp==2.0.5
     # via sphinx
 sphinxcontrib-jquery==4.1
     # via sphinx-rtd-theme
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.6
+sphinxcontrib-qthelp==1.0.7
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.9
+sphinxcontrib-serializinghtml==1.1.10
     # via sphinx
-urllib3==2.0.7
+urllib3==2.1.0
     # via requests
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
Update the jinja2 version due to the Dependabot alert.

Updating the rest of the doc deps to their latest versions.