### PR TITLE
JobLauncher: print stdout and stderr

### DIFF
--- a/scripts/python/scrjob/launchers/joblauncher.py
+++ b/scripts/python/scrjob/launchers/joblauncher.py
@@ -1,10 +1,9 @@
-import os
+"""Module defining JobLauncher base class."""
+
 from subprocess import TimeoutExpired
 
-from scrjob import config
 
-
-class JobLauncher(object):
+class JobLauncher:
     """JobLauncher is the super class for the job launcher family.
 
     Methods
@@ -41,7 +40,7 @@ class JobLauncher(object):
         self.name = launcher
         self.hostfile = ''
 
-    def launch_run(self, args, nodes=[], down_nodes=[]):
+    def launch_run(self, args, nodes=None, down_nodes=None):
         """This method is called to launch a jobstep.
 
         This method must be overridden.
@@ -85,10 +84,9 @@ class JobLauncher(object):
                 proc.communicate(timeout=timeout)
             except TimeoutExpired:
                 return (False, None)
-            except e:
-                print(f'wait_run for proc {proc} failed with exception {e}')
+            except Exception as exc:
+                print(f'wait_run for proc {proc} failed with exception {exc}')
                 return (None, None)
-
         return (True, proc.returncode)
 
     def kill_run(self, jobstep=None):
@@ -106,5 +104,5 @@ class JobLauncher(object):
 
                 # ensure complete
                 jobstep.communicate()
-            except:
+            except Exception:
                 pass

--- a/scripts/python/scrjob/launchers/joblauncher.py
+++ b/scripts/python/scrjob/launchers/joblauncher.py
@@ -1,4 +1,5 @@
 """Module defining JobLauncher base class."""
+import sys
 
 from subprocess import TimeoutExpired
 
@@ -81,12 +82,17 @@ class JobLauncher:
         """
         if proc is not None:
             try:
-                proc.communicate(timeout=timeout)
+                out, err = proc.communicate(timeout=timeout)
             except TimeoutExpired:
                 return (False, None)
             except Exception as exc:
                 print(f'wait_run for proc {proc} failed with exception {exc}')
                 return (None, None)
+            else:
+                if out:
+                    print(out)
+                if err:
+                    print(err, file=sys.stderr)
         return (True, proc.returncode)
 
     def kill_run(self, jobstep=None):


### PR DESCRIPTION
Problem: stdout and stderr of processes launched through the
JobLauncher class and waited on with `wait_run` is lost. This
can be somewhat confusing for users whose applications crash with
no way to tell what went wrong.

Print stdout and stderr in the `wait_run` method of `JobLauncher`.